### PR TITLE
feat: BlockId latest and pending

### DIFF
--- a/starknet-core/src/types/block.rs
+++ b/starknet-core/src/types/block.rs
@@ -6,6 +6,8 @@ use serde::Deserialize;
 pub enum BlockId {
     Hash(H256),
     Number(u64),
+    Latest,
+    Pending,
 }
 
 #[derive(Debug, Deserialize)]

--- a/starknet-providers/src/provider.rs
+++ b/starknet-providers/src/provider.rs
@@ -21,22 +21,22 @@ pub trait Provider {
     async fn call_contract(
         &self,
         invoke_tx: InvokeFunction,
-        block_hash_or_number: Option<BlockId>,
+        block_id: Option<BlockId>,
     ) -> Result<CallContractResult, Self::Error>;
 
-    async fn get_block(&self, block_hash_or_number: Option<BlockId>) -> Result<Block, Self::Error>;
+    async fn get_block(&self, block_id: Option<BlockId>) -> Result<Block, Self::Error>;
 
     async fn get_code(
         &self,
         contract_address: H256,
-        block_hash_or_number: Option<BlockId>,
+        block_id: Option<BlockId>,
     ) -> Result<ContractCode, Self::Error>;
 
     async fn get_storage_at(
         &self,
         contract_address: H256,
         key: U256,
-        block_hash_or_number: Option<BlockId>,
+        block_id: Option<BlockId>,
     ) -> Result<U256, Self::Error>;
 
     async fn get_transaction_status(


### PR DESCRIPTION
This PR adds two new values to the BlockId enum: `Latest` and `Pending`. Most of the API calls, as far as I could figure out, support a `blockId=latest` parameter. Some even work "better" with a `blockId` than for example a `blockNumber` (compare [this one using blockId=36999](https://alpha4.starknet.io/feeder_gateway/get_code?contractAddress=0x052551bca2724c49823effc6e8b0c1084291b832e1c1c195c39671420bff2a6e&blockId=36999) with [this one using blockNumber=36999](https://alpha4.starknet.io/feeder_gateway/get_code?contractAddress=0x052551bca2724c49823effc6e8b0c1084291b832e1c1c195c39671420bff2a6e&blockNumber=36999)) but I haven't discovered it out fully. Need to ask Starkware :)

I've also changed the parameters nomenclature to better represent the value.

Please let me know what you think.