### PR TITLE
refactor: using rename_all

### DIFF
--- a/starknet-core/src/types/contract_addresses.rs
+++ b/starknet-core/src/types/contract_addresses.rs
@@ -2,9 +2,8 @@ use ethereum_types::Address;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
 pub struct ContractAddresses {
-    #[serde(rename = "Starknet")]
     pub starknet: Address,
-    #[serde(rename = "GpsStatementVerifier")]
     pub gps_statement_verifier: Address,
 }

--- a/starknet-core/src/types/contract_code.rs
+++ b/starknet-core/src/types/contract_code.rs
@@ -8,13 +8,10 @@ pub struct ContractCode {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "type")]
+#[serde(tag = "type", rename_all = "lowercase")]
 pub enum AbiEntry {
-    #[serde(rename = "constructor")]
     Constructor(Constructor),
-    #[serde(rename = "function")]
     Function(Function),
-    #[serde(rename = "struct")]
     Struct(Struct),
     #[serde(rename = "l1_handler")]
     L1Handler(L1Handler),

--- a/starknet-core/src/types/transaction.rs
+++ b/starknet-core/src/types/transaction.rs
@@ -14,11 +14,9 @@ pub enum TransactionId {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "type")]
+#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Transaction {
-    #[serde(rename = "DEPLOY")]
     Deploy(DeployTransaction),
-    #[serde(rename = "INVOKE_FUNCTION")]
     InvokeFunction(InvokeFunctionTransaction),
 }
 

--- a/starknet-core/src/types/transaction_receipt.rs
+++ b/starknet-core/src/types/transaction_receipt.rs
@@ -33,35 +33,24 @@ pub struct ConfirmedReceipt {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "tx_status")]
+#[serde(tag = "tx_status", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum TransactionStatus {
-    #[serde(rename = "NOT_RECEIVED")]
     NotReceived,
-    #[serde(rename = "RECEIVED")]
     Received,
-    #[serde(rename = "PENDING")]
     Pending,
-    #[serde(rename = "REJECTED")]
     Rejected,
-    #[serde(rename = "ACCEPTED_ON_L2")]
     AcceptedOnL2(TransactionBlockHash),
-    #[serde(rename = "ACCEPTED_ON_L1")]
     AcceptedOnL1(TransactionBlockHash),
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum TransactionStatusType {
-    #[serde(rename = "NOT_RECEIVED")]
     NotReceived,
-    #[serde(rename = "RECEIVED")]
     Received,
-    #[serde(rename = "PENDING")]
     Pending,
-    #[serde(rename = "REJECTED")]
     Rejected,
-    #[serde(rename = "ACCEPTED_ON_L2")]
     AcceptedOnL2,
-    #[serde(rename = "ACCEPTED_ON_L1")]
     AcceptedOnL1,
 }
 

--- a/starknet-core/src/types/transaction_request.rs
+++ b/starknet-core/src/types/transaction_request.rs
@@ -10,11 +10,9 @@ use ethereum_types::{H256, U256};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize)]
-#[serde(tag = "type")]
+#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum TransactionRequest {
-    #[serde(rename = "DEPLOY")]
     Deploy(DeployTransaction),
-    #[serde(rename = "INVOKE_FUNCTION")]
     InvokeFunction(InvokeFunctionTransaction),
 }
 
@@ -62,12 +60,10 @@ pub struct ContractDefinition {
 }
 
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub struct EntryPointsByType {
-    #[serde(rename = "CONSTRUCTOR")]
     pub constructor: Vec<EntryPoint>,
-    #[serde(rename = "EXTERNAL")]
     pub external: Vec<EntryPoint>,
-    #[serde(rename = "L1_HANDLER")]
     pub l1_handler: Vec<EntryPoint>,
 }
 


### PR DESCRIPTION
Just a small thing, using serde's [rename-all](https://serde.rs/container-attrs.html) in a couple of places. I think it makes the code more readable.