### PR TITLE
fix: use symbolic links for files in `assets` folder

### DIFF
--- a/assets/CORE_README.md
+++ b/assets/CORE_README.md
@@ -1,3 +1,1 @@
-# StarkNet data types
-
-// TODO: add `starknet-core` documentation
+../starknet-core/README.md

--- a/assets/PROVIDERS_README.md
+++ b/assets/PROVIDERS_README.md
@@ -1,3 +1,1 @@
-# Clients for interacting with StarkNet nodes and sequencers
-
-// TODO: add `starknet-providers` documentation
+../starknet-providers/README.md


### PR DESCRIPTION
This PR changes to use symbolic links for files in `./assets`.

`README.md` files from sub-crates are linked to a top-level `assets` folder since sub-crate folders are excluded when packaging `starknet`. However, hard links were incorrectly used, which are not supported by Git.