### PR TITLE
Add format checking for md, yaml, and json files

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,30 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
-      - name: Check code format
+      - name: Install prettier
+        run: |
+          yarn global add prettier
+      - name: Check Markdown format
+        run: |
+          prettier --check "**/*.md"
+      - name: Check Yaml format
+        run: |
+          prettier --check "**/*.{yaml,yml}"
+      - name: Check JSON format
+        run: |
+          EXIT_CODE="0";
+          readarray -d '' FILES < <(find -type f -name "*.json" -not -path "./target/*");
+          for FILE in ${FILES[@]}; do
+              cat $FILE | jq > /tmp/formatted_json.json;
+              if cmp --silent "$FILE" /tmp/formatted_json.json; then
+                  printf "\033[1;30m$FILE\033[0m OK\n";
+              else
+                  printf "\033[1;33m$FILE\033[0m FAILED\n";
+                  EXIT_CODE="1";
+              fi
+          done
+          exit $EXIT_CODE;
+      - name: Check Rust format
         run: |
           cargo fmt --all -- --check
       - name: Run Clippy lints


### PR DESCRIPTION
This PR adds formatting checking for the following file types on top of `.rs` files:

- `md`
- `yaml` and `yml`
- `json`

`jq` is used for `json` files instead of `prettier` since `prettier` seems to accept multiple representations of the same `json` file in some cases.