### PR TITLE
feat: get_last_batch_id

### DIFF
--- a/starknet-providers/src/provider.rs
+++ b/starknet-providers/src/provider.rs
@@ -64,4 +64,6 @@ pub trait Provider {
     ) -> Result<H256, Self::Error>;
 
     async fn get_transaction_id_by_hash(&self, transaction_hash: H256) -> Result<u64, Self::Error>;
+
+    async fn get_last_batch_id(&self) -> Result<u64, Self::Error>;
 }

--- a/starknet-providers/src/sequencer_gateway.rs
+++ b/starknet-providers/src/sequencer_gateway.rs
@@ -375,6 +375,20 @@ impl Provider for SequencerGatewayProvider {
             }
         }
     }
+
+    async fn get_last_batch_id(&self) -> Result<u64, Self::Error> {
+        let request_url = self.extend_feeder_gateway_url("get_last_batch_id");
+
+        match self
+            .send_get_request::<GatewayResponse<u64>>(request_url)
+            .await?
+        {
+            GatewayResponse::Data(batch_id) => Ok(batch_id),
+            GatewayResponse::StarknetError(starknet_err) => {
+                Err(ProviderError::StarknetError(starknet_err))
+            }
+        }
+    }
 }
 
 fn extend_url(url: &mut Url, segment: &str) {


### PR DESCRIPTION
The feeder gateway client in `cairo-lang` has a [`get_last_batch_id` function](https://github.com/starkware-libs/cairo-lang/blob/master/src/services/everest/api/feeder_gateway/feeder_gateway_client.py#L17) that's missing in the lib. This PR adds it. The call itself [returns](https://alpha4.starknet.io/feeder_gateway/get_last_batch_id) a single number.