### PR TITLE
ci: audit and udeps

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,19 @@
+on:
+  schedule:
+    # 2:20 past midnight UTC
+    - cron: "20 2 * * *"
+
+name: Security audit
+jobs:
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Run audit check
+        uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v2
 
-      - name: Use stable toolchain
+      - name: Setup toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}

--- a/.github/workflows/udeps.yml
+++ b/.github/workflows/udeps.yml
@@ -1,0 +1,40 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+name: Unused deps
+jobs:
+  udeps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Setup nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - name: Setup cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install udeps
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-udeps --locked
+
+      - name: Run udeps
+        uses: actions-rs/cargo@v1
+        with:
+          command: udeps

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -17,4 +17,6 @@ base64 = "0.13.0"
 ethereum-types = "0.12.1"
 hex = "0.4.3"
 serde = { version = "1.0.133", features = ["derive"] }
+
+[dev-dependencies]
 serde_json = "1.0.74"


### PR DESCRIPTION
Adds two new CI Actions, as discussed in #4:

1) Security audit check via the [audit-check](https://github.com/actions-rs/audit-check) action. It is set up to run periodically once a day (as opposed to it being triggered by a push to `master` on on a PR) because of a [limitation](https://github.com/actions-rs/audit-check#limitations) that the action can't be triggered if the PR is coming from a fork. I figure it's fine this way because of the release process.

2) Unused dependencies via [cargo-udeps](https://github.com/est31/cargo-udeps). There's no GH Action wrapper for the tool, so I just built it using `action-rs/toolchain`, similar to the `test` workflow. It runs on `nightly`.

I had a look at [cargo-deny](https://github.com/EmbarkStudios/cargo-deny-action) as mentioned in #4, but I don't think it's necessary.