### PR TITLE
ci: use rust-cache for udeps

### DIFF
--- a/.github/workflows/udeps.yml
+++ b/.github/workflows/udeps.yml
@@ -19,14 +19,9 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Setup cache
-        uses: actions/cache@v2
+      - uses: Swatinem/rust-cache@v1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          cache-on-failure: true
 
       - name: Install udeps
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Resolves #17 

I changed the cache step for the same as is used in the Test action, udeps [now take](https://github.com/xJonathanLEI/starknet-rs/runs/4768223668?check_suite_focus=true) about a minute 🥳 