### PR TITLE
feat: implement high-level Pedersen util in `starknet-core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,6 +1490,8 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
+ "starknet-crypto",
+ "thiserror",
 ]
 
 [[package]]

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -13,10 +13,12 @@ Core structures for the starknet crate
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
+starknet-crypto = { version = "0.1.0", path = "../starknet-crypto" }
 base64 = "0.13.0"
 ethereum-types = "0.12.1"
 hex = "0.4.3"
 serde = { version = "1.0.133", features = ["derive"] }
+thiserror = "1.0.30"
 
 [dev-dependencies]
 serde_json = "1.0.74"

--- a/starknet-core/src/crypto.rs
+++ b/starknet-core/src/crypto.rs
@@ -1,0 +1,83 @@
+use ethereum_types::{H256, U256};
+use starknet_crypto::{pedersen_hash, FieldElement};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum PedersenHashError {
+    #[error("data must not be empty")]
+    EmptyData,
+    #[error("element out of range: {0}")]
+    ElementOutOfRange(U256),
+}
+
+pub fn compute_hash_on_elements(data: &[U256]) -> Result<H256, PedersenHashError> {
+    if data.is_empty() {
+        return Err(PedersenHashError::EmptyData);
+    }
+
+    // unwrap() is safe here as it'll always succeed
+    let mut current_hash = FieldElement::from_bytes_be([0u8; 32]).unwrap();
+
+    for item in data.iter() {
+        current_hash = pedersen_hash(
+            &current_hash,
+            &u256_to_field_element(item).ok_or(PedersenHashError::ElementOutOfRange(*item))?,
+        );
+    }
+
+    let data_len = U256::from(data.len());
+    current_hash = pedersen_hash(
+        &current_hash,
+        &u256_to_field_element(&data_len).ok_or(PedersenHashError::ElementOutOfRange(data_len))?,
+    );
+
+    Ok(H256::from_slice(&current_hash.to_bytes_le()[..]))
+}
+
+fn u256_to_field_element(num: &U256) -> Option<FieldElement> {
+    let mut buffer = [0u8; 32];
+    num.to_big_endian(&mut buffer);
+    FieldElement::from_bytes_be(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_hash_on_elements() {
+        // Generated with `cairo-lang`
+        let hash = compute_hash_on_elements(&[
+            "0xaa".parse::<U256>().unwrap(),
+            "0xbb".parse::<U256>().unwrap(),
+            "0xcc".parse::<U256>().unwrap(),
+            "0xdd".parse::<U256>().unwrap(),
+        ])
+        .unwrap();
+        let expected_hash = "025cde77210b1c223b2c6e69db6e9021aa1599177ab177474d5326cd2a62cb69"
+            .parse::<H256>()
+            .unwrap();
+
+        assert_eq!(expected_hash, hash);
+    }
+
+    #[test]
+    fn test_compute_hash_on_elements_empty_data() {
+        match compute_hash_on_elements(&[]) {
+            Err(PedersenHashError::EmptyData) => {}
+            _ => panic!("Should throw error on empty data"),
+        };
+    }
+
+    #[test]
+    fn test_compute_hash_on_elements_out_of_range() {
+        match compute_hash_on_elements(&[
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                .parse::<U256>()
+                .unwrap(),
+        ]) {
+            Err(PedersenHashError::ElementOutOfRange(_)) => {}
+            _ => panic!("Should throw error on out of range data"),
+        };
+    }
+}

--- a/starknet-core/src/lib.rs
+++ b/starknet-core/src/lib.rs
@@ -4,3 +4,5 @@
 pub mod serde;
 
 pub mod types;
+
+pub mod crypto;

--- a/starknet-crypto/src/field_element.rs
+++ b/starknet-crypto/src/field_element.rs
@@ -30,6 +30,11 @@ impl FieldElement {
             None
         }
     }
+
+    /// Convert the field element into a big-endian byte representation
+    pub fn to_bytes_le(&self) -> [u8; 32] {
+        self.to_repr().0
+    }
 }
 
 impl FieldElement {


### PR DESCRIPTION
This PR adds a `compute_hash_on_elements` utility function to `starknet-core`. This function is useful for computing the sig hash for the account contract.

Code ported from #18 with the underlying crypto library replaced with `starknet-crypto`.

A new public function `to_bytes_le` was added to `starknet_crypto::FieldElement` to make this possible.