### PR TITLE
feat: implement `ecdsa_sign` in `starknet-core`

### DIFF
--- a/starknet-crypto/src/ecdsa.rs
+++ b/starknet-crypto/src/ecdsa.rs
@@ -4,7 +4,6 @@ use crate::{
     FieldElement, SignError, VerifyError,
 };
 
-const FIELD_ELEMENT_ZERO: FieldElement = FieldElement::new([0, 0, 0, 0]);
 const ELEMENT_UPPER_BOUND: FieldElement = FieldElement::new([
     18446743986131435553,
     160989183,
@@ -44,14 +43,14 @@ pub fn sign(
     if message >= &ELEMENT_UPPER_BOUND {
         return Err(SignError::InvalidMessageHash);
     }
-    if k == &FIELD_ELEMENT_ZERO {
+    if k == &FieldElement::ZERO {
         return Err(SignError::InvalidK);
     }
 
     let generator = &CONSTANT_POINTS[1];
 
     let r = generator.multiply(&k.into_bits()).x;
-    if r == FIELD_ELEMENT_ZERO || r >= ELEMENT_UPPER_BOUND {
+    if r == FieldElement::ZERO || r >= ELEMENT_UPPER_BOUND {
         return Err(SignError::InvalidK);
     }
 
@@ -60,7 +59,7 @@ pub fn sign(
     let s = r.mul_mod_floor(private_key, &EC_ORDER);
     let s = s.add_unbounded(message);
     let s = FieldElement::bigint_mul_mod_floor(s, &k_inv, &EC_ORDER);
-    if s == FIELD_ELEMENT_ZERO || s >= EC_ORDER {
+    if s == FieldElement::ZERO || s >= EC_ORDER {
         return Err(SignError::InvalidK);
     }
 
@@ -84,10 +83,10 @@ pub fn verify(
     if message >= &ELEMENT_UPPER_BOUND {
         return Err(VerifyError::InvalidMessageHash);
     }
-    if r == &FIELD_ELEMENT_ZERO || r >= &ELEMENT_UPPER_BOUND {
+    if r == &FieldElement::ZERO || r >= &ELEMENT_UPPER_BOUND {
         return Err(VerifyError::InvalidR);
     }
-    if s == &FIELD_ELEMENT_ZERO || s >= &EC_ORDER {
+    if s == &FieldElement::ZERO || s >= &EC_ORDER {
         return Err(VerifyError::InvalidS);
     }
 
@@ -96,7 +95,7 @@ pub fn verify(
     let generator = &CONSTANT_POINTS[1];
 
     let w = s.mod_inverse(&EC_ORDER);
-    if w == FIELD_ELEMENT_ZERO || w >= ELEMENT_UPPER_BOUND {
+    if w == FieldElement::ZERO || w >= ELEMENT_UPPER_BOUND {
         return Err(VerifyError::InvalidS);
     }
 

--- a/starknet-crypto/src/field_element.rs
+++ b/starknet-crypto/src/field_element.rs
@@ -15,6 +15,14 @@ use std::ops::{Add, Mul};
 pub struct FieldElement([u64; 4]);
 
 impl FieldElement {
+    pub const ZERO: FieldElement = FieldElement([0, 0, 0, 0]);
+    pub const ONE: FieldElement = FieldElement([
+        18446744073709551585,
+        18446744073709551615,
+        18446744073709551615,
+        576460752303422960,
+    ]);
+
     /// Attempts to convert a big-endian byte representation of a field element into an element of
     /// this prime field. Returns None if the input is not canonical (is not smaller than the
     /// field's modulus).
@@ -32,7 +40,7 @@ impl FieldElement {
     }
 
     /// Convert the field element into a big-endian byte representation
-    pub fn to_bytes_le(&self) -> [u8; 32] {
+    pub fn to_bytes_be(&self) -> [u8; 32] {
         self.to_repr().0
     }
 }


### PR DESCRIPTION
This PR:

- implements `ecdsa_sign`, a safe wrapper over the low level `starknet_crypto::sign`;
- exposes `ZERO` and `ONE` constants on `starknet_crypto::FieldElement`;
- fixes a typo introduced in #38: `to_bytes_le` -> `to_bytes_be`.