### PR TITLE
feat: implement `get_selector_from_name`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +296,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +342,17 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
+dependencies = [
+ "block-buffer 0.10.0",
+ "crypto-common",
  "generic-array",
 ]
 
@@ -574,7 +603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -751,6 +780,12 @@ checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "lazy_static"
@@ -1420,11 +1455,21 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f935e31cf406e8c0e96c2815a5516181b7004ae8c5f296293221e9b1e356bd"
+dependencies = [
+ "digest 0.10.1",
+ "keccak",
 ]
 
 [[package]]
@@ -1490,6 +1535,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
+ "sha3",
  "starknet-crypto",
  "thiserror",
 ]

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -18,6 +18,7 @@ base64 = "0.13.0"
 ethereum-types = "0.12.1"
 hex = "0.4.3"
 serde = { version = "1.0.133", features = ["derive"] }
+sha3 = "0.10.0"
 thiserror = "1.0.30"
 
 [dev-dependencies]

--- a/starknet-core/src/lib.rs
+++ b/starknet-core/src/lib.rs
@@ -6,3 +6,5 @@ pub mod serde;
 pub mod types;
 
 pub mod crypto;
+
+pub mod utils;

--- a/starknet-core/src/utils.rs
+++ b/starknet-core/src/utils.rs
@@ -1,0 +1,94 @@
+use ethereum_types::H256;
+use sha3::{Digest, Keccak256};
+use thiserror::Error;
+
+const DEFAULT_ENTRY_POINT_NAME: &str = "__default__";
+const DEFAULT_L1_ENTRY_POINT_NAME: &str = "__l1_default__";
+
+#[derive(Debug, Error)]
+#[error("the provided name contains non-ASCII characters: {name}")]
+pub struct NonAsciiNameError<'a> {
+    pub name: &'a str,
+}
+
+/// A variant of eth-keccak that computes a value that fits in a StarkNet field element.
+pub fn starknet_keccak(data: &[u8]) -> H256 {
+    let mut hasher = Keccak256::new();
+    hasher.update(data);
+    let mut hash = hasher.finalize();
+
+    // Remove the first 6 bits
+    hash[0] &= 0b00000011;
+
+    H256::from_slice(&hash)
+}
+
+pub fn get_selector_from_name(func_name: &str) -> Result<H256, NonAsciiNameError> {
+    if func_name == DEFAULT_ENTRY_POINT_NAME || func_name == DEFAULT_L1_ENTRY_POINT_NAME {
+        Ok(H256::from_slice(&[0u8; 32]))
+    } else {
+        let name_bytes = func_name.as_bytes();
+        if name_bytes.is_ascii() {
+            Ok(starknet_keccak(name_bytes))
+        } else {
+            Err(NonAsciiNameError { name: func_name })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_starknet_keccak() {
+        // Generated from `cairo-lang`
+        let data = b"execute";
+        let expected_hash = "0240060cdb34fcc260f41eac7474ee1d7c80b7e3607daff9ac67c7ea2ebb1c44"
+            .parse::<H256>()
+            .unwrap();
+
+        let hash = starknet_keccak(data);
+
+        assert_eq!(hash, expected_hash);
+    }
+
+    #[test]
+    fn test_get_selector_from_name() {
+        // Generated from `cairo-lang`
+        let func_name = "execute";
+        let expected_selector = "0240060cdb34fcc260f41eac7474ee1d7c80b7e3607daff9ac67c7ea2ebb1c44"
+            .parse::<H256>()
+            .unwrap();
+
+        let selector = get_selector_from_name(func_name).unwrap();
+
+        assert_eq!(selector, expected_selector);
+    }
+
+    #[test]
+    fn test_get_default_selector() {
+        let default_selector = "0000000000000000000000000000000000000000000000000000000000000000"
+            .parse::<H256>()
+            .unwrap();
+
+        assert_eq!(
+            get_selector_from_name("__default__").unwrap(),
+            default_selector
+        );
+        assert_eq!(
+            get_selector_from_name("__l1_default__").unwrap(),
+            default_selector
+        );
+    }
+
+    #[test]
+    fn test_get_selector_from_non_ascii_name() {
+        let func_name = "🦀";
+
+        match get_selector_from_name(func_name) {
+            Err(_) => {}
+            _ => panic!("Should throw error on non-ASCII name"),
+        };
+    }
+}

--- a/starknet-core/src/utils.rs
+++ b/starknet-core/src/utils.rs
@@ -25,7 +25,7 @@ pub fn starknet_keccak(data: &[u8]) -> H256 {
 
 pub fn get_selector_from_name(func_name: &str) -> Result<H256, NonAsciiNameError> {
     if func_name == DEFAULT_ENTRY_POINT_NAME || func_name == DEFAULT_L1_ENTRY_POINT_NAME {
-        Ok(H256::from_slice(&[0u8; 32]))
+        Ok(H256::zero())
     } else {
         let name_bytes = func_name.as_bytes();
         if name_bytes.is_ascii() {


### PR DESCRIPTION
This PR ports `get_selector_from_name` from `cairo-lang`.