### PR TITLE
refactor: remove `U256` and `H256` on all public APIs

### DIFF
--- a/starknet-core/src/crypto.rs
+++ b/starknet-core/src/crypto.rs
@@ -1,111 +1,106 @@
-use ethereum_types::{H256, U256};
-use starknet_crypto::{pedersen_hash, rfc6979_generate_k, sign, verify, FieldElement, VerifyError};
+use crate::types::UnsignedFieldElement;
+
+use starknet_crypto::{
+    pedersen_hash, rfc6979_generate_k, sign, verify, FieldElement, SignError, VerifyError,
+};
 use thiserror::Error;
 
 #[derive(Debug)]
 pub struct Signature {
-    pub r: U256,
-    pub s: U256,
+    pub r: UnsignedFieldElement,
+    pub s: UnsignedFieldElement,
 }
 
 #[derive(Debug, Error)]
 pub enum PedersenHashError {
     #[error("data must not be empty")]
     EmptyData,
-    #[error("element out of range: {0}")]
-    ElementOutOfRange(U256),
 }
 
 #[derive(Debug, Error)]
-pub enum EcdsaError {
-    #[error("private key out of range: {0}")]
-    PrivateKeyOutOfRange(U256),
-    #[error("public key out of range: {0}")]
-    PublicKeyOutOfRange(U256),
-    #[error("message hash out of range: {0}")]
-    MessageHashOutOfRange(H256),
-    #[error("signature out of range: {0}")]
-    SignatureOutOfRange(U256),
+pub enum EcdsaSignError {
+    #[error("message hash out of range")]
+    MessageHashOutOfRange,
 }
 
-pub fn compute_hash_on_elements(data: &[U256]) -> Result<H256, PedersenHashError> {
+#[derive(Debug, Error)]
+pub enum EcdsaVerifyError {
+    #[error("message hash out of range")]
+    MessageHashOutOfRange,
+    #[error("signature r value out of range")]
+    SignatureROutOfRange,
+    #[error("signature s value out of range")]
+    SignatureSOutOfRange,
+}
+
+pub fn compute_hash_on_elements(
+    data: &[UnsignedFieldElement],
+) -> Result<UnsignedFieldElement, PedersenHashError> {
     if data.is_empty() {
         return Err(PedersenHashError::EmptyData);
     }
 
-    // unwrap() is safe here as it'll always succeed
-    let mut current_hash = FieldElement::from_bytes_be([0u8; 32]).unwrap();
+    let mut current_hash = FieldElement::ZERO;
 
     for item in data.iter() {
-        current_hash = pedersen_hash(
-            &current_hash,
-            &u256_to_field_element(item).ok_or(PedersenHashError::ElementOutOfRange(*item))?,
-        );
+        current_hash = pedersen_hash(&current_hash, &(*item).into());
     }
 
-    let data_len = U256::from(data.len());
-    current_hash = pedersen_hash(
-        &current_hash,
-        &u256_to_field_element(&data_len).ok_or(PedersenHashError::ElementOutOfRange(data_len))?,
-    );
+    let data_len = UnsignedFieldElement::from(data.len());
+    current_hash = pedersen_hash(&current_hash, &data_len.into());
 
-    Ok(H256::from_slice(&current_hash.to_bytes_be()))
+    Ok(current_hash.into())
 }
 
-pub fn ecdsa_sign(private_key: &U256, message_hash: H256) -> Result<Signature, EcdsaError> {
-    let private_key =
-        u256_to_field_element(private_key).ok_or(EcdsaError::PrivateKeyOutOfRange(*private_key))?;
-    let message_hash = FieldElement::from_bytes_be(message_hash.0)
-        .ok_or(EcdsaError::MessageHashOutOfRange(message_hash))?;
+pub fn ecdsa_sign(
+    private_key: &UnsignedFieldElement,
+    message_hash: &UnsignedFieldElement,
+) -> Result<Signature, EcdsaSignError> {
+    let private_key_fe = (*private_key).into();
+    let message_hash_fe = (*message_hash).into();
 
     // Seed-retry logic ported from `cairo-lang`
     let mut seed = None;
     loop {
-        let k = rfc6979_generate_k(&message_hash, &private_key, seed.as_ref());
+        let k = rfc6979_generate_k(&message_hash_fe, &private_key_fe, seed.as_ref());
 
-        // The only possible error is invalid K, in which case we simply retry
-        if let Ok(sig) = sign(&private_key, &message_hash, &k) {
-            return Ok(Signature {
-                r: U256::from_big_endian(&sig.r.to_bytes_be()),
-                s: U256::from_big_endian(&sig.s.to_bytes_be()),
-            });
-        }
-
-        seed = match seed {
-            Some(prev_seed) => Some(prev_seed + FieldElement::ONE),
-            None => Some(FieldElement::ONE),
+        match sign(&private_key_fe, &message_hash_fe, &k) {
+            Ok(sig) => {
+                return Ok(Signature {
+                    r: sig.r.into(),
+                    s: sig.s.into(),
+                });
+            }
+            Err(SignError::InvalidMessageHash) => {
+                return Err(EcdsaSignError::MessageHashOutOfRange)
+            }
+            Err(SignError::InvalidK) => {
+                // Bump seed and retry
+                seed = match seed {
+                    Some(prev_seed) => Some(prev_seed + FieldElement::ONE),
+                    None => Some(FieldElement::ONE),
+                };
+            }
         };
     }
 }
 
 pub fn ecdsa_verify(
-    public_key: &U256,
-    message_hash: H256,
+    public_key: &UnsignedFieldElement,
+    message_hash: &UnsignedFieldElement,
     signature: &Signature,
-) -> Result<bool, EcdsaError> {
-    let public_key =
-        u256_to_field_element(public_key).ok_or(EcdsaError::PublicKeyOutOfRange(*public_key))?;
-    let hash = FieldElement::from_bytes_be(message_hash.0)
-        .ok_or(EcdsaError::MessageHashOutOfRange(message_hash))?;
-    let signature_r =
-        u256_to_field_element(&signature.r).ok_or(EcdsaError::SignatureOutOfRange(signature.r))?;
-    let signature_s =
-        u256_to_field_element(&signature.s).ok_or(EcdsaError::SignatureOutOfRange(signature.s))?;
-
-    match verify(&public_key, &hash, &signature_r, &signature_s) {
+) -> Result<bool, EcdsaVerifyError> {
+    match verify(
+        &(*public_key).into(),
+        &(*message_hash).into(),
+        &signature.r.into(),
+        &signature.s.into(),
+    ) {
         Ok(result) => Ok(result),
-        Err(VerifyError::InvalidMessageHash) => {
-            Err(EcdsaError::MessageHashOutOfRange(message_hash))
-        }
-        Err(VerifyError::InvalidR) => Err(EcdsaError::SignatureOutOfRange(signature.r)),
-        Err(VerifyError::InvalidS) => Err(EcdsaError::SignatureOutOfRange(signature.s)),
+        Err(VerifyError::InvalidMessageHash) => Err(EcdsaVerifyError::MessageHashOutOfRange),
+        Err(VerifyError::InvalidR) => Err(EcdsaVerifyError::SignatureROutOfRange),
+        Err(VerifyError::InvalidS) => Err(EcdsaVerifyError::SignatureSOutOfRange),
     }
-}
-
-fn u256_to_field_element(num: &U256) -> Option<FieldElement> {
-    let mut buffer = [0u8; 32];
-    num.to_big_endian(&mut buffer);
-    FieldElement::from_bytes_be(buffer)
 }
 
 #[cfg(test)]
@@ -116,15 +111,16 @@ mod tests {
     fn test_compute_hash_on_elements() {
         // Generated with `cairo-lang`
         let hash = compute_hash_on_elements(&[
-            "0xaa".parse::<U256>().unwrap(),
-            "0xbb".parse::<U256>().unwrap(),
-            "0xcc".parse::<U256>().unwrap(),
-            "0xdd".parse::<U256>().unwrap(),
+            UnsignedFieldElement::from_hex_str("0xaa").unwrap(),
+            UnsignedFieldElement::from_hex_str("0xbb").unwrap(),
+            UnsignedFieldElement::from_hex_str("0xcc").unwrap(),
+            UnsignedFieldElement::from_hex_str("0xdd").unwrap(),
         ])
         .unwrap();
-        let expected_hash = "025cde77210b1c223b2c6e69db6e9021aa1599177ab177474d5326cd2a62cb69"
-            .parse::<H256>()
-            .unwrap();
+        let expected_hash = UnsignedFieldElement::from_hex_str(
+            "025cde77210b1c223b2c6e69db6e9021aa1599177ab177474d5326cd2a62cb69",
+        )
+        .unwrap();
 
         assert_eq!(expected_hash, hash);
     }
@@ -138,66 +134,45 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_hash_on_elements_out_of_range() {
-        match compute_hash_on_elements(&[
-            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-                .parse::<U256>()
-                .unwrap(),
-        ]) {
-            Err(PedersenHashError::ElementOutOfRange(_)) => {}
-            _ => panic!("Should throw error on out of range data"),
-        };
-    }
-
-    #[test]
     fn test_ecdsa_sign() {
         // Generated with `cairo-lang`
         let signature = ecdsa_sign(
-            &"0139fe4d6f02e666e86a6f58e65060f115cd3c185bd9e98bd829636931458f79"
-                .parse::<U256>()
-                .unwrap(),
-            "06fea80189363a786037ed3e7ba546dad0ef7de49fccae0e31eb658b7dd4ea76"
-                .parse::<H256>()
-                .unwrap(),
+            &UnsignedFieldElement::from_hex_str(
+                "0139fe4d6f02e666e86a6f58e65060f115cd3c185bd9e98bd829636931458f79",
+            )
+            .unwrap(),
+            &UnsignedFieldElement::from_hex_str(
+                "06fea80189363a786037ed3e7ba546dad0ef7de49fccae0e31eb658b7dd4ea76",
+            )
+            .unwrap(),
         )
         .unwrap();
-        let expected_r = "061ec782f76a66f6984efc3a1b6d152a124c701c00abdd2bf76641b4135c770f"
-            .parse::<U256>()
-            .unwrap();
-        let expected_s = "04e44e759cea02c23568bb4d8a09929bbca8768ab68270d50c18d214166ccd9a"
-            .parse::<U256>()
-            .unwrap();
+        let expected_r = UnsignedFieldElement::from_hex_str(
+            "061ec782f76a66f6984efc3a1b6d152a124c701c00abdd2bf76641b4135c770f",
+        )
+        .unwrap();
+        let expected_s = UnsignedFieldElement::from_hex_str(
+            "04e44e759cea02c23568bb4d8a09929bbca8768ab68270d50c18d214166ccd9a",
+        )
+        .unwrap();
 
         assert_eq!(signature.r, expected_r);
         assert_eq!(signature.s, expected_s);
     }
 
     #[test]
-    fn test_ecdsa_sign_private_key_out_of_range() {
-        match ecdsa_sign(
-            &"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-                .parse::<U256>()
-                .unwrap(),
-            "06fea80189363a786037ed3e7ba546dad0ef7de49fccae0e31eb658b7dd4ea76"
-                .parse::<H256>()
-                .unwrap(),
-        ) {
-            Err(EcdsaError::PrivateKeyOutOfRange(_)) => {}
-            _ => panic!("Should throw error on out of range private key"),
-        };
-    }
-
-    #[test]
     fn test_ecdsa_sign_message_hash_out_of_range() {
         match ecdsa_sign(
-            &"0139fe4d6f02e666e86a6f58e65060f115cd3c185bd9e98bd829636931458f79"
-                .parse::<U256>()
-                .unwrap(),
-            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-                .parse::<H256>()
-                .unwrap(),
+            &UnsignedFieldElement::from_hex_str(
+                "0139fe4d6f02e666e86a6f58e65060f115cd3c185bd9e98bd829636931458f79",
+            )
+            .unwrap(),
+            &UnsignedFieldElement::from_hex_str(
+                "0800000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
         ) {
-            Err(EcdsaError::MessageHashOutOfRange(_)) => {}
+            Err(EcdsaSignError::MessageHashOutOfRange) => {}
             _ => panic!("Should throw error on out of range message hash"),
         };
     }
@@ -205,21 +180,25 @@ mod tests {
     #[test]
     fn test_ecdsa_verify_valid_signature() {
         // Generated with `cairo-lang`
-        let public_key = "02c5dbad71c92a45cc4b40573ae661f8147869a91d57b8d9b8f48c8af7f83159"
-            .parse::<U256>()
-            .unwrap();
-        let message_hash = "06fea80189363a786037ed3e7ba546dad0ef7de49fccae0e31eb658b7dd4ea76"
-            .parse::<H256>()
-            .unwrap();
-        let r = "061ec782f76a66f6984efc3a1b6d152a124c701c00abdd2bf76641b4135c770f"
-            .parse::<U256>()
-            .unwrap();
-        let s = "04e44e759cea02c23568bb4d8a09929bbca8768ab68270d50c18d214166ccd9a"
-            .parse::<U256>()
-            .unwrap();
+        let public_key = UnsignedFieldElement::from_hex_str(
+            "02c5dbad71c92a45cc4b40573ae661f8147869a91d57b8d9b8f48c8af7f83159",
+        )
+        .unwrap();
+        let message_hash = UnsignedFieldElement::from_hex_str(
+            "06fea80189363a786037ed3e7ba546dad0ef7de49fccae0e31eb658b7dd4ea76",
+        )
+        .unwrap();
+        let r = UnsignedFieldElement::from_hex_str(
+            "061ec782f76a66f6984efc3a1b6d152a124c701c00abdd2bf76641b4135c770f",
+        )
+        .unwrap();
+        let s = UnsignedFieldElement::from_hex_str(
+            "04e44e759cea02c23568bb4d8a09929bbca8768ab68270d50c18d214166ccd9a",
+        )
+        .unwrap();
 
         assert_eq!(
-            ecdsa_verify(&public_key, message_hash, &Signature { r, s }).unwrap(),
+            ecdsa_verify(&public_key, &message_hash, &Signature { r, s }).unwrap(),
             true
         );
     }
@@ -227,21 +206,25 @@ mod tests {
     #[test]
     fn test_ecdsa_verify_invalid_signature() {
         // Generated with `cairo-lang`
-        let public_key = "02c5dbad71c92a45cc4b40573ae661f8147869a91d57b8d9b8f48c8af7f83159"
-            .parse::<U256>()
-            .unwrap();
-        let message_hash = "06fea80189363a786037ed3e7ba546dad0ef7de49fccae0e31eb658b7dd4ea76"
-            .parse::<H256>()
-            .unwrap();
-        let r = "061ec782f76a66f6984efc3a1b6d152a124c701c00abdd2bf76641b4135c770f"
-            .parse::<U256>()
-            .unwrap();
-        let s = "04e44e759cea02c23568bb4d8a09929bbca8768ab68270d50c18d214166ccd9b"
-            .parse::<U256>()
-            .unwrap();
+        let public_key = UnsignedFieldElement::from_hex_str(
+            "02c5dbad71c92a45cc4b40573ae661f8147869a91d57b8d9b8f48c8af7f83159",
+        )
+        .unwrap();
+        let message_hash = UnsignedFieldElement::from_hex_str(
+            "06fea80189363a786037ed3e7ba546dad0ef7de49fccae0e31eb658b7dd4ea76",
+        )
+        .unwrap();
+        let r = UnsignedFieldElement::from_hex_str(
+            "061ec782f76a66f6984efc3a1b6d152a124c701c00abdd2bf76641b4135c770f",
+        )
+        .unwrap();
+        let s = UnsignedFieldElement::from_hex_str(
+            "04e44e759cea02c23568bb4d8a09929bbca8768ab68270d50c18d214166ccd9b",
+        )
+        .unwrap();
 
         assert_eq!(
-            ecdsa_verify(&public_key, message_hash, &Signature { r, s }).unwrap(),
+            ecdsa_verify(&public_key, &message_hash, &Signature { r, s }).unwrap(),
             false
         );
     }

--- a/starknet-core/src/types/field_element/unsigned.rs
+++ b/starknet-core/src/types/field_element/unsigned.rs
@@ -31,6 +31,8 @@ pub enum FromUintError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum FromByteArrayError {
+    #[error("invalid length")]
+    InvalidLength,
     #[error("number out of range")]
     OutOfRange,
 }
@@ -72,6 +74,19 @@ impl UnsignedFieldElement {
         match Self::try_from(parsed_u256) {
             Ok(value) => Ok(value),
             Err(FromUintError::OutOfRange) => Err(FromStrError::OutOfRange),
+        }
+    }
+
+    pub fn try_from_bytes_be(value: &[u8]) -> Result<Self, FromByteArrayError> {
+        if value.len() != 32 {
+            Err(FromByteArrayError::InvalidLength)
+        } else {
+            let value = U256::from_big_endian(value);
+            if value > Self::MAX.inner {
+                Err(FromByteArrayError::OutOfRange)
+            } else {
+                Ok(Self { inner: value })
+            }
         }
     }
 }

--- a/starknet-core/src/types/field_element/unsigned.rs
+++ b/starknet-core/src/types/field_element/unsigned.rs
@@ -248,6 +248,14 @@ impl TryFrom<&[u8; 32]> for UnsignedFieldElement {
     }
 }
 
+impl From<usize> for UnsignedFieldElement {
+    fn from(value: usize) -> Self {
+        Self {
+            inner: U256::from(value),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -1,5 +1,5 @@
 // Re-export commonly used upstream types
-pub use ethereum_types::{Address, H256, U256};
+pub use ethereum_types::Address as L1Address;
 
 mod block;
 pub use block::{Block, BlockId};

--- a/starknet-signers/src/key_pair.rs
+++ b/starknet-signers/src/key_pair.rs
@@ -1,94 +1,52 @@
 use starknet_core::{
-    crypto::{ecdsa_sign, ecdsa_verify, EcdsaError, Signature},
-    types::{H256, U256},
+    crypto::{ecdsa_sign, ecdsa_verify, EcdsaSignError, EcdsaVerifyError, Signature},
+    types::UnsignedFieldElement,
 };
-use starknet_crypto::{get_public_key, FieldElement};
+use starknet_crypto::get_public_key;
 
 #[derive(Debug)]
 pub struct SigningKey {
-    secret_scalar: U256,
+    secret_scalar: UnsignedFieldElement,
 }
 
 #[derive(Debug)]
 pub struct VerifyingKey {
-    scalar: U256,
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum KeyError {
-    #[error("scalar out of range: {0}")]
-    ScalarOutOfRange(U256),
-    #[error("hash out of range: {0}")]
-    HashOutOfRange(H256),
+    scalar: UnsignedFieldElement,
 }
 
 impl SigningKey {
-    pub fn from_secret_scalar(secret_scalar: &U256) -> Result<Self, KeyError> {
-        // Make use of `FieldElement` for the range check
-        // TODO: use `U256` constant for the check or unify types (#13) so that no range check is
-        //       required at all.
-        let mut buffer = [0u8; 32];
-        secret_scalar.to_big_endian(&mut buffer);
-        if FieldElement::from_bytes_be(buffer).is_some() {
-            Ok(Self {
-                secret_scalar: *secret_scalar,
-            })
-        } else {
-            Err(KeyError::ScalarOutOfRange(*secret_scalar))
-        }
+    pub fn from_secret_scalar(secret_scalar: UnsignedFieldElement) -> Self {
+        Self { secret_scalar }
     }
 
-    pub fn secret_scalar(&self) -> U256 {
+    pub fn secret_scalar(&self) -> UnsignedFieldElement {
         self.secret_scalar
     }
 
     pub fn verifying_key(&self) -> VerifyingKey {
-        let mut buffer = [0u8; 32];
-        self.secret_scalar.to_big_endian(&mut buffer);
-
-        VerifyingKey::from_scalar(&U256::from_big_endian(
-            &get_public_key(&FieldElement::from_bytes_be(buffer).unwrap()).to_bytes_be(),
-        ))
-        .unwrap()
+        VerifyingKey::from_scalar(get_public_key(&self.secret_scalar.into()).into())
     }
 
-    pub fn sign(&self, hash: H256) -> Result<Signature, KeyError> {
-        // Quite inefficient here as we're converting between `U256` and `FieldElement`
-        // unnecessarily. This shall be fixed once we unify the types as tracked here:
-        //   https://github.com/xJonathanLEI/starknet-rs/issues/13
-        match ecdsa_sign(&self.secret_scalar, hash) {
-            Ok(sig) => Ok(sig),
-            Err(EcdsaError::MessageHashOutOfRange(hash)) => Err(KeyError::HashOutOfRange(hash)),
-            _ => panic!("unexpected error type"), // impossible
-        }
+    pub fn sign(&self, hash: &UnsignedFieldElement) -> Result<Signature, EcdsaSignError> {
+        ecdsa_sign(&self.secret_scalar, hash)
     }
 }
 
 impl VerifyingKey {
-    pub fn from_scalar(scalar: &U256) -> Result<Self, KeyError> {
-        // Make use of `FieldElement` for the range check
-        // TODO: use `U256` constant for the check or unify types (#13) so that no range check is
-        //       required at all.
-        let mut buffer = [0u8; 32];
-        scalar.to_big_endian(&mut buffer);
-        if FieldElement::from_bytes_be(buffer).is_some() {
-            Ok(Self { scalar: *scalar })
-        } else {
-            Err(KeyError::ScalarOutOfRange(*scalar))
-        }
+    pub fn from_scalar(scalar: UnsignedFieldElement) -> Self {
+        Self { scalar }
     }
 
-    pub fn scalar(&self) -> U256 {
+    pub fn scalar(&self) -> UnsignedFieldElement {
         self.scalar
     }
 
-    pub fn verify(&self, hash: H256, signature: &Signature) -> Result<bool, KeyError> {
-        match ecdsa_verify(&self.scalar, hash, signature) {
-            Ok(result) => Ok(result),
-            Err(EcdsaError::MessageHashOutOfRange(hash)) => Err(KeyError::HashOutOfRange(hash)),
-            Err(EcdsaError::SignatureOutOfRange(sig)) => Err(KeyError::ScalarOutOfRange(sig)),
-            _ => panic!("unexpected error type"),
-        }
+    pub fn verify(
+        &self,
+        hash: &UnsignedFieldElement,
+        signature: &Signature,
+    ) -> Result<bool, EcdsaVerifyError> {
+        ecdsa_verify(&self.scalar, hash, signature)
     }
 }
 
@@ -99,11 +57,12 @@ mod tests {
     #[test]
     fn test_get_secret_scalar() {
         // Generated with `cairo-lang`
-        let private_key = "0139fe4d6f02e666e86a6f58e65060f115cd3c185bd9e98bd829636931458f79"
-            .parse::<U256>()
-            .unwrap();
+        let private_key = UnsignedFieldElement::from_hex_str(
+            "0139fe4d6f02e666e86a6f58e65060f115cd3c185bd9e98bd829636931458f79",
+        )
+        .unwrap();
 
-        let signing_key = SigningKey::from_secret_scalar(&private_key).unwrap();
+        let signing_key = SigningKey::from_secret_scalar(private_key);
 
         assert_eq!(signing_key.secret_scalar(), private_key);
     }
@@ -111,15 +70,16 @@ mod tests {
     #[test]
     fn test_get_verifying_key() {
         // Generated with `cairo-lang`
-        let private_key = "0139fe4d6f02e666e86a6f58e65060f115cd3c185bd9e98bd829636931458f79"
-            .parse::<U256>()
-            .unwrap();
-        let expected_public_key =
-            "02c5dbad71c92a45cc4b40573ae661f8147869a91d57b8d9b8f48c8af7f83159"
-                .parse::<U256>()
-                .unwrap();
+        let private_key = UnsignedFieldElement::from_hex_str(
+            "0139fe4d6f02e666e86a6f58e65060f115cd3c185bd9e98bd829636931458f79",
+        )
+        .unwrap();
+        let expected_public_key = UnsignedFieldElement::from_hex_str(
+            "02c5dbad71c92a45cc4b40573ae661f8147869a91d57b8d9b8f48c8af7f83159",
+        )
+        .unwrap();
 
-        let signing_key = SigningKey::from_secret_scalar(&private_key).unwrap();
+        let signing_key = SigningKey::from_secret_scalar(private_key);
         let verifying_key = signing_key.verifying_key();
 
         assert_eq!(verifying_key.scalar(), expected_public_key);
@@ -128,51 +88,45 @@ mod tests {
     #[test]
     fn test_sign() {
         // Generated with `cairo-lang`
-        let private_key = "0139fe4d6f02e666e86a6f58e65060f115cd3c185bd9e98bd829636931458f79"
-            .parse::<U256>()
-            .unwrap();
-        let hash = "06fea80189363a786037ed3e7ba546dad0ef7de49fccae0e31eb658b7dd4ea76"
-            .parse::<H256>()
-            .unwrap();
-        let expected_r = "061ec782f76a66f6984efc3a1b6d152a124c701c00abdd2bf76641b4135c770f"
-            .parse::<U256>()
-            .unwrap();
-        let expected_s = "04e44e759cea02c23568bb4d8a09929bbca8768ab68270d50c18d214166ccd9a"
-            .parse::<U256>()
-            .unwrap();
+        let private_key = UnsignedFieldElement::from_hex_str(
+            "0139fe4d6f02e666e86a6f58e65060f115cd3c185bd9e98bd829636931458f79",
+        )
+        .unwrap();
+        let hash = UnsignedFieldElement::from_hex_str(
+            "06fea80189363a786037ed3e7ba546dad0ef7de49fccae0e31eb658b7dd4ea76",
+        )
+        .unwrap();
+        let expected_r = UnsignedFieldElement::from_hex_str(
+            "061ec782f76a66f6984efc3a1b6d152a124c701c00abdd2bf76641b4135c770f",
+        )
+        .unwrap();
+        let expected_s = UnsignedFieldElement::from_hex_str(
+            "04e44e759cea02c23568bb4d8a09929bbca8768ab68270d50c18d214166ccd9a",
+        )
+        .unwrap();
 
-        let signing_key = SigningKey::from_secret_scalar(&private_key).unwrap();
-        let signature = signing_key.sign(hash).unwrap();
+        let signing_key = SigningKey::from_secret_scalar(private_key);
+        let signature = signing_key.sign(&hash).unwrap();
 
         assert_eq!(signature.r, expected_r);
         assert_eq!(signature.s, expected_s);
     }
 
     #[test]
-    fn test_secret_scalar_out_of_range() {
-        match SigningKey::from_secret_scalar(
-            &"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-                .parse::<U256>()
-                .unwrap(),
-        ) {
-            Err(KeyError::ScalarOutOfRange(_)) => {}
-            _ => panic!("Should throw error on out of range private key"),
-        };
-    }
-
-    #[test]
     fn test_hash_out_of_range() {
-        let private_key = "0139fe4d6f02e666e86a6f58e65060f115cd3c185bd9e98bd829636931458f79"
-            .parse::<U256>()
-            .unwrap();
-        let hash = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-            .parse::<H256>()
-            .unwrap();
+        let private_key = UnsignedFieldElement::from_hex_str(
+            "0139fe4d6f02e666e86a6f58e65060f115cd3c185bd9e98bd829636931458f79",
+        )
+        .unwrap();
+        let hash = UnsignedFieldElement::from_hex_str(
+            "0800000000000000000000000000000000000000000000000000000000000000",
+        )
+        .unwrap();
 
-        let signing_key = SigningKey::from_secret_scalar(&private_key).unwrap();
+        let signing_key = SigningKey::from_secret_scalar(private_key);
 
-        match signing_key.sign(hash) {
-            Err(KeyError::HashOutOfRange(_)) => {}
+        match signing_key.sign(&hash) {
+            Err(EcdsaSignError::MessageHashOutOfRange) => {}
             _ => panic!("Should throw error on out of range hash"),
         };
     }
@@ -180,23 +134,27 @@ mod tests {
     #[test]
     fn test_verify_valid_signature() {
         // Generated with `cairo-lang`
-        let public_key = "02c5dbad71c92a45cc4b40573ae661f8147869a91d57b8d9b8f48c8af7f83159"
-            .parse::<U256>()
-            .unwrap();
-        let hash = "06fea80189363a786037ed3e7ba546dad0ef7de49fccae0e31eb658b7dd4ea76"
-            .parse::<H256>()
-            .unwrap();
-        let r = "061ec782f76a66f6984efc3a1b6d152a124c701c00abdd2bf76641b4135c770f"
-            .parse::<U256>()
-            .unwrap();
-        let s = "04e44e759cea02c23568bb4d8a09929bbca8768ab68270d50c18d214166ccd9a"
-            .parse::<U256>()
-            .unwrap();
+        let public_key = UnsignedFieldElement::from_hex_str(
+            "02c5dbad71c92a45cc4b40573ae661f8147869a91d57b8d9b8f48c8af7f83159",
+        )
+        .unwrap();
+        let hash = UnsignedFieldElement::from_hex_str(
+            "06fea80189363a786037ed3e7ba546dad0ef7de49fccae0e31eb658b7dd4ea76",
+        )
+        .unwrap();
+        let r = UnsignedFieldElement::from_hex_str(
+            "061ec782f76a66f6984efc3a1b6d152a124c701c00abdd2bf76641b4135c770f",
+        )
+        .unwrap();
+        let s = UnsignedFieldElement::from_hex_str(
+            "04e44e759cea02c23568bb4d8a09929bbca8768ab68270d50c18d214166ccd9a",
+        )
+        .unwrap();
 
-        let verifying_key = VerifyingKey::from_scalar(&public_key).unwrap();
+        let verifying_key = VerifyingKey::from_scalar(public_key);
 
         assert_eq!(
-            verifying_key.verify(hash, &Signature { r, s }).unwrap(),
+            verifying_key.verify(&hash, &Signature { r, s }).unwrap(),
             true
         );
     }
@@ -204,23 +162,27 @@ mod tests {
     #[test]
     fn test_verify_invalid_signature() {
         // Generated with `cairo-lang`
-        let public_key = "02c5dbad71c92a45cc4b40573ae661f8147869a91d57b8d9b8f48c8af7f83159"
-            .parse::<U256>()
-            .unwrap();
-        let hash = "06fea80189363a786037ed3e7ba546dad0ef7de49fccae0e31eb658b7dd4ea76"
-            .parse::<H256>()
-            .unwrap();
-        let r = "061ec782f76a66f6984efc3a1b6d152a124c701c00abdd2bf76641b4135c770f"
-            .parse::<U256>()
-            .unwrap();
-        let s = "04e44e759cea02c23568bb4d8a09929bbca8768ab68270d50c18d214166ccd9b"
-            .parse::<U256>()
-            .unwrap();
+        let public_key = UnsignedFieldElement::from_hex_str(
+            "02c5dbad71c92a45cc4b40573ae661f8147869a91d57b8d9b8f48c8af7f83159",
+        )
+        .unwrap();
+        let hash = UnsignedFieldElement::from_hex_str(
+            "06fea80189363a786037ed3e7ba546dad0ef7de49fccae0e31eb658b7dd4ea76",
+        )
+        .unwrap();
+        let r = UnsignedFieldElement::from_hex_str(
+            "061ec782f76a66f6984efc3a1b6d152a124c701c00abdd2bf76641b4135c770f",
+        )
+        .unwrap();
+        let s = UnsignedFieldElement::from_hex_str(
+            "04e44e759cea02c23568bb4d8a09929bbca8768ab68270d50c18d214166ccd9b",
+        )
+        .unwrap();
 
-        let verifying_key = VerifyingKey::from_scalar(&public_key).unwrap();
+        let verifying_key = VerifyingKey::from_scalar(public_key);
 
         assert_eq!(
-            verifying_key.verify(hash, &Signature { r, s }).unwrap(),
+            verifying_key.verify(&hash, &Signature { r, s }).unwrap(),
             false
         );
     }

--- a/starknet-signers/src/lib.rs
+++ b/starknet-signers/src/lib.rs
@@ -1,2 +1,2 @@
 mod key_pair;
-pub use key_pair::{KeyError, SigningKey, VerifyingKey};
+pub use key_pair::{SigningKey, VerifyingKey};


### PR DESCRIPTION
Resolves task 3 of #13:

> replace `U256` and `H256` with `UnsignedFieldElement` in crypto functions