### PR TITLE
feat: add `Signer` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,6 +1580,7 @@ dependencies = [
 name = "starknet-signers"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "starknet-core",
  "starknet-crypto",
  "thiserror",

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -15,4 +15,5 @@ keywords = ["ethereum", "starknet", "web3"]
 [dependencies]
 starknet-core = { version = "0.1.0", path = "../starknet-core" }
 starknet-crypto = { version = "0.1.0", path = "../starknet-crypto" }
+async-trait = "0.1.52"
 thiserror = "1.0.30"

--- a/starknet-signers/src/lib.rs
+++ b/starknet-signers/src/lib.rs
@@ -1,2 +1,11 @@
 mod key_pair;
 pub use key_pair::{SigningKey, VerifyingKey};
+
+mod signer;
+pub use signer::Signer;
+
+pub mod local_wallet;
+pub use local_wallet::LocalWallet;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Infallible {}

--- a/starknet-signers/src/local_wallet.rs
+++ b/starknet-signers/src/local_wallet.rs
@@ -1,0 +1,49 @@
+use crate::{Infallible, Signer, SigningKey};
+
+use async_trait::async_trait;
+use starknet_core::{
+    crypto::{EcdsaSignError, Signature},
+    types::UnsignedFieldElement,
+};
+
+pub struct LocalWallet {
+    private_key: SigningKey,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SignError {
+    #[error(transparent)]
+    EcdsaSignError(EcdsaSignError),
+}
+
+impl LocalWallet {
+    pub fn from_signing_key(key: SigningKey) -> Self {
+        key.into()
+    }
+}
+
+#[async_trait]
+impl Signer for LocalWallet {
+    type GetAddressError = Infallible;
+    type SignError = SignError;
+
+    async fn get_address(&self) -> Result<UnsignedFieldElement, Self::GetAddressError> {
+        Ok(self.private_key.verifying_key().scalar())
+    }
+
+    async fn sign_hash(&self, hash: &UnsignedFieldElement) -> Result<Signature, Self::SignError> {
+        Ok(self.private_key.sign(hash)?)
+    }
+}
+
+impl From<SigningKey> for LocalWallet {
+    fn from(value: SigningKey) -> Self {
+        Self { private_key: value }
+    }
+}
+
+impl From<EcdsaSignError> for SignError {
+    fn from(value: EcdsaSignError) -> Self {
+        Self::EcdsaSignError(value)
+    }
+}

--- a/starknet-signers/src/local_wallet.rs
+++ b/starknet-signers/src/local_wallet.rs
@@ -1,4 +1,4 @@
-use crate::{Infallible, Signer, SigningKey};
+use crate::{Infallible, Signer, SigningKey, VerifyingKey};
 
 use async_trait::async_trait;
 use starknet_core::{
@@ -24,11 +24,11 @@ impl LocalWallet {
 
 #[async_trait]
 impl Signer for LocalWallet {
-    type GetAddressError = Infallible;
+    type GetPublicKeyError = Infallible;
     type SignError = SignError;
 
-    async fn get_address(&self) -> Result<UnsignedFieldElement, Self::GetAddressError> {
-        Ok(self.private_key.verifying_key().scalar())
+    async fn get_public_key(&self) -> Result<VerifyingKey, Self::GetPublicKeyError> {
+        Ok(self.private_key.verifying_key())
     }
 
     async fn sign_hash(&self, hash: &UnsignedFieldElement) -> Result<Signature, Self::SignError> {

--- a/starknet-signers/src/signer.rs
+++ b/starknet-signers/src/signer.rs
@@ -1,13 +1,15 @@
+use crate::VerifyingKey;
+
 use async_trait::async_trait;
 use starknet_core::{crypto::Signature, types::UnsignedFieldElement};
 use std::error::Error;
 
 #[async_trait]
 pub trait Signer {
-    type GetAddressError: Error;
+    type GetPublicKeyError: Error;
     type SignError: Error;
 
-    async fn get_address(&self) -> Result<UnsignedFieldElement, Self::GetAddressError>;
+    async fn get_public_key(&self) -> Result<VerifyingKey, Self::GetPublicKeyError>;
 
     async fn sign_hash(&self, hash: &UnsignedFieldElement) -> Result<Signature, Self::SignError>;
 }

--- a/starknet-signers/src/signer.rs
+++ b/starknet-signers/src/signer.rs
@@ -1,0 +1,13 @@
+use async_trait::async_trait;
+use starknet_core::{crypto::Signature, types::UnsignedFieldElement};
+use std::error::Error;
+
+#[async_trait]
+pub trait Signer {
+    type GetAddressError: Error;
+    type SignError: Error;
+
+    async fn get_address(&self) -> Result<UnsignedFieldElement, Self::GetAddressError>;
+
+    async fn sign_hash(&self, hash: &UnsignedFieldElement) -> Result<Signature, Self::SignError>;
+}


### PR DESCRIPTION
Resolves task 1 of #50:

> add `Signer` trait as abstraction over `SigningKey` and other future implementations

This PR:

- adds a new `Signer` trait;
- adds a new type `LocalWallet` which wraps `SigningKey` and implements `Signer`.

In `ethers-rs`, the `address` method is synchronous, forcing all implementations that are asynchronous in nature to pre-fetch the address in their constructor, even if the user doesn't want to know the address. I took a different approach and made it `async` and free implementations from eagerly loading the address.