### PR TITLE
fix: fix deserializer used for contract call result

### DIFF
--- a/starknet-core/src/types/call_contract.rs
+++ b/starknet-core/src/types/call_contract.rs
@@ -1,4 +1,7 @@
-use super::{super::serde::unsigned_field_element::hex, UnsignedFieldElement};
+use super::{
+    super::serde::unsigned_field_element::{hex, hex_slice},
+    UnsignedFieldElement,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -14,5 +17,6 @@ pub struct InvokeFunction {
 
 #[derive(Debug, Deserialize)]
 pub struct CallContractResult {
+    #[serde(with = "hex_slice")]
     pub result: Vec<UnsignedFieldElement>,
 }


### PR DESCRIPTION
The `result` field in `CallContractResult` uses hex representation. This bug wasn't discovered during the `UnsignedFieldElement` refactor because there's no test case covering this functionality.