### PR TITLE
feat: explicit BlockId::Latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ This workspace contains the following crates:
 ### Get the latest block from `alpha-goerli` testnet
 
 ```rust
-use starknet::{core::types::BlockId, providers::{Provider, SequencerGatewayProvider}};
+use starknet::{
+    core::types::BlockId,
+    providers::{Provider, SequencerGatewayProvider},
+};
 
 #[tokio::main]
 async fn main() {
@@ -96,7 +99,10 @@ async fn main() {
 ```rust
 use starknet::{
     accounts::{Account, SingleOwnerAccount},
-    core::{types::{BlockId, UnsignedFieldElement}, utils::get_selector_from_name}},
+    core::{
+        types::{BlockId, UnsignedFieldElement},
+        utils::get_selector_from_name,
+    },
     providers::SequencerGatewayProvider,
     signers::{LocalWallet, SigningKey},
 };

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ use starknet::providers::{Provider, SequencerGatewayProvider};
 #[tokio::main]
 async fn main() {
     let provider = SequencerGatewayProvider::starknet_alpha_goerli();
-    let latest_block = provider.get_block(None).await;
+    let latest_block = provider.get_block(BlockId::Latest).await;
     println!("{:#?}", latest_block);
 }
 ```
@@ -116,7 +116,7 @@ async fn main() {
     .unwrap();
 
     let account = SingleOwnerAccount::new(provider, signer, address);
-    let nonce = account.get_nonce(None).await.unwrap();
+    let nonce = account.get_nonce(BlockId::Latest).await.unwrap();
 
     let result = account
         .execute(
@@ -140,7 +140,7 @@ async fn main() {
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](./LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](./LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](./LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](./LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This workspace contains the following crates:
 ### Get the latest block from `alpha-goerli` testnet
 
 ```rust
-use starknet::providers::{Provider, SequencerGatewayProvider};
+use starknet::{core::types::BlockId, providers::{Provider, SequencerGatewayProvider}};
 
 #[tokio::main]
 async fn main() {
@@ -96,7 +96,7 @@ async fn main() {
 ```rust
 use starknet::{
     accounts::{Account, SingleOwnerAccount},
-    core::{types::UnsignedFieldElement, utils::get_selector_from_name},
+    core::{types::{BlockId, UnsignedFieldElement}, utils::get_selector_from_name}},
     providers::SequencerGatewayProvider,
     signers::{LocalWallet, SigningKey},
 };

--- a/starknet-accounts/src/account.rs
+++ b/starknet-accounts/src/account.rs
@@ -9,7 +9,7 @@ pub trait Account {
 
     async fn get_nonce(
         &self,
-        block_identifier: Option<BlockId>,
+        block_identifier: BlockId,
     ) -> Result<UnsignedFieldElement, Self::GetNonceError>;
 
     async fn execute(

--- a/starknet-accounts/src/single_owner.rs
+++ b/starknet-accounts/src/single_owner.rs
@@ -71,7 +71,7 @@ where
 
     async fn get_nonce(
         &self,
-        block_identifier: Option<BlockId>,
+        block_identifier: BlockId,
     ) -> Result<UnsignedFieldElement, Self::GetNonceError> {
         let call_result = self
             .provider

--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -24,7 +24,7 @@ async fn can_get_nonce() {
     let account = SingleOwnerAccount::new(provider, signer, address);
 
     assert_ne!(
-        account.get_nonce(None).await.unwrap(),
+        account.get_nonce(BlockId::Latest).await.unwrap(),
         UnsignedFieldElement::ZERO
     );
 }
@@ -55,7 +55,7 @@ async fn can_execute_tst_mint() {
     .unwrap();
 
     let account = SingleOwnerAccount::new(provider, signer, address);
-    let nonce = account.get_nonce(Some(BlockId::Pending)).await.unwrap();
+    let nonce = account.get_nonce(BlockId::Pending).await.unwrap();
 
     let result = account
         .execute(

--- a/starknet-core/src/types/block.rs
+++ b/starknet-core/src/types/block.rs
@@ -9,6 +9,7 @@ pub enum BlockId {
     Hash(UnsignedFieldElement),
     Number(u64),
     Pending,
+    Latest,
 }
 
 #[derive(Debug, Deserialize)]

--- a/starknet-providers/src/provider.rs
+++ b/starknet-providers/src/provider.rs
@@ -21,22 +21,22 @@ pub trait Provider {
     async fn call_contract(
         &self,
         invoke_tx: InvokeFunction,
-        block_identifier: Option<BlockId>,
+        block_identifier: BlockId,
     ) -> Result<CallContractResult, Self::Error>;
 
-    async fn get_block(&self, block_identifier: Option<BlockId>) -> Result<Block, Self::Error>;
+    async fn get_block(&self, block_identifier: BlockId) -> Result<Block, Self::Error>;
 
     async fn get_code(
         &self,
         contract_address: UnsignedFieldElement,
-        block_identifier: Option<BlockId>,
+        block_identifier: BlockId,
     ) -> Result<ContractCode, Self::Error>;
 
     async fn get_storage_at(
         &self,
         contract_address: UnsignedFieldElement,
         key: UnsignedFieldElement,
-        block_identifier: Option<BlockId>,
+        block_identifier: BlockId,
     ) -> Result<UnsignedFieldElement, Self::Error>;
 
     async fn get_transaction_status(

--- a/starknet-providers/src/sequencer_gateway.rs
+++ b/starknet-providers/src/sequencer_gateway.rs
@@ -173,7 +173,7 @@ impl Provider for SequencerGatewayProvider {
     async fn call_contract(
         &self,
         invoke_tx: InvokeFunction,
-        block_identifier: Option<BlockId>,
+        block_identifier: BlockId,
     ) -> Result<CallContractResult, Self::Error> {
         let mut request_url = self.extend_feeder_gateway_url("call_contract");
         append_block_id(&mut request_url, block_identifier);
@@ -186,7 +186,7 @@ impl Provider for SequencerGatewayProvider {
         }
     }
 
-    async fn get_block(&self, block_identifier: Option<BlockId>) -> Result<Block, Self::Error> {
+    async fn get_block(&self, block_identifier: BlockId) -> Result<Block, Self::Error> {
         let mut request_url = self.extend_feeder_gateway_url("get_block");
         append_block_id(&mut request_url, block_identifier);
 
@@ -204,7 +204,7 @@ impl Provider for SequencerGatewayProvider {
     async fn get_code(
         &self,
         contract_address: UnsignedFieldElement,
-        block_identifier: Option<BlockId>,
+        block_identifier: BlockId,
     ) -> Result<ContractCode, Self::Error> {
         let mut request_url = self.extend_feeder_gateway_url("get_code");
         request_url
@@ -231,7 +231,7 @@ impl Provider for SequencerGatewayProvider {
         &self,
         contract_address: UnsignedFieldElement,
         key: UnsignedFieldElement,
-        block_identifier: Option<BlockId>,
+        block_identifier: BlockId,
     ) -> Result<UnsignedFieldElement, Self::Error> {
         let mut request_url = self.extend_feeder_gateway_url("get_storage_at");
         request_url
@@ -406,20 +406,20 @@ fn extend_url(url: &mut Url, segment: &str) {
         .extend(&[segment]);
 }
 
-fn append_block_id(url: &mut Url, block_identifier: Option<BlockId>) {
+fn append_block_id(url: &mut Url, block_identifier: BlockId) {
     match block_identifier {
-        Some(BlockId::Hash(block_hash)) => {
+        BlockId::Hash(block_hash) => {
             url.query_pairs_mut()
                 .append_pair("blockHash", &format!("{:#x}", block_hash));
         }
-        Some(BlockId::Number(block_number)) => {
+        BlockId::Number(block_number) => {
             url.query_pairs_mut()
                 .append_pair("blockNumber", &block_number.to_string());
         }
-        Some(BlockId::Pending) => {
+        BlockId::Pending => {
             url.query_pairs_mut().append_pair("blockNumber", "pending");
         }
-        None => (),
+        BlockId::Latest => (), // latest block is implicit
     };
 }
 


### PR DESCRIPTION
This PR replaces the use of `Option<BlockId>` with an explicit `BlockId::Latest` variant, as discussed in point 4) in #53.