### PR TITLE
ci: skip alpha-goerli integration tests

### DIFF
--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -8,6 +8,7 @@ use starknet_signers::{LocalWallet, SigningKey};
 use std::str::FromStr;
 
 #[tokio::test]
+#[ignore = "temporarily skipping test until Starkware improves network stability"]
 async fn can_get_nonce() {
     let provider = SequencerGatewayProvider::starknet_alpha_goerli();
     let signer = LocalWallet::from(SigningKey::from_secret_scalar(
@@ -30,6 +31,7 @@ async fn can_get_nonce() {
 }
 
 #[tokio::test]
+#[ignore = "temporarily skipping test until Starkware improves network stability"]
 async fn can_execute_tst_mint() {
     // This test case is not very useful as the sequencer will always respond with
     // `TransactionReceived` even if the transaction will eventually fail, just like how

--- a/starknet-contract/tests/contract_deployment.rs
+++ b/starknet-contract/tests/contract_deployment.rs
@@ -3,6 +3,7 @@ use starknet_core::types::UnsignedFieldElement;
 use std::str::FromStr;
 
 #[tokio::test]
+#[ignore = "temporarily skipping test until Starkware improves network stability"]
 async fn can_deploy_contract_to_alpha_goerli() {
     let artifact = serde_json::from_str::<ContractArtifact>(include_str!(
         "../test-data/artifacts/oz_account.txt"


### PR DESCRIPTION
This PR skips 3 tests that hit the alpha testnet. Based on Henri's request in the Telegram group, I figured it's better to skip them completely rather then just ignore failures in the CI process. 