### PR TITLE
feat: replace `ff` with `ark-ff`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,70 @@
 version = 3
 
 [[package]]
-name = "addchain"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2e69442aa5628ea6951fa33e24efe8313f4321a91bd729fc2f75bdfc858570"
-dependencies = [
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand",
+]
 
 [[package]]
 name = "arrayvec"
@@ -137,7 +186,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -337,6 +386,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,31 +456,6 @@ dependencies = [
  "impl-serde",
  "primitive-types",
  "uint",
-]
-
-[[package]]
-name = "ff"
-version = "0.11.0"
-source = "git+https://github.com/eqlabs/ff?branch=derive_bitvec#87caad7d36cfb50bd2caba1c1d41abc1463f191f"
-dependencies = [
- "byteorder",
- "ff_derive",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "ff_derive"
-version = "0.11.0"
-source = "git+https://github.com/eqlabs/ff?branch=derive_bitvec#87caad7d36cfb50bd2caba1c1d41abc1463f191f"
-dependencies = [
- "addchain",
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -905,17 +940,6 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
@@ -1057,10 +1081,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1329,11 +1368,20 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.4",
 ]
 
 [[package]]
@@ -1392,9 +1440,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -1558,14 +1624,14 @@ dependencies = [
 name = "starknet-crypto"
 version = "0.1.0"
 dependencies = [
+ "ark-ff",
  "bitvec",
  "criterion",
  "crypto-bigint",
- "ff",
  "hex",
  "hex-literal",
  "hmac",
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "rfc6979",
@@ -1619,6 +1685,18 @@ checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
 dependencies = [
  "proc-macro2",
  "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
  "unicode-xid",
 ]
 
@@ -1805,6 +1883,12 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uint"
@@ -2023,3 +2107,18 @@ name = "zeroize"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc222aec311c323c717f56060324f32b82da1ce1dd81d9a09aa6a9030bfe08db"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e8f13fef10b63c06356d65d416b070798ddabcadc10d3ece0c5be9b3c7eddb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]

--- a/starknet-core/src/types/field_element/unsigned.rs
+++ b/starknet-core/src/types/field_element/unsigned.rs
@@ -272,7 +272,7 @@ impl From<UnsignedFieldElement> for FieldElement {
         value.inner.to_big_endian(&mut buffer);
 
         // This can never fail as `inner` is always smaller than field modulus
-        Self::from_bytes_be(buffer).unwrap()
+        Self::from_bytes_be(&buffer).unwrap()
     }
 }
 

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -13,14 +13,10 @@ Low-level cryptography utilities for StarkNet
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
+ark-ff = "0.3.0"
 # Parity's scale codec locks us here
 bitvec = "0.20.4"
 crypto-bigint = "0.3.2"
-# Use eqlabs's fork of ff to work around the bitvec-funty clash:
-# https://github.com/eqlabs/pathfinder/blob/8f9155a8fba60fd4f0b51d57209889a622fad6a9/crates/pedersen/Cargo.toml#L19
-ff = { git = "https://github.com/eqlabs/ff", branch = "derive_bitvec", default-features = false, features = [
-    "derive",
-]}
 hmac = "0.11.0"
 num-bigint = "0.4.3"
 num-integer = "0.1.44"

--- a/starknet-crypto/benches/ecdsa_get_public_key.rs
+++ b/starknet-crypto/benches/ecdsa_get_public_key.rs
@@ -1,12 +1,11 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use ff::PrimeField;
 use hex_literal::hex;
-use starknet_crypto::{get_public_key, FieldElement, FieldElementRepr};
+use starknet_crypto::{get_public_key, FieldElement};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let private_key = hex!("04a724706e80e5ea88b9ee60a7ede83cbc2de27da0659bef2929381a298b672d");
 
-    let private_key = FieldElement::from_repr(FieldElementRepr(private_key)).unwrap();
+    let private_key = FieldElement::from_bytes_be(&private_key).unwrap();
 
     c.bench_function("ecdsa_get_public_key", |b| {
         b.iter(|| {

--- a/starknet-crypto/benches/ecdsa_sign.rs
+++ b/starknet-crypto/benches/ecdsa_sign.rs
@@ -1,16 +1,15 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use ff::PrimeField;
 use hex_literal::hex;
-use starknet_crypto::{sign, FieldElement, FieldElementRepr};
+use starknet_crypto::{sign, FieldElement};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let private_key = hex!("04a724706e80e5ea88b9ee60a7ede83cbc2de27da0659bef2929381a298b672d");
     let message = hex!("010aaf60f545a5b9a55463fbb56f35dfdfe8010ff1d95283afe1b14e07cb8f61");
     let k = hex!("075414c392c57a61417fc1702ad6fa83d12541690963915646617b59451972b3");
 
-    let private_key = FieldElement::from_repr(FieldElementRepr(private_key)).unwrap();
-    let message = FieldElement::from_repr(FieldElementRepr(message)).unwrap();
-    let k = FieldElement::from_repr(FieldElementRepr(k)).unwrap();
+    let private_key = FieldElement::from_bytes_be(&private_key).unwrap();
+    let message = FieldElement::from_bytes_be(&message).unwrap();
+    let k = FieldElement::from_bytes_be(&k).unwrap();
 
     c.bench_function("ecdsa_sign", |b| {
         b.iter(|| {

--- a/starknet-crypto/benches/ecdsa_verify.rs
+++ b/starknet-crypto/benches/ecdsa_verify.rs
@@ -1,7 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use ff::PrimeField;
 use hex_literal::hex;
-use starknet_crypto::{verify, FieldElement, FieldElementRepr};
+use starknet_crypto::{verify, FieldElement};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let stark_key = hex!("0565ee8f4203a04fbd5de77c678bc3738538f35c0871e377cdc45fcfa79e6bd9");
@@ -9,10 +8,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let r_bytes = hex!("03879bf25e6919880960131bb3b614c40d942791f83dac999d28028824c2d712");
     let s_bytes = hex!("01f2a4527241c802e0885cf3aeac5bdfdbb559c09a45e1b745addae358f6c03b");
 
-    let stark_key = FieldElement::from_repr(FieldElementRepr(stark_key)).unwrap();
-    let msg_hash = FieldElement::from_repr(FieldElementRepr(msg_hash)).unwrap();
-    let r_bytes = FieldElement::from_repr(FieldElementRepr(r_bytes)).unwrap();
-    let s_bytes = FieldElement::from_repr(FieldElementRepr(s_bytes)).unwrap();
+    let stark_key = FieldElement::from_bytes_be(&stark_key).unwrap();
+    let msg_hash = FieldElement::from_bytes_be(&msg_hash).unwrap();
+    let r_bytes = FieldElement::from_bytes_be(&r_bytes).unwrap();
+    let s_bytes = FieldElement::from_bytes_be(&s_bytes).unwrap();
 
     c.bench_function("ecdsa_verify", |b| {
         b.iter(|| {

--- a/starknet-crypto/benches/pedersen_hash.rs
+++ b/starknet-crypto/benches/pedersen_hash.rs
@@ -1,7 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use ff::PrimeField;
 use hex_literal::hex;
-use starknet_crypto::{pedersen_hash, FieldElement, FieldElementRepr};
+use starknet_crypto::{pedersen_hash, FieldElement};
 
 // Benchmark taken from pathfinder for performance comparison:
 // https://github.com/eqlabs/pathfinder/blob/b091cb889e624897dbb0cbec3c1df9a9e411eb1e/crates/pedersen/benches/pedersen.rs
@@ -10,8 +9,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let e0 = hex!("03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb");
     let e1 = hex!("0208a0a10250e382e1e4bbe2880906c2791bf6275695e02fbbc6aeff9cd8b31a");
 
-    let e0 = FieldElement::from_repr(FieldElementRepr(e0)).unwrap();
-    let e1 = FieldElement::from_repr(FieldElementRepr(e1)).unwrap();
+    let e0 = FieldElement::from_bytes_be(&e0).unwrap();
+    let e1 = FieldElement::from_bytes_be(&e1).unwrap();
 
     c.bench_function("pedersen_hash", |b| {
         b.iter(|| {

--- a/starknet-crypto/benches/rfc6979_generate_k.rs
+++ b/starknet-crypto/benches/rfc6979_generate_k.rs
@@ -1,16 +1,15 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use ff::PrimeField;
 use hex_literal::hex;
-use starknet_crypto::{rfc6979_generate_k, FieldElement, FieldElementRepr};
+use starknet_crypto::{rfc6979_generate_k, FieldElement};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let message_hash = hex!("010b559a3b4dc1b7137d90521cb413b397ff07963214d128a92d65aec7182f68");
     let private_key = hex!("07e3184f4bef18f371bc53fc412dff1b30dbc94f758490fb8e2349bae647a642");
     let seed = hex!("03fe27199aaad4e700559e2436a919f4de70def585a6deb2f4c087fdf6a27c1b");
 
-    let message_hash = FieldElement::from_repr(FieldElementRepr(message_hash)).unwrap();
-    let private_key = FieldElement::from_repr(FieldElementRepr(private_key)).unwrap();
-    let seed = FieldElement::from_repr(FieldElementRepr(seed)).unwrap();
+    let message_hash = FieldElement::from_bytes_be(&message_hash).unwrap();
+    let private_key = FieldElement::from_bytes_be(&private_key).unwrap();
+    let seed = FieldElement::from_bytes_be(&seed).unwrap();
 
     c.bench_function("rfc6979_generate_k", |b| {
         b.iter(|| {

--- a/starknet-crypto/src/ec_point.rs
+++ b/starknet-crypto/src/ec_point.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 
 use bitvec::{order::Lsb0, slice::BitSlice};
-use ff::Field;
 
 /// A point on an elliptic curve over [FieldElement].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -26,8 +25,8 @@ impl EcPoint {
 
     fn identity() -> EcPoint {
         Self {
-            x: FieldElement::zero(),
-            y: FieldElement::zero(),
+            x: FieldElement::ZERO,
+            y: FieldElement::ZERO,
             infinity: true,
         }
     }
@@ -39,9 +38,9 @@ impl EcPoint {
 
         // l = (3x^2+a)/2y with a=1 from stark curve
         let lambda = {
-            let two = FieldElement::one() + FieldElement::one();
-            let three = two + FieldElement::one();
-            let dividend = three * (self.x * self.x) + FieldElement::one();
+            let two = FieldElement::ONE + FieldElement::ONE;
+            let three = two + FieldElement::ONE;
+            let dividend = three * (self.x * self.x) + FieldElement::ONE;
             let divisor_inv = (two * self.y).invert().unwrap();
             dividend * divisor_inv
         };

--- a/starknet-crypto/src/ecdsa.rs
+++ b/starknet-crypto/src/ecdsa.rs
@@ -25,7 +25,7 @@ pub struct Signature {
 ///
 /// * `private_key`: The private key
 pub fn get_public_key(private_key: &FieldElement) -> FieldElement {
-    (&CONSTANT_POINTS[1]).multiply(&private_key.into_bits()).x
+    (&CONSTANT_POINTS[1]).multiply(&private_key.to_bits_le()).x
 }
 
 /// Computes ECDSA signature given a Stark private key and message hash.
@@ -49,7 +49,7 @@ pub fn sign(
 
     let generator = &CONSTANT_POINTS[1];
 
-    let r = generator.multiply(&k.into_bits()).x;
+    let r = generator.multiply(&k.to_bits_le()).x;
     if r == FieldElement::ZERO || r >= ELEMENT_UPPER_BOUND {
         return Err(SignError::InvalidK);
     }
@@ -100,10 +100,10 @@ pub fn verify(
     }
 
     let zw = message.mul_mod_floor(&w, &EC_ORDER);
-    let zw_g = generator.multiply(&zw.into_bits());
+    let zw_g = generator.multiply(&zw.to_bits_le());
 
     let rw = r.mul_mod_floor(&w, &EC_ORDER);
-    let rw_q = full_public_key.multiply(&rw.into_bits());
+    let rw_q = full_public_key.multiply(&rw.to_bits_le());
 
     Ok(zw_g.add(&rw_q).x == *r || zw_g.subtract(&rw_q).x == *r)
 }

--- a/starknet-crypto/src/field_element.rs
+++ b/starknet-crypto/src/field_element.rs
@@ -82,8 +82,8 @@ impl FieldElement {
 impl FieldElement {
     // Hard-coded to use big-endian because `FieldElement` uses it
     pub(crate) fn add_unbounded(&self, addend: &FieldElement) -> BigInt {
-        let augend = BigInt::from_bytes_be(num_bigint::Sign::Plus, &self.to_repr().0);
-        let addend = BigInt::from_bytes_be(num_bigint::Sign::Plus, &addend.to_repr().0);
+        let augend = BigInt::from_bytes_be(num_bigint::Sign::Plus, &self.to_bytes_be());
+        let addend = BigInt::from_bytes_be(num_bigint::Sign::Plus, &addend.to_bytes_be());
         augend.add(addend)
     }
 
@@ -93,7 +93,7 @@ impl FieldElement {
         multiplier: &FieldElement,
         modulus: &FieldElement,
     ) -> FieldElement {
-        let multiplicand = BigInt::from_bytes_be(num_bigint::Sign::Plus, &self.to_repr().0);
+        let multiplicand = BigInt::from_bytes_be(num_bigint::Sign::Plus, &self.to_bytes_be());
         Self::bigint_mul_mod_floor(multiplicand, multiplier, modulus)
     }
 
@@ -102,8 +102,8 @@ impl FieldElement {
         multiplier: &FieldElement,
         modulus: &FieldElement,
     ) -> FieldElement {
-        let multiplier = BigInt::from_bytes_be(num_bigint::Sign::Plus, &multiplier.to_repr().0);
-        let modulus = BigInt::from_bytes_be(num_bigint::Sign::Plus, &modulus.to_repr().0);
+        let multiplier = BigInt::from_bytes_be(num_bigint::Sign::Plus, &multiplier.to_bytes_be());
+        let modulus = BigInt::from_bytes_be(num_bigint::Sign::Plus, &modulus.to_bytes_be());
 
         let result = multiplicand.mul(multiplier).mod_floor(&modulus);
 
@@ -116,8 +116,8 @@ impl FieldElement {
 
     // Hard-coded to use big-endian because `FieldElement` uses it
     pub(crate) fn mod_inverse(&self, modulus: &FieldElement) -> FieldElement {
-        let operand = BigInt::from_bytes_be(num_bigint::Sign::Plus, &self.to_repr().0);
-        let modulus = BigInt::from_bytes_be(num_bigint::Sign::Plus, &modulus.to_repr().0);
+        let operand = BigInt::from_bytes_be(num_bigint::Sign::Plus, &self.to_bytes_be());
+        let modulus = BigInt::from_bytes_be(num_bigint::Sign::Plus, &modulus.to_bytes_be());
 
         // Ported from:
         //   https://github.com/dignifiedquire/num-bigint/blob/56576b592fea6341b7e1711a1629e4cc1bfc419c/src/algorithms/mod_inverse.rs#L11

--- a/starknet-crypto/src/field_element/fr.rs
+++ b/starknet-crypto/src/field_element/fr.rs
@@ -1,0 +1,62 @@
+use ark_ff::{
+    biginteger::BigInteger256,
+    fields::{FftParameters, Fp256Parameters, FpParameters},
+};
+
+pub struct FrParameters;
+
+impl Fp256Parameters for FrParameters {}
+
+impl FftParameters for FrParameters {
+    type BigInt = BigInteger256;
+
+    const TWO_ADICITY: u32 = 192;
+
+    const TWO_ADIC_ROOT_OF_UNITY: BigInteger256 = BigInteger256::new([
+        0x4106bccd64a2bdd8,
+        0xaaada25731fe3be9,
+        0xa35c5be60505574,
+        0x7222e32c47afc26,
+    ]);
+}
+
+impl FpParameters for FrParameters {
+    const MODULUS: BigInteger256 = BigInteger256::new([0x1, 0x0, 0x0, 0x800000000000011]);
+
+    const MODULUS_BITS: u32 = 252;
+
+    const CAPACITY: u32 = Self::MODULUS_BITS - 1;
+
+    const REPR_SHAVE_BITS: u32 = 4;
+
+    const R: BigInteger256 = BigInteger256::new([
+        0xffffffffffffffe1,
+        0xffffffffffffffff,
+        0xffffffffffffffff,
+        0x7fffffffffffdf0,
+    ]);
+
+    const R2: BigInteger256 = BigInteger256::new([
+        0xfffffd737e000401,
+        0x1330fffff,
+        0xffffffffff6f8000,
+        0x7ffd4ab5e008810,
+    ]);
+
+    const INV: u64 = 0xffffffffffffffff;
+
+    const GENERATOR: BigInteger256 = BigInteger256::new([
+        0xffffffffffffffa1,
+        0xffffffffffffffff,
+        0xffffffffffffffff,
+        0x7fffffffffff9b0,
+    ]);
+
+    const MODULUS_MINUS_ONE_DIV_TWO: BigInteger256 =
+        BigInteger256::new([0x0, 0x0, 0x8000000000000000, 0x400000000000008]);
+
+    const T: BigInteger256 = BigInteger256::new([0x800000000000011, 0x0, 0x0, 0x0]);
+
+    const T_MINUS_ONE_DIV_TWO: BigInteger256 =
+        BigInteger256::new([0x400000000000008, 0x0, 0x0, 0x0]);
+}

--- a/starknet-crypto/src/field_element/mod.rs
+++ b/starknet-crypto/src/field_element/mod.rs
@@ -1,22 +1,23 @@
 #![allow(clippy::too_many_arguments)]
 
+use crate::field_element::fr::FrParameters;
+use ark_ff::{fields::Fp256, BigInteger, BigInteger256, Field, PrimeField, SquareRootField};
 use bitvec::{array::BitArray, order::Lsb0};
-use ff::PrimeField;
 use num_bigint::BigInt;
 use num_integer::Integer;
 use num_traits::{One, Zero};
 use std::ops::{Add, Mul};
 
-/// Field element for the Stark curve with big-endian encoding.
-#[derive(PrimeField)]
-#[PrimeFieldModulus = "3618502788666131213697322783095070105623107215331596699973092056135872020481"]
-#[PrimeFieldGenerator = "3"]
-#[PrimeFieldReprEndianness = "big"]
-pub struct FieldElement([u64; 4]);
+mod fr;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
+pub struct FieldElement {
+    inner: Fp256<FrParameters>,
+}
 
 impl FieldElement {
-    pub const ZERO: FieldElement = FieldElement([0, 0, 0, 0]);
-    pub const ONE: FieldElement = FieldElement([
+    pub const ZERO: FieldElement = FieldElement::new([0, 0, 0, 0]);
+    pub const ONE: FieldElement = FieldElement::new([
         18446744073709551585,
         18446744073709551615,
         18446744073709551615,
@@ -30,48 +31,84 @@ impl FieldElement {
     /// ### Arguments
     ///
     /// * `bytes`: The byte array in **big endian** format
-    pub fn from_bytes_be(bytes: [u8; 32]) -> Option<Self> {
-        let result = FieldElement::from_repr(FieldElementRepr(bytes));
-        if result.is_some().into() {
-            Some(result.unwrap())
-        } else {
-            None
+    pub fn from_bytes_be(bytes: &[u8; 32]) -> Option<Self> {
+        let mut bits = [false; 32 * 8];
+        for (ind_byte, byte) in bytes.iter().enumerate() {
+            for ind_bit in 0..8 {
+                bits[ind_byte * 8 + ind_bit] = (byte >> (7 - ind_bit)) & 1 == 1;
+            }
         }
+
+        // No need to check range as `from_repr` already does that
+        let big_int = BigInteger256::from_bits_be(&bits);
+        Fp256::<FrParameters>::from_repr(big_int).map(|inner| Self { inner })
     }
 
     /// Convert the field element into a big-endian byte representation
     pub fn to_bytes_be(&self) -> [u8; 32] {
-        self.to_repr().0
+        let mut buffer = [0u8; 32];
+        buffer.copy_from_slice(&self.inner.into_repr().to_bytes_be());
+
+        buffer
+    }
+
+    pub fn invert(&self) -> Option<FieldElement> {
+        self.inner.inverse().map(|inner| Self { inner })
+    }
+
+    pub fn sqrt(&self) -> Option<FieldElement> {
+        self.inner.sqrt().map(|inner| Self { inner })
+    }
+}
+
+impl std::ops::Add<FieldElement> for FieldElement {
+    type Output = FieldElement;
+
+    fn add(self, rhs: FieldElement) -> Self::Output {
+        FieldElement {
+            inner: self.inner + rhs.inner,
+        }
+    }
+}
+
+impl std::ops::Sub<FieldElement> for FieldElement {
+    type Output = FieldElement;
+
+    fn sub(self, rhs: FieldElement) -> Self::Output {
+        FieldElement {
+            inner: self.inner - rhs.inner,
+        }
+    }
+}
+
+impl std::ops::Mul<FieldElement> for FieldElement {
+    type Output = FieldElement;
+
+    fn mul(self, rhs: FieldElement) -> Self::Output {
+        FieldElement {
+            inner: self.inner * rhs.inner,
+        }
+    }
+}
+
+impl std::ops::Neg for FieldElement {
+    type Output = FieldElement;
+
+    fn neg(self) -> Self::Output {
+        FieldElement { inner: -self.inner }
     }
 }
 
 impl FieldElement {
     pub(crate) const fn new(data: [u64; 4]) -> Self {
-        Self(data)
+        Self {
+            inner: Fp256::new(BigInteger256::new(data)),
+        }
     }
 
     /// Transforms [FieldElement] into little endian bit representation.
-    pub(crate) fn into_bits(mut self) -> BitArray<Lsb0, [u64; 4]> {
-        #[cfg(not(target_endian = "little"))]
-        {
-            todo!("untested and probably unimplemented: big-endian targets")
-        }
-
-        #[cfg(target_endian = "little")]
-        {
-            self.mont_reduce(
-                self.0[0usize],
-                self.0[1usize],
-                self.0[2usize],
-                self.0[3usize],
-                0,
-                0,
-                0,
-                0,
-            );
-
-            self.0.into()
-        }
+    pub(crate) fn to_bits_le(self) -> BitArray<Lsb0, [u64; 4]> {
+        BitArray::<Lsb0, [u64; 4]>::new(self.inner.into_repr().0)
     }
 }
 
@@ -111,7 +148,7 @@ impl FieldElement {
         let mut result = [0u8; 32];
         result[(32 - buffer.len())..].copy_from_slice(&buffer[..]);
 
-        FieldElement::from_repr(FieldElementRepr(result)).unwrap()
+        FieldElement::from_bytes_be(&result).unwrap()
     }
 
     // Hard-coded to use big-endian because `FieldElement` uses it
@@ -135,6 +172,6 @@ impl FieldElement {
         let mut result = [0u8; 32];
         result[(32 - buffer.len())..].copy_from_slice(&buffer[..]);
 
-        FieldElement::from_repr(FieldElementRepr(result)).unwrap()
+        FieldElement::from_bytes_be(&result).unwrap()
     }
 }

--- a/starknet-crypto/src/lib.rs
+++ b/starknet-crypto/src/lib.rs
@@ -11,7 +11,7 @@ mod rfc6979;
 #[cfg(test)]
 mod test_utils;
 
-pub use field_element::{FieldElement, FieldElementRepr};
+pub use field_element::FieldElement;
 
 pub use pedersen_hash::pedersen_hash;
 

--- a/starknet-crypto/src/pedersen_hash.rs
+++ b/starknet-crypto/src/pedersen_hash.rs
@@ -14,8 +14,8 @@ const PEDERSEN_P3: EcPoint = CONSTANT_POINTS[502];
 /// * `y`: The y coordinate
 pub fn pedersen_hash(x: &FieldElement, y: &FieldElement) -> FieldElement {
     let mut result = SHIFT_POINT;
-    let x = x.into_bits();
-    let y = y.into_bits();
+    let x = x.to_bits_le();
+    let y = y.to_bits_le();
 
     // Add a_low * P1
     let tmp = PEDERSEN_P0.multiply(&x[..248]);

--- a/starknet-crypto/src/rfc6979.rs
+++ b/starknet-crypto/src/rfc6979.rs
@@ -48,7 +48,7 @@ pub fn generate_k(
     let mut buffer = [0u8; 32];
     buffer[..].copy_from_slice(&k.to_be_byte_array()[..]);
 
-    FieldElement::from_bytes_be(buffer).unwrap()
+    FieldElement::from_bytes_be(&buffer).unwrap()
 }
 
 // Modified from upstream `rfc6979::generate_k` with a hard-coded right bit shift. The more

--- a/starknet-crypto/src/rfc6979.rs
+++ b/starknet-crypto/src/rfc6979.rs
@@ -1,7 +1,6 @@
 use crate::FieldElement;
 
 use crypto_bigint::{ArrayEncoding, ByteArray, Integer, U256};
-use ff::PrimeField;
 use hmac::digest::{BlockInput, FixedOutput, Reset, Update};
 use zeroize::{Zeroize, Zeroizing};
 
@@ -23,11 +22,11 @@ pub fn generate_k(
     // The message hash padding as implemented in `cairo-lang` is not needed here. The hash is
     // padded in `cairo-lang` only to make sure the lowest 4 bits won't get truncated, but here it's
     // never getting truncated anyways.
-    let message_hash = U256::from_be_slice(&message_hash.to_repr().0).to_be_byte_array();
-    let private_key = U256::from_be_slice(&private_key.to_repr().0);
+    let message_hash = U256::from_be_slice(&message_hash.to_bytes_be()).to_be_byte_array();
+    let private_key = U256::from_be_slice(&private_key.to_bytes_be());
 
     let seed_bytes = match seed {
-        Some(seed) => seed.to_repr().0,
+        Some(seed) => seed.to_bytes_be(),
         None => [0u8; 32],
     };
 

--- a/starknet-crypto/src/test_utils.rs
+++ b/starknet-crypto/src/test_utils.rs
@@ -12,5 +12,5 @@ pub fn field_element_from_be_hex(hex: &str) -> FieldElement {
     let mut buffer = [0u8; 32];
     buffer[(32 - decoded.len())..].copy_from_slice(&decoded[..]);
 
-    FieldElement::from_bytes_be(buffer).unwrap()
+    FieldElement::from_bytes_be(&buffer).unwrap()
 }


### PR DESCRIPTION
Resolves task 1 of #61:

> replace `ff` with `ark-ff` in `starknet-crypto` to make sure crypto primitives are properly upheld