### PR TITLE
refactor: adopt `serde_with`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +746,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1385,6 +1426,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,6 +1563,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1e6ec4d8950e5b1e894eac0d360742f3b1407a6078a604a731c4b3f49cefbc"
+dependencies = [
+ "rustversion",
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,6 +1670,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "serde_with",
  "starknet-core",
  "starknet-providers",
  "thiserror",
@@ -1615,6 +1686,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
+ "serde_with",
  "sha3",
  "starknet-crypto",
  "thiserror",
@@ -1650,6 +1722,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_with",
  "starknet-core",
  "thiserror",
  "url",
@@ -1670,6 +1743,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -17,6 +17,7 @@ starknet-core = { version = "0.1.0", path = "../starknet-core" }
 starknet-providers = { version = "0.1.0", path = "../starknet-providers" }
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
+serde_with = "1.12.0"
 flate2 = "1.0.22"
 thiserror = "1.0.30"
 rand = "0.8.4"

--- a/starknet-contract/src/artifact.rs
+++ b/starknet-contract/src/artifact.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use starknet_core::{
-    serde::unsigned_field_element::hex_slice,
+    serde::unsigned_field_element::UfeHex,
     types::{AbiEntry, EntryPointsByType, UnsignedFieldElement},
 };
 
@@ -14,13 +15,14 @@ pub struct Artifact {
     pub program: Program,
 }
 
+#[serde_as]
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Program {
     #[serde(skip_serializing)]
     pub attributes: serde::de::IgnoredAny, // Skipped since it's not used in deployment
     pub builtins: Vec<String>,
-    #[serde(with = "hex_slice")]
+    #[serde_as(as = "Vec<UfeHex>")]
     pub data: Vec<UnsignedFieldElement>,
     #[serde(skip_serializing)]
     pub debug_info: serde::de::IgnoredAny, // Skipped since it's not used in deployment

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -18,6 +18,7 @@ base64 = "0.13.0"
 ethereum-types = "0.12.1"
 hex = "0.4.3"
 serde = { version = "1.0.133", features = ["derive"] }
+serde_with = "1.12.0"
 sha3 = "0.10.0"
 thiserror = "1.0.30"
 

--- a/starknet-core/src/types/block.rs
+++ b/starknet-core/src/types/block.rs
@@ -1,9 +1,10 @@
 use super::{
-    super::serde::unsigned_field_element::{hex, hex_option},
+    super::serde::unsigned_field_element::{UfeHex, UfeHexOption},
     ConfirmedTransactionReceipt, TransactionType, UnsignedFieldElement,
 };
 
 use serde::Deserialize;
+use serde_with::serde_as;
 
 pub enum BlockId {
     Hash(UnsignedFieldElement),
@@ -12,15 +13,18 @@ pub enum BlockId {
     Latest,
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct Block {
-    #[serde(default, with = "hex_option")]
+    #[serde(default)]
+    #[serde_as(as = "UfeHexOption")]
     pub block_hash: Option<UnsignedFieldElement>,
     pub block_number: Option<u64>,
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub parent_block_hash: UnsignedFieldElement,
     pub timestamp: u64,
-    #[serde(default, with = "hex_option")]
+    #[serde(default)]
+    #[serde_as(as = "UfeHexOption")]
     pub state_root: Option<UnsignedFieldElement>,
     pub transactions: Vec<TransactionType>,
     pub transaction_receipts: Vec<ConfirmedTransactionReceipt>,

--- a/starknet-core/src/types/call_contract.rs
+++ b/starknet-core/src/types/call_contract.rs
@@ -1,22 +1,22 @@
-use super::{
-    super::serde::unsigned_field_element::{hex, hex_slice},
-    UnsignedFieldElement,
-};
+use super::{super::serde::unsigned_field_element::UfeHex, UnsignedFieldElement};
 
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
+#[serde_as]
 #[derive(Debug, Serialize)]
 pub struct InvokeFunction {
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub contract_address: UnsignedFieldElement,
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub entry_point_selector: UnsignedFieldElement,
     pub calldata: Vec<UnsignedFieldElement>,
     pub signature: Vec<UnsignedFieldElement>,
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct CallContractResult {
-    #[serde(with = "hex_slice")]
+    #[serde_as(as = "Vec<UfeHex>")]
     pub result: Vec<UnsignedFieldElement>,
 }

--- a/starknet-core/src/types/contract_code.rs
+++ b/starknet-core/src/types/contract_code.rs
@@ -1,10 +1,12 @@
-use super::{super::serde::unsigned_field_element::hex_slice, UnsignedFieldElement};
+use super::{super::serde::unsigned_field_element::UfeHex, UnsignedFieldElement};
 
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct ContractCode {
-    #[serde(with = "hex_slice")]
+    #[serde_as(as = "Vec<UfeHex>")]
     pub bytecode: Vec<UnsignedFieldElement>,
     pub abi: Option<Vec<AbiEntry>>,
 }

--- a/starknet-core/src/types/transaction.rs
+++ b/starknet-core/src/types/transaction.rs
@@ -1,14 +1,13 @@
 use super::{
     UnsignedFieldElement,
     {
-        super::serde::unsigned_field_element::{
-            hex, hex_option, pending_block_hash::deserialize as pending_block_hash_de,
-        },
+        super::serde::unsigned_field_element::{UfeHex, UfeHexOption, UfePendingBlockHash},
         TransactionStatus,
     },
 };
 
 use serde::Deserialize;
+use serde_with::serde_as;
 
 pub enum TransactionId {
     Hash(UnsignedFieldElement),
@@ -28,20 +27,24 @@ pub enum Transaction {
     Full(FullTransaction),
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct BriefTransaction {
-    #[serde(default, with = "hex_option")]
+    #[serde(default)]
+    #[serde_as(as = "UfeHexOption")]
     pub block_hash: Option<UnsignedFieldElement>,
     #[serde(alias = "tx_status")]
     pub status: TransactionStatus,
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct FullTransaction {
     pub block_number: Option<u64>,
     pub transaction: Option<TransactionType>,
     pub status: TransactionStatus,
-    #[serde(default, deserialize_with = "pending_block_hash_de")]
+    #[serde(default)]
+    #[serde_as(as = "UfePendingBlockHash")]
     pub block_hash: Option<UnsignedFieldElement>,
     pub transaction_index: Option<u64>,
 }
@@ -54,27 +57,29 @@ pub enum EntryPointType {
     L1Handler,
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct DeployTransaction {
     pub constructor_calldata: Vec<UnsignedFieldElement>,
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub contract_address: UnsignedFieldElement,
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub contract_address_salt: UnsignedFieldElement,
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub transaction_hash: UnsignedFieldElement,
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct InvokeFunctionTransaction {
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub contract_address: UnsignedFieldElement,
     pub entry_point_type: EntryPointType,
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub entry_point_selector: UnsignedFieldElement,
     pub calldata: Vec<UnsignedFieldElement>,
     pub signature: Vec<UnsignedFieldElement>,
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub transaction_hash: UnsignedFieldElement,
 }
 

--- a/starknet-core/src/types/transaction_receipt.rs
+++ b/starknet-core/src/types/transaction_receipt.rs
@@ -1,19 +1,20 @@
 use super::{
-    super::serde::unsigned_field_element::{
-        hex, pending_block_hash::deserialize as pending_block_hash_de,
-    },
+    super::serde::unsigned_field_element::{UfeHex, UfePendingBlockHash},
     UnsignedFieldElement,
 };
 
 use ethereum_types::Address as L1Address;
 use serde::Deserialize;
+use serde_with::serde_as;
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct Receipt {
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub transaction_hash: UnsignedFieldElement,
     pub status: TransactionStatus,
-    #[serde(default, deserialize_with = "pending_block_hash_de")]
+    #[serde(default)]
+    #[serde_as(as = "UfePendingBlockHash")]
     pub block_hash: Option<UnsignedFieldElement>,
     pub block_number: Option<u64>,
     pub transaction_index: Option<u64>,
@@ -22,9 +23,10 @@ pub struct Receipt {
     pub events: Vec<Event>,
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct ConfirmedReceipt {
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub transaction_hash: UnsignedFieldElement,
     pub transaction_index: u64,
     pub execution_resources: ExecutionResources,
@@ -60,17 +62,19 @@ pub struct BuiltinInstanceCounter {
     pub ec_op_builtin: u64,
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct L2ToL1Message {
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub from_address: UnsignedFieldElement,
     pub to_address: L1Address,
     pub payload: Vec<UnsignedFieldElement>,
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct Event {
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub from_address: UnsignedFieldElement,
     pub keys: Vec<UnsignedFieldElement>,
     pub data: Vec<UnsignedFieldElement>,

--- a/starknet-core/src/types/transaction_request.rs
+++ b/starknet-core/src/types/transaction_request.rs
@@ -1,19 +1,22 @@
 use super::{
     super::serde::{
         byte_array::base64::serialize as base64_ser,
-        unsigned_field_element::{hex, hex_option},
+        unsigned_field_element::{UfeHex, UfeHexOption},
     },
     AbiEntry, UnsignedFieldElement,
 };
 
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct AddTransactionResult {
     pub code: AddTransactionResultCode,
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub transaction_hash: UnsignedFieldElement,
-    #[serde(default, with = "hex_option")]
+    #[serde(default)]
+    #[serde_as(as = "UfeHexOption")]
     pub address: Option<UnsignedFieldElement>,
 }
 
@@ -30,19 +33,21 @@ pub enum TransactionRequest {
     InvokeFunction(InvokeFunctionTransaction),
 }
 
+#[serde_as]
 #[derive(Debug, Serialize)]
 pub struct DeployTransaction {
     pub constructor_calldata: Vec<UnsignedFieldElement>,
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub contract_address_salt: UnsignedFieldElement,
     pub contract_definition: ContractDefinition,
 }
 
+#[serde_as]
 #[derive(Debug, Serialize)]
 pub struct InvokeFunctionTransaction {
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub contract_address: UnsignedFieldElement,
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub entry_point_selector: UnsignedFieldElement,
     pub calldata: Vec<UnsignedFieldElement>,
     pub signature: Vec<UnsignedFieldElement>,
@@ -65,10 +70,11 @@ pub struct EntryPointsByType {
     pub l1_handler: Vec<EntryPoint>,
 }
 
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EntryPoint {
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub selector: UnsignedFieldElement,
-    #[serde(with = "hex")]
+    #[serde_as(as = "UfeHex")]
     pub offset: UnsignedFieldElement,
 }

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -20,3 +20,4 @@ reqwest = { version = "0.11.8" }
 thiserror = "1.0.30"
 serde = "1.0.133"
 serde_json = "1.0.74"
+serde_with = "1.12.0"

--- a/starknet-providers/src/sequencer_gateway.rs
+++ b/starknet-providers/src/sequencer_gateway.rs
@@ -4,8 +4,9 @@ use async_trait::async_trait;
 use reqwest::{Client, Error as ReqwestError};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Error as SerdeJsonError;
+use serde_with::serde_as;
 use starknet_core::{
-    serde::unsigned_field_element::hex,
+    serde::unsigned_field_element::UfeHex,
     types::{
         AddTransactionResult, Block, BlockId, BriefTransaction, CallContractResult,
         ContractAddresses, ContractCode, FullTransaction, InvokeFunction, StarknetError,
@@ -74,11 +75,11 @@ enum GetCodeResponse {
 }
 
 // Work UnsignedFieldElement deserialization
+#[serde_as]
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum RawUnsignedFieldElementResponse {
-    #[serde(with = "hex")]
-    Data(UnsignedFieldElement),
+    Data(#[serde_as(as = "UfeHex")] UnsignedFieldElement),
     StarknetError(StarknetError),
 }
 


### PR DESCRIPTION
This PR replaces `serde` modules with `serde_with` traits.

When working on #62, I encountered a type (`storage_diffs` from `get_state_update`) that uses `UnsignedFieldElement` as a `HashMap` key. To deserialize this type under the existing `serde` solution, I'll have to build yet another module that targets `HashMap<UnsignedFieldElement, _>` specifically, similar to what's been done with `Vec<UnsignedFieldElement>`. That's really annoying and makes code very ugly. So I've decided to use the magic from `serde_with` to solve it for good.