### PR TITLE
doc: fix broken `IAccount` link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ starknet = { git = "https://github.com/xJonathanLEI/starknet-rs" }
 
 - [x] Sequencer gateway / feeder gateway client
 - [x] Smart contract deployment
-- [x] Signer for using [IAccount](https://github.com/OpenZeppelin/cairo-contracts/blob/main/contracts/IAccount.cairo) account contracts
+- [x] Signer for using [IAccount](https://github.com/OpenZeppelin/cairo-contracts/blob/main/openzeppelin/account/IAccount.cairo) account contracts
 - [ ] Strongly-typed smart contract binding code generation from ABI
 
 ## Crates


### PR DESCRIPTION
OpenZeppelin restructured their repo so the `IAccount` link no longer works. I don't really want to use a permalink here as `IAccount` can evolve over time.