### PR TITLE
ci: add CI pipeline for running WASM tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,3 +65,48 @@ jobs:
         with:
           command: test
           args: --all --target ${{ matrix.target }}
+
+  wasm-test:
+    name: WASM tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure:
+
+      - name: Add wasm32-unknown-unknown target
+        run: |
+          rustup target add wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: wasm-pack
+
+      - name: Run starknet-ff tests
+        run: |
+          (cd ./starknet-ff && wasm-pack test --node)
+
+      - name: Run starknet-crypto tests
+        run: |
+          (cd ./starknet-crypto && wasm-pack test --node)
+
+      - name: Run starknet-core tests
+        run: |
+          (cd ./starknet-core && wasm-pack test --node)
+
+      - name: Run starknet-signers tests
+        run: |
+          (cd ./starknet-signers && wasm-pack test --node)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,9 +862,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1469,6 +1469,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,6 +1709,7 @@ dependencies = [
  "starknet-crypto",
  "starknet-ff",
  "thiserror",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -1723,6 +1730,7 @@ dependencies = [
  "sha2",
  "starknet-ff",
  "thiserror",
+ "wasm-bindgen-test",
  "zeroize",
 ]
 
@@ -1736,6 +1744,7 @@ dependencies = [
  "hex",
  "serde",
  "thiserror",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -1760,6 +1769,7 @@ dependencies = [
  "starknet-core",
  "starknet-crypto",
  "thiserror",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -2120,9 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2158,6 +2168,30 @@ name = "wasm-bindgen-shared"
 version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45c8d417d87eefa0087e62e3c75ad086be39433449e2961add9a5d9ce5acc2f1"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0e560d44db5e73b69a9757a15512fe7e1ef93ed2061c928871a4025798293dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "web-sys"

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -23,3 +23,6 @@ serde_json = { version = "1.0.74", features = ["arbitrary_precision"] }
 serde_with = "1.12.0"
 sha3 = "0.10.0"
 thiserror = "1.0.30"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3.29"

--- a/starknet-core/src/crypto.rs
+++ b/starknet-core/src/crypto.rs
@@ -81,6 +81,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_compute_hash_on_elements() {
         // Generated with `cairo-lang`
         let hash = compute_hash_on_elements(&[
@@ -98,6 +99,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_compute_hash_on_elements_empty_data() {
         // Generated with `cairo-lang`
         let hash = compute_hash_on_elements(&[]);
@@ -110,6 +112,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_ecdsa_sign() {
         // Generated with `cairo-lang`
         let signature = ecdsa_sign(
@@ -137,6 +140,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_ecdsa_sign_message_hash_out_of_range() {
         match ecdsa_sign(
             &FieldElement::from_hex_be(
@@ -154,6 +158,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_ecdsa_verify_valid_signature() {
         // Generated with `cairo-lang`
         let public_key = FieldElement::from_hex_be(
@@ -180,6 +185,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_ecdsa_verify_invalid_signature() {
         // Generated with `cairo-lang`
         let public_key = FieldElement::from_hex_be(

--- a/starknet-core/src/serde/unsigned_field_element.rs
+++ b/starknet-core/src/serde/unsigned_field_element.rs
@@ -100,6 +100,7 @@ mod tests {
     struct TestStruct(#[serde_as(as = "UfeHexOption")] pub Option<FieldElement>);
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn empty_string_deser() {
         let r = serde_json::from_str::<TestStruct>("\"\"").unwrap();
         assert_eq!(r.0, None);

--- a/starknet-core/src/types/block.rs
+++ b/starknet-core/src/types/block.rs
@@ -52,6 +52,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_block_deser_with_transactions() {
         let raw =
             include_str!("../../test-data/raw_gateway_responses/get_block/1_with_transactions.txt");
@@ -86,6 +87,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_block_deser_with_messages() {
         // has an L2 to L1 message
         let raw =
@@ -101,6 +103,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_block_deser_with_events() {
         // has events introduced with StarkNet v0.7.0
         let raw = include_str!("../../test-data/raw_gateway_responses/get_block/3_with_events.txt");
@@ -115,6 +118,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_block_deser_pending() {
         // pending blocks don't have `block_hash`, `block_number`, or `state_root`
         let raw = include_str!("../../test-data/raw_gateway_responses/get_block/4_pending.txt");

--- a/starknet-core/src/types/contract_addresses.rs
+++ b/starknet-core/src/types/contract_addresses.rs
@@ -14,6 +14,7 @@ mod tests {
     use core::str::FromStr;
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_contract_addresses_deser() {
         // curl -X GET https://alpha4.starknet.io/feeder_gateway/get_contract_addresses
         let raw = r#"{"Starknet": "0xde29d060D45901Fb19ED6C6e959EB22d8626708e", "GpsStatementVerifier": "0xAB43bA48c9edF4C2C4bB01237348D1D7B28ef168"}"#;

--- a/starknet-core/src/types/contract_artifact.rs
+++ b/starknet-core/src/types/contract_artifact.rs
@@ -106,6 +106,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_artifact_deser_oz_account() {
         serde_json::from_str::<ContractArtifact>(include_str!(
             "../../test-data/contracts/artifacts/oz_account.txt"
@@ -114,6 +115,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_artifact_deser_event_example() {
         serde_json::from_str::<ContractArtifact>(include_str!(
             "../../test-data/contracts/artifacts/event_example.txt"
@@ -122,6 +124,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_get_full_contract_deser_code() {
         serde_json::from_str::<ContractArtifact>(include_str!(
             "../../test-data/raw_gateway_responses/get_full_contract/1_code.txt"
@@ -130,6 +133,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_get_full_contract_deser_all_abi_types() {
         serde_json::from_str::<ContractArtifact>(include_str!(
             "../../test-data/raw_gateway_responses/get_full_contract/2_all_abi_types.txt"

--- a/starknet-core/src/types/contract_code.rs
+++ b/starknet-core/src/types/contract_code.rs
@@ -130,6 +130,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_contract_code_deser() {
         let raw = include_str!("../../test-data/raw_gateway_responses/get_code/1_code.txt");
 
@@ -162,6 +163,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_contract_code_deser_all_abi_types() {
         // $ curl "https://alpha4.starknet.io/feeder_gateway/get_code?contractAddress=0x06ef97a90be1c0458f6e7bd1faf05021f2d81211f658155df0c5c97a39eb2d12"
         // Contract built from: https://github.com/starkware-libs/cairo-lang/blob/3d33c4e829a87bc3d88cf04ed6a489e788918b8b/src/starkware/starknet/compiler/starknet_preprocessor_test.py#L143

--- a/starknet-core/src/types/state_update.rs
+++ b/starknet-core/src/types/state_update.rs
@@ -48,6 +48,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_state_update_deser() {
         let raw =
             include_str!("../../test-data/raw_gateway_responses/get_state_update/1_success.txt");

--- a/starknet-core/src/types/transaction.rs
+++ b/starknet-core/src/types/transaction.rs
@@ -98,6 +98,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_deser_full_invoke_transaction() {
         let raw =
             include_str!("../../test-data/raw_gateway_responses/get_transaction/1_invoke.txt");
@@ -113,6 +114,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_deser_full_deploy_transaction() {
         let raw =
             include_str!("../../test-data/raw_gateway_responses/get_transaction/2_deploy.txt");
@@ -127,6 +129,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_deser_not_received() {
         let raw = include_str!(
             "../../test-data/raw_gateway_responses/get_transaction/3_not_received.txt"
@@ -138,6 +141,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_deser_failure() {
         let raw =
             include_str!("../../test-data/raw_gateway_responses/get_transaction/4_failure.txt");
@@ -150,6 +154,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_deser_brief_accepted() {
         let raw = include_str!(
             "../../test-data/raw_gateway_responses/get_transaction_status/1_accepted.txt"
@@ -170,6 +175,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_deser_brief_not_received() {
         let raw = include_str!(
             "../../test-data/raw_gateway_responses/get_transaction_status/2_not_received.txt"
@@ -182,6 +188,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_deser_brief_failure() {
         let raw = include_str!(
             "../../test-data/raw_gateway_responses/get_transaction_status/3_failure.txt"

--- a/starknet-core/src/types/transaction_receipt.rs
+++ b/starknet-core/src/types/transaction_receipt.rs
@@ -108,6 +108,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_receipt_deser_accepted() {
         let raw = include_str!(
             "../../test-data/raw_gateway_responses/get_transaction_receipt/1_accepted.txt"
@@ -121,6 +122,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_receipt_deser_not_received() {
         let raw = include_str!(
             "../../test-data/raw_gateway_responses/get_transaction_receipt/2_not_received.txt"
@@ -139,6 +141,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_receipt_deser_with_events() {
         let raw = include_str!(
             "../../test-data/raw_gateway_responses/get_transaction_receipt/3_with_events.txt"
@@ -149,6 +152,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_receipt_deser_failure() {
         let raw = include_str!(
             "../../test-data/raw_gateway_responses/get_transaction_receipt/4_failure.txt"
@@ -160,6 +164,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_transaction_status_deser_accepted_on_l2() {
         // note that the hashes coming from the API can be shorter
         // by a byte or two than the FieldElement into which we serialize into,
@@ -183,6 +188,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_transaction_status_deser_accepted_on_l1() {
         // curl -X GET https://alpha4.starknet.io/feeder_gateway/get_transaction_status\?transactionHash\=0x10f2462bd8d90ad7242f16c5432f5ca6a53d2846592c6170242e032a5f836a
         let raw = r#"{
@@ -202,6 +208,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_transaction_status_deser_rejected() {
         let raw = r#"{
             "tx_status": "REJECTED",

--- a/starknet-core/src/utils.rs
+++ b/starknet-core/src/utils.rs
@@ -43,6 +43,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_starknet_keccak() {
         // Generated from `cairo-lang`
         let data = b"execute";
@@ -57,6 +58,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_get_selector_from_name() {
         // Generated from `cairo-lang`
         let func_name = "execute";
@@ -71,6 +73,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_get_default_selector() {
         let default_selector = FieldElement::from_hex_be(
             "0000000000000000000000000000000000000000000000000000000000000000",
@@ -88,6 +91,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_get_selector_from_non_ascii_name() {
         let func_name = "🦀";
 

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -31,6 +31,9 @@ hex-literal = "0.3.4"
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
 
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3.29"
+
 [[bench]]
 name = "pedersen_hash"
 harness = false

--- a/starknet-crypto/src/ecdsa.rs
+++ b/starknet-crypto/src/ecdsa.rs
@@ -118,6 +118,7 @@ mod tests {
     //   https://github.com/starkware-libs/crypto-cpp/blob/95864fbe11d5287e345432dbe1e80dea3c35fc58/src/starkware/crypto/ffi/crypto_lib_test.go
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_get_public_key_1() {
         let private_key = field_element_from_be_hex(
             "03c1e9550e66958296d11b60f8e8e7a7ad990d07fa65d5f7652c4a6c87d4e3cc",
@@ -130,6 +131,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_get_public_key_2() {
         let private_key = field_element_from_be_hex(
             "0000000000000000000000000000000000000000000000000000000000000012",
@@ -142,6 +144,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_verify_valid_message() {
         let stark_key = field_element_from_be_hex(
             "01ef15c18599971b7beced415a40f0c7deacfd9b0d1819e03d723d8bc943cfca",
@@ -163,6 +166,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_verify_invalid_message() {
         let stark_key = field_element_from_be_hex(
             "077a4b314db07c45076d11f62b6f9e748a39790441823307743cf00d6597ea43",
@@ -184,6 +188,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_sign() {
         let private_key = field_element_from_be_hex(
             "0000000000000000000000000000000000000000000000000000000000000001",

--- a/starknet-crypto/src/pedersen_hash.rs
+++ b/starknet-crypto/src/pedersen_hash.rs
@@ -46,6 +46,7 @@ mod tests {
     //   https://github.com/starkware-libs/crypto-cpp/blob/95864fbe11d5287e345432dbe1e80dea3c35fc58/src/starkware/crypto/ffi/crypto_lib_test.go
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_pedersen_hash() {
         let in1 = field_element_from_be_hex(
             "03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb",

--- a/starknet-crypto/src/rfc6979.rs
+++ b/starknet-crypto/src/rfc6979.rs
@@ -92,12 +92,14 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_generate_k_padded() {
         // Test vectors generated from `cairo-lang`
         test_generate_k_from_json_str(include_str!("../test-data/rfc6979_padded.json"));
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_generate_k_not_padded() {
         // Test vectors generated from `cairo-lang`
         test_generate_k_from_json_str(include_str!("../test-data/rfc6979_not_padded.json"));

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -21,3 +21,6 @@ thiserror = "1.0.30"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.3", features = ["js"] }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3.29"

--- a/starknet-ff/src/lib.rs
+++ b/starknet-ff/src/lib.rs
@@ -398,6 +398,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_dec_fmt() {
         let nums = [
             "0",
@@ -416,6 +417,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_zero_padded_hex_fmt() {
         let fe = FieldElement::from_hex_be("0x1234abcd").unwrap();
 
@@ -437,6 +439,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_addition() {
         let additions = [
             ["1", "1", "2"],
@@ -457,6 +460,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_subtraction() {
         let subtractions = [
             ["10", "7", "3"],
@@ -477,6 +481,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_multiplication() {
         let multiplications = [
             ["2", "3", "6"],

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -17,3 +17,6 @@ starknet-core = { version = "0.1.0", path = "../starknet-core" }
 starknet-crypto = { version = "0.1.0", path = "../starknet-crypto" }
 async-trait = "0.1.52"
 thiserror = "1.0.30"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3.29"

--- a/starknet-signers/src/key_pair.rs
+++ b/starknet-signers/src/key_pair.rs
@@ -55,6 +55,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_get_secret_scalar() {
         // Generated with `cairo-lang`
         let private_key = FieldElement::from_hex_be(
@@ -68,6 +69,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_get_verifying_key() {
         // Generated with `cairo-lang`
         let private_key = FieldElement::from_hex_be(
@@ -86,6 +88,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_sign() {
         // Generated with `cairo-lang`
         let private_key = FieldElement::from_hex_be(
@@ -113,6 +116,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_hash_out_of_range() {
         let private_key = FieldElement::from_hex_be(
             "0139fe4d6f02e666e86a6f58e65060f115cd3c185bd9e98bd829636931458f79",
@@ -132,6 +136,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_verify_valid_signature() {
         // Generated with `cairo-lang`
         let public_key = FieldElement::from_hex_be(
@@ -160,6 +165,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_verify_invalid_signature() {
         // Generated with `cairo-lang`
         let public_key = FieldElement::from_hex_be(


### PR DESCRIPTION
This PR:

- makes all `#[test]` tests runnable for `wasm32-unknown-unknown` through `wasm-bindgen-test`; and
- adds yet another CI pipeline for running these tests via `wasm-pack test`.

We have added wasm-specific code for the WebAssembly support, so it's important we keep testing stuff under wasm too.