### PR TITLE
ci: run integration tests again

### DIFF
--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -7,7 +7,6 @@ use starknet_providers::SequencerGatewayProvider;
 use starknet_signers::{LocalWallet, SigningKey};
 
 #[tokio::test]
-#[ignore = "temporarily skipping test until Starkware improves network stability"]
 async fn can_get_nonce() {
     let provider = SequencerGatewayProvider::starknet_alpha_goerli();
     let signer = LocalWallet::from(SigningKey::from_secret_scalar(
@@ -30,7 +29,6 @@ async fn can_get_nonce() {
 }
 
 #[tokio::test]
-#[ignore = "temporarily skipping test until Starkware improves network stability"]
 async fn can_execute_tst_mint() {
     // This test case is not very useful as the sequencer will always respond with
     // `TransactionReceived` even if the transaction will eventually fail, just like how

--- a/starknet-contract/tests/contract_deployment.rs
+++ b/starknet-contract/tests/contract_deployment.rs
@@ -2,7 +2,6 @@ use starknet_contract::ContractFactory;
 use starknet_core::types::{ContractArtifact, FieldElement};
 
 #[tokio::test]
-#[ignore = "temporarily skipping test until Starkware improves network stability"]
 async fn can_deploy_contract_to_alpha_goerli() {
     let artifact = serde_json::from_str::<ContractArtifact>(include_str!(
         "../test-data/artifacts/oz_account.txt"


### PR DESCRIPTION
This reverts #59

I feel the testnet reliability has improved since so we can let those live tests run again.