### PR TITLE
misc: remove `Transaction` enum

### DIFF
--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -6,7 +6,7 @@ pub use block::{Block, BlockId};
 
 mod transaction;
 pub use transaction::{
-    DeployTransaction, EntryPointType, InvokeFunctionTransaction, Transaction, TransactionInfo,
+    DeployTransaction, EntryPointType, InvokeFunctionTransaction, TransactionInfo,
     TransactionStatusInfo, TransactionType,
 };
 

--- a/starknet-core/src/types/transaction.rs
+++ b/starknet-core/src/types/transaction.rs
@@ -16,12 +16,6 @@ pub enum TransactionType {
     InvokeFunction(InvokeFunctionTransaction),
 }
 
-#[derive(Debug, Deserialize)]
-pub enum Transaction {
-    Brief(TransactionStatusInfo),
-    Full(TransactionInfo),
-}
-
 #[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct TransactionStatusInfo {


### PR DESCRIPTION
This PR removes the unused `Transaction` enum.

Decided to do this because I got the `clippy::large_enum_variant` lint warning after I added `max_fee` to `starknet_core::types::transaction::InvokeFunctionTransaction`, and realized we don't need this enum type anyways. If we _really_ need to express their relationship, might as well do a marker trait.