### PR TITLE
ci: test building for WASM

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,6 +89,10 @@ jobs:
         run: |
           rustup target add wasm32-unknown-unknown
 
+      - name: Build project
+        run: |
+          cargo build --target wasm32-unknown-unknown
+
       - name: Install wasm-pack
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Looks like our CI pipeline doesn't test building for `wasm32-unknown-unknown`.