### PR TITLE
feat(starknet-contracts): Send + Sync Safe Random Number Generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "az"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f771a5d1f5503f7f4279a30f3643d3421ba149848b89ecaaec0ea2acf04a5ac4"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +630,16 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "gmp-mpfr-sys"
+version = "1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a146a7357ce9573bdcc416fc4a99b960e166e72d8eaffa7c59966d51866b5bfb"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1414,6 +1430,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rug"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac804305677221f4c82469fd7eb8bfe00dd01420aa191197cb87d738520feef"
+dependencies = [
+ "az",
+ "gmp-mpfr-sys",
+ "libc",
+]
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,6 +1713,7 @@ version = "0.1.0"
 dependencies = [
  "flate2",
  "rand",
+ "rug",
  "serde",
  "serde_json",
  "serde_with",

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -21,6 +21,7 @@ serde_with = "1.12.0"
 flate2 = "1.0.22"
 thiserror = "1.0.30"
 rand = "0.8.4"
+rug = "1.15.0"
 
 [dev-dependencies]
 tokio = { version = "1.15.0", features = ["full"] }

--- a/starknet-contract/src/factory.rs
+++ b/starknet-contract/src/factory.rs
@@ -1,6 +1,5 @@
 use flate2::{write::GzEncoder, Compression};
-use rug::rand::ThreadRandState;
-use rand::{thread_rng, RngCore};
+use rug::rand::RandState;
 use starknet_core::types::{
     AbiEntry, AddTransactionResult, ContractArtifact, ContractDefinition, DeployTransactionRequest,
     EntryPointsByType, FieldElement, TransactionRequest,
@@ -62,8 +61,7 @@ impl<P: Provider> Factory<P> {
         // rng.fill_bytes(&mut salt_buffer[1..]);
 
         // Create a Send + Sync safe random number generator
-        let mut gen = create_generator();
-        let mut rand = ThreadRandState::new_custom(&mut gen);
+        let mut rand = RandState::new();
         salt_buffer.map(|_| rand.bits(8));
         // TODO: change to cover full range
         salt_buffer[0] = 0;

--- a/starknet-contract/src/factory.rs
+++ b/starknet-contract/src/factory.rs
@@ -1,4 +1,5 @@
 use flate2::{write::GzEncoder, Compression};
+use rug::rand::ThreadRandState;
 use rand::{thread_rng, RngCore};
 use starknet_core::types::{
     AbiEntry, AddTransactionResult, ContractArtifact, ContractDefinition, DeployTransactionRequest,
@@ -57,8 +58,15 @@ impl<P: Provider> Factory<P> {
 
         // Generate 31 bytes only here to avoid out of range error
         // TODO: change to cover full range
-        let mut rng = thread_rng();
-        rng.fill_bytes(&mut salt_buffer[1..]);
+        // let mut rng = thread_rng();
+        // rng.fill_bytes(&mut salt_buffer[1..]);
+
+        // Create a Send + Sync safe random number generator
+        let mut gen = create_generator();
+        let mut rand = ThreadRandState::new_custom(&mut gen);
+        salt_buffer.map(|_| rand.bits(8));
+        // TODO: change to cover full range
+        salt_buffer[0] = 0;
 
         self.provider
             .add_transaction(


### PR DESCRIPTION
This PR introduces `Send + Sync` safe random number generation by using the [rug](https://docs.rs/rug/latest/rug/index.html) crate.