### PR TITLE
ci: run clippy checks on all targets

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -41,4 +41,4 @@ jobs:
           cargo fmt --all -- --check
       - name: Run Clippy lints
         run: |
-          cargo clippy
+          cargo clippy --all --all-targets

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Build project
         run: |
-          cargo build --target wasm32-unknown-unknown
+          cargo build --all --target wasm32-unknown-unknown
 
       - name: Install wasm-pack
         uses: actions-rs/cargo@v1

--- a/starknet-core/src/crypto.rs
+++ b/starknet-core/src/crypto.rs
@@ -178,10 +178,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(
-            ecdsa_verify(&public_key, &message_hash, &Signature { r, s }).unwrap(),
-            true
-        );
+        assert!(ecdsa_verify(&public_key, &message_hash, &Signature { r, s }).unwrap());
     }
 
     #[test]
@@ -205,9 +202,6 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(
-            ecdsa_verify(&public_key, &message_hash, &Signature { r, s }).unwrap(),
-            false
-        );
+        assert!(!ecdsa_verify(&public_key, &message_hash, &Signature { r, s }).unwrap());
     }
 }

--- a/starknet-crypto/src/ecdsa.rs
+++ b/starknet-crypto/src/ecdsa.rs
@@ -159,10 +159,7 @@ mod tests {
             "0405c3191ab3883ef2b763af35bc5f5d15b3b4e99461d70e84c654a351a7c81b",
         );
 
-        assert_eq!(
-            verify(&stark_key, &msg_hash, &r_bytes, &s_bytes).unwrap(),
-            true
-        );
+        assert!(verify(&stark_key, &msg_hash, &r_bytes, &s_bytes).unwrap());
     }
 
     #[test]
@@ -181,10 +178,7 @@ mod tests {
             "01f2c44a7798f55192f153b4c48ea5c1241fbb69e6132cc8a0da9c5b62a4286e",
         );
 
-        assert_eq!(
-            verify(&stark_key, &msg_hash, &r_bytes, &s_bytes).unwrap(),
-            false
-        );
+        assert!(!verify(&stark_key, &msg_hash, &r_bytes, &s_bytes).unwrap());
     }
 
     #[test]
@@ -203,9 +197,6 @@ mod tests {
         let signature = sign(&private_key, &message, &k).unwrap();
         let public_key = get_public_key(&private_key);
 
-        assert_eq!(
-            verify(&public_key, &message, &signature.r, &signature.s).unwrap(),
-            true
-        );
+        assert!(verify(&public_key, &message, &signature.r, &signature.s).unwrap());
     }
 }

--- a/starknet-signers/src/key_pair.rs
+++ b/starknet-signers/src/key_pair.rs
@@ -158,10 +158,7 @@ mod tests {
 
         let verifying_key = VerifyingKey::from_scalar(public_key);
 
-        assert_eq!(
-            verifying_key.verify(&hash, &Signature { r, s }).unwrap(),
-            true
-        );
+        assert!(verifying_key.verify(&hash, &Signature { r, s }).unwrap());
     }
 
     #[test]
@@ -187,9 +184,6 @@ mod tests {
 
         let verifying_key = VerifyingKey::from_scalar(public_key);
 
-        assert_eq!(
-            verifying_key.verify(&hash, &Signature { r, s }).unwrap(),
-            false
-        );
+        assert!(!verifying_key.verify(&hash, &Signature { r, s }).unwrap());
     }
 }


### PR DESCRIPTION
I just realized our CI has not been checking non-default targets like tests and benches. This PR fixes it along with some clippy warnings discovered.