### PR TITLE
feat: add util function for converting Cairo string to felt

### DIFF
--- a/starknet-core/src/utils.rs
+++ b/starknet-core/src/utils.rs
@@ -12,6 +12,14 @@ pub struct NonAsciiNameError<'a> {
     pub name: &'a str,
 }
 
+#[derive(Debug, Error)]
+pub enum CairoShortStringToFeltError {
+    #[error("Cairo string can only contain ASCII characters")]
+    NonAsciiCharacter,
+    #[error("short string exceeds maximum length of 31 characters")]
+    StringTooLong,
+}
+
 /// A variant of eth-keccak that computes a value that fits in a StarkNet field element.
 pub fn starknet_keccak(data: &[u8]) -> FieldElement {
     let mut hasher = Keccak256::new();
@@ -36,6 +44,24 @@ pub fn get_selector_from_name(func_name: &str) -> Result<FieldElement, NonAsciiN
             Err(NonAsciiNameError { name: func_name })
         }
     }
+}
+
+/// Converts Cairo short string to [FieldElement].
+pub fn cairo_short_string_to_felt(str: &str) -> Result<FieldElement, CairoShortStringToFeltError> {
+    if !str.is_ascii() {
+        return Err(CairoShortStringToFeltError::NonAsciiCharacter);
+    }
+    if str.len() > 31 {
+        return Err(CairoShortStringToFeltError::StringTooLong);
+    }
+
+    let ascii_bytes = str.as_bytes();
+
+    let mut buffer = [0u8; 32];
+    buffer[(32 - ascii_bytes.len())..].copy_from_slice(ascii_bytes);
+
+    // The conversion will never fail
+    Ok(FieldElement::from_bytes_be(&buffer).unwrap())
 }
 
 #[cfg(test)]
@@ -99,5 +125,27 @@ mod tests {
             Err(_) => {}
             _ => panic!("Should throw error on non-ASCII name"),
         };
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    fn test_cairo_short_string_to_felt() {
+        let data = [
+            (
+                "abcdefghijklmnopqrstuvwxyz",
+                "156490583352162063278528710879425690470022892627113539022649722",
+            ),
+            (
+                "1234567890123456789012345678901",
+                "86921973946889608444641514252360676678984087116218318142845213717418291249",
+            ),
+        ];
+
+        for (str, felt_dec) in data.into_iter() {
+            assert_eq!(
+                cairo_short_string_to_felt(str).unwrap(),
+                FieldElement::from_dec_str(felt_dec).unwrap()
+            );
+        }
     }
 }

--- a/starknet-core/src/utils.rs
+++ b/starknet-core/src/utils.rs
@@ -148,4 +148,22 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    fn test_cairo_short_string_to_felt_too_long() {
+        assert!(matches!(
+            cairo_short_string_to_felt("12345678901234567890123456789012"),
+            Err(CairoShortStringToFeltError::StringTooLong)
+        ));
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    fn test_cairo_short_string_to_felt_non_ascii() {
+        assert!(matches!(
+            cairo_short_string_to_felt("🦀"),
+            Err(CairoShortStringToFeltError::NonAsciiCharacter)
+        ));
+    }
 }


### PR DESCRIPTION
This PR adds a simple utility function for converting [Cairo short strings](https://www.cairo-lang.org/docs/how_cairo_works/consts.html#short-string-literals) to `FieldElement`.