### PR TITLE
Dev/deny unknown fields

### DIFF
--- a/starknet-core/src/types/block.rs
+++ b/starknet-core/src/types/block.rs
@@ -15,6 +15,7 @@ pub enum BlockId {
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum BlockStatus {
     /// Block that is yet to be closed
     Pending,
@@ -30,6 +31,7 @@ pub enum BlockStatus {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct Block {
     #[serde(default)]
     #[serde_as(as = "UfeHexOption")]

--- a/starknet-core/src/types/call_contract.rs
+++ b/starknet-core/src/types/call_contract.rs
@@ -5,6 +5,7 @@ use serde_with::serde_as;
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct CallContractResult {
     #[serde_as(as = "Vec<UfeHex>")]
     pub result: Vec<FieldElement>,

--- a/starknet-core/src/types/contract_addresses.rs
+++ b/starknet-core/src/types/contract_addresses.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct ContractAddresses {
     pub starknet: Address,
     pub gps_statement_verifier: Address,

--- a/starknet-core/src/types/contract_code.rs
+++ b/starknet-core/src/types/contract_code.rs
@@ -5,6 +5,7 @@ use serde_with::serde_as;
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct ContractCode {
     #[serde_as(as = "Vec<UfeHex>")]
     pub bytecode: Vec<FieldElement>,
@@ -60,24 +61,28 @@ pub struct Event {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct Input {
     pub name: String,
     pub r#type: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct Output {
     pub name: String,
     pub r#type: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct EventData {
     pub name: String,
     pub r#type: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct Member {
     pub name: String,
     pub offset: u64,

--- a/starknet-core/src/types/fee.rs
+++ b/starknet-core/src/types/fee.rs
@@ -1,12 +1,14 @@
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct FeeEstimate {
     pub amount: u64,
     pub unit: FeeUnit,
 }
 
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum FeeUnit {
     #[serde(rename = "wei")]
     Wei,

--- a/starknet-core/src/types/starknet_error.rs
+++ b/starknet-core/src/types/starknet_error.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct Error {
     pub code: ErrorCode,
     pub message: String,
@@ -15,6 +16,7 @@ impl std::fmt::Display for Error {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum ErrorCode {
     #[serde(rename = "StarknetErrorCode.BLOCK_NOT_FOUND")]
     BlockNotFound,

--- a/starknet-core/src/types/state_update.rs
+++ b/starknet-core/src/types/state_update.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct StateUpdate {
     #[serde(default)]
     #[serde_as(as = "Option<UfeHex>")]
@@ -19,6 +20,7 @@ pub struct StateUpdate {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct StateDiff {
     #[serde_as(as = "HashMap<UfeHex, _>")]
     pub storage_diffs: HashMap<FieldElement, Vec<StorageDiff>>,
@@ -27,6 +29,7 @@ pub struct StateDiff {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct StorageDiff {
     #[serde_as(as = "UfeHex")]
     pub key: FieldElement,
@@ -36,6 +39,7 @@ pub struct StorageDiff {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct DeployedContract {
     #[serde_as(as = "UfeHex")]
     pub address: FieldElement,

--- a/starknet-core/src/types/trace.rs
+++ b/starknet-core/src/types/trace.rs
@@ -8,6 +8,7 @@ use starknet_crypto::FieldElement;
 /// Represents the trace of a StarkNet transaction execution, including internal calls.
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct TransactionTrace {
     /// An object describing the invocation of a specific function.
     pub function_invocation: FunctionInvocation,
@@ -18,6 +19,7 @@ pub struct TransactionTrace {
 /// A lean version of CallInfo class, containing merely the information relevant for the user.
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct FunctionInvocation {
     #[serde_as(as = "UfeHex")]
     pub caller_address: FieldElement,
@@ -40,6 +42,7 @@ pub struct FunctionInvocation {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct OrderedEventResponse {
     pub order: u64,
     #[serde_as(as = "Vec<UfeHex>")]
@@ -50,6 +53,7 @@ pub struct OrderedEventResponse {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct OrderedL2ToL1MessageResponse {
     pub order: u64,
     pub to_address: Address,

--- a/starknet-core/src/types/transaction.rs
+++ b/starknet-core/src/types/transaction.rs
@@ -11,6 +11,7 @@ use serde_with::serde_as;
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum TransactionType {
     Deploy(DeployTransaction),
     InvokeFunction(InvokeFunctionTransaction),
@@ -18,6 +19,7 @@ pub enum TransactionType {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct TransactionStatusInfo {
     #[serde(default)]
     #[serde_as(as = "UfeHexOption")]
@@ -28,6 +30,7 @@ pub struct TransactionStatusInfo {
     pub transaction_failure_reason: Option<TransactionFailureReason>,
 }
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct TransactionFailureReason {
     pub code: String,
     pub error_message: Option<String>,
@@ -35,6 +38,7 @@ pub struct TransactionFailureReason {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct TransactionInfo {
     #[serde(default)]
     #[serde_as(as = "UfePendingBlockHash")]
@@ -49,6 +53,7 @@ pub struct TransactionInfo {
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum EntryPointType {
     External,
     L1Handler,
@@ -57,6 +62,7 @@ pub enum EntryPointType {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct DeployTransaction {
     #[serde_as(deserialize_as = "Vec<UfeHex>")]
     pub constructor_calldata: Vec<FieldElement>,
@@ -74,6 +80,7 @@ pub struct DeployTransaction {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct InvokeFunctionTransaction {
     #[serde_as(as = "UfeHex")]
     pub contract_address: FieldElement,

--- a/starknet-core/src/types/transaction_receipt.rs
+++ b/starknet-core/src/types/transaction_receipt.rs
@@ -10,6 +10,7 @@ use serde_with::serde_as;
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct Receipt {
     #[serde(default)]
     #[serde_as(as = "UfePendingBlockHash")]
@@ -31,6 +32,7 @@ pub struct Receipt {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct ConfirmedReceipt {
     #[serde_as(as = "UfeHex")]
     pub transaction_hash: FieldElement,
@@ -47,6 +49,7 @@ pub struct ConfirmedReceipt {
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum TransactionStatus {
     /// Transaction has not been received yet (i.e. not written to storage)
     NotReceived,
@@ -64,6 +67,7 @@ pub enum TransactionStatus {
 }
 
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct ExecutionResources {
     pub n_steps: u64,
     pub n_memory_holes: u64,
@@ -71,6 +75,7 @@ pub struct ExecutionResources {
 }
 
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct BuiltinInstanceCounter {
     pub pedersen_builtin: Option<u64>,
     pub range_check_builtin: Option<u64>,
@@ -82,6 +87,7 @@ pub struct BuiltinInstanceCounter {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct L1ToL2Message {
     pub from_address: L1Address,
     #[serde_as(as = "UfeHex")]
@@ -94,6 +100,7 @@ pub struct L1ToL2Message {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct L2ToL1Message {
     #[serde_as(as = "UfeHex")]
     pub from_address: FieldElement,
@@ -104,6 +111,7 @@ pub struct L2ToL1Message {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct Event {
     #[serde_as(as = "UfeHex")]
     pub from_address: FieldElement,

--- a/starknet-core/src/types/transaction_receipt.rs
+++ b/starknet-core/src/types/transaction_receipt.rs
@@ -38,6 +38,7 @@ pub struct ConfirmedReceipt {
     pub transaction_hash: FieldElement,
     pub transaction_index: u64,
     pub execution_resources: ExecutionResources,
+    pub l1_to_l2_consumed_message: Option<L1ToL2Message>,
     pub l2_to_l1_messages: Vec<L2ToL1Message>,
     pub events: Vec<Event>,
     // This field is marked optional because it's missing from old blocks. Drop `Option` once it's
@@ -92,10 +93,12 @@ pub struct L1ToL2Message {
     pub from_address: L1Address,
     #[serde_as(as = "UfeHex")]
     pub to_address: FieldElement,
+    #[serde_as(deserialize_as = "UfeHex")]
     pub selector: FieldElement,
     #[serde_as(deserialize_as = "Vec<UfeHex>")]
     pub payload: Vec<FieldElement>,
-    pub nonce: Option<u64>,
+    #[serde_as(deserialize_as = "Option<UfeHex>")]
+    pub nonce: Option<FieldElement>,
 }
 
 #[serde_as]

--- a/starknet-core/src/types/transaction_request.rs
+++ b/starknet-core/src/types/transaction_request.rs
@@ -11,6 +11,7 @@ use serde_with::serde_as;
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct AddTransactionResult {
     pub code: AddTransactionResultCode,
     #[serde_as(as = "UfeHex")]
@@ -21,6 +22,7 @@ pub struct AddTransactionResult {
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum AddTransactionResultCode {
     #[serde(rename = "TRANSACTION_RECEIVED")]
     TransactionReceived,
@@ -66,6 +68,7 @@ pub struct ContractDefinition {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct EntryPointsByType {
     pub constructor: Vec<EntryPoint>,
     pub external: Vec<EntryPoint>,
@@ -74,6 +77,7 @@ pub struct EntryPointsByType {
 
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct EntryPoint {
     #[serde_as(as = "UfeHex")]
     pub selector: FieldElement,


### PR DESCRIPTION
Resolves #73.

The attribute is not added to `AbiEntry` related types (e.g. `Constructor`) because those types are affected by the `serde` bug. Deserialization is broken if the attribute is applied.

A missing field has been discovered in the process: `l1_to_l2_consumed_message` is missing from `ConfirmedReceipt`. It's been fixed.