### PR TITLE
feat: use builder pattern for `Account`

### DIFF
--- a/examples/mint_tokens.rs
+++ b/examples/mint_tokens.rs
@@ -1,10 +1,6 @@
 use starknet::{
     accounts::{Account, Call, SingleOwnerAccount},
-    core::{
-        chain_id,
-        types::{BlockId, FieldElement},
-        utils::get_selector_from_name,
-    },
+    core::{chain_id, types::FieldElement, utils::get_selector_from_name},
     providers::SequencerGatewayProvider,
     signers::{LocalWallet, SigningKey},
 };
@@ -22,21 +18,18 @@ async fn main() {
     .unwrap();
 
     let account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
-    let nonce = account.get_nonce(BlockId::Latest).await.unwrap();
 
     let result = account
-        .execute(
-            &[Call {
-                to: tst_token_address,
-                selector: get_selector_from_name("mint").unwrap(),
-                calldata: vec![
-                    address,
-                    FieldElement::from_dec_str("1000000000000000000000").unwrap(),
-                    FieldElement::ZERO,
-                ],
-            }],
-            nonce,
-        )
+        .execute(&[Call {
+            to: tst_token_address,
+            selector: get_selector_from_name("mint").unwrap(),
+            calldata: vec![
+                address,
+                FieldElement::from_dec_str("1000000000000000000000").unwrap(),
+                FieldElement::ZERO,
+            ],
+        }])
+        .send()
         .await
         .unwrap();
 

--- a/starknet-accounts/src/account.rs
+++ b/starknet-accounts/src/account.rs
@@ -4,19 +4,83 @@ use async_trait::async_trait;
 use starknet_core::types::{AddTransactionResult, BlockId, FieldElement};
 use std::error::Error;
 
+#[derive(Debug)]
+pub struct AttachedAccountCall<'a, A> {
+    pub calls: Vec<Call>,
+    pub nonce: Option<FieldElement>,
+    pub max_fee: Option<FieldElement>,
+    pub(crate) account: &'a A,
+}
+
+pub trait AccountCall {
+    fn get_calls(&self) -> &[Call];
+
+    fn get_nonce(&self) -> &Option<FieldElement>;
+
+    fn get_max_fee(&self) -> &Option<FieldElement>;
+
+    fn nonce(self, nonce: FieldElement) -> Self;
+
+    fn max_fee(self, max_fee: FieldElement) -> Self;
+}
+
 #[async_trait(?Send)]
-pub trait Account {
+pub trait Account: Sized {
     type GetNonceError: Error + Send;
-    type ExecuteError: Error + Send;
+    type SendTransactionError: Error + Send;
 
     async fn get_nonce(
         &self,
         block_identifier: BlockId,
     ) -> Result<FieldElement, Self::GetNonceError>;
 
-    async fn execute(
+    fn execute(&self, calls: &[Call]) -> AttachedAccountCall<Self>;
+
+    async fn send_transaction<C>(
         &self,
-        calls: &[Call],
-        nonce: FieldElement,
-    ) -> Result<AddTransactionResult, Self::ExecuteError>;
+        call: &C,
+    ) -> Result<AddTransactionResult, Self::SendTransactionError>
+    where
+        C: AccountCall;
+}
+
+impl<'a, A> AttachedAccountCall<'a, A>
+where
+    A: Account,
+{
+    pub async fn send(&self) -> Result<AddTransactionResult, A::SendTransactionError> {
+        self.account.send_transaction(self).await
+    }
+}
+
+impl<'a, A> AccountCall for AttachedAccountCall<'a, A> {
+    fn get_calls(&self) -> &[Call] {
+        &self.calls
+    }
+
+    fn get_nonce(&self) -> &Option<FieldElement> {
+        &self.nonce
+    }
+
+    fn get_max_fee(&self) -> &Option<FieldElement> {
+        &self.max_fee
+    }
+
+    fn nonce(self, nonce: FieldElement) -> Self {
+        Self {
+            calls: self.calls,
+            nonce: Some(nonce),
+            max_fee: self.max_fee,
+            account: self.account,
+        }
+    }
+
+    fn max_fee(self, max_fee: FieldElement) -> Self {
+        Self {
+            calls: self.calls,
+            nonce: self.nonce,
+            max_fee: Some(max_fee),
+            account: self.account,
+        }
+    }
 }

--- a/starknet-accounts/src/call.rs
+++ b/starknet-accounts/src/call.rs
@@ -1,6 +1,6 @@
 use starknet_core::types::FieldElement;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Call {
     pub to: FieldElement,
     pub selector: FieldElement,

--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -55,32 +55,29 @@ async fn can_execute_tst_mint() {
     .unwrap();
 
     let account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
-    let nonce = account.get_nonce(BlockId::Pending).await.unwrap();
 
     let result = account
-        .execute(
-            &[
-                Call {
-                    to: tst_token_address,
-                    selector: get_selector_from_name("mint").unwrap(),
-                    calldata: vec![
-                        address,
-                        FieldElement::from_dec_str("1000000000000000000000").unwrap(),
-                        FieldElement::ZERO,
-                    ],
-                },
-                Call {
-                    to: tst_token_address,
-                    selector: get_selector_from_name("mint").unwrap(),
-                    calldata: vec![
-                        address,
-                        FieldElement::from_dec_str("2000000000000000000000").unwrap(),
-                        FieldElement::ZERO,
-                    ],
-                },
-            ],
-            nonce,
-        )
+        .execute(&[
+            Call {
+                to: tst_token_address,
+                selector: get_selector_from_name("mint").unwrap(),
+                calldata: vec![
+                    address,
+                    FieldElement::from_dec_str("1000000000000000000000").unwrap(),
+                    FieldElement::ZERO,
+                ],
+            },
+            Call {
+                to: tst_token_address,
+                selector: get_selector_from_name("mint").unwrap(),
+                calldata: vec![
+                    address,
+                    FieldElement::from_dec_str("2000000000000000000000").unwrap(),
+                    FieldElement::ZERO,
+                ],
+            },
+        ])
+        .send()
         .await
         .unwrap();
 


### PR DESCRIPTION
Resolves #101.

Now you can just do `account.execute(&[Call{...}]).send().await`, and inject `nonce` or `max_fee` if you want.