### PR TITLE
Added Debug+Clone traits to signers and accounts structs

### DIFF
--- a/starknet-accounts/src/single_owner.rs
+++ b/starknet-accounts/src/single_owner.rs
@@ -31,6 +31,7 @@ const SELECTOR_EXECUTE: FieldElement = FieldElement::from_mont([
     305947032915839070,
 ]);
 
+#[derive(Debug, Clone)]
 pub struct SingleOwnerAccount<P, S>
 where
     P: Provider + Send,

--- a/starknet-signers/src/key_pair.rs
+++ b/starknet-signers/src/key_pair.rs
@@ -4,12 +4,12 @@ use starknet_core::{
 };
 use starknet_crypto::get_public_key;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SigningKey {
     secret_scalar: FieldElement,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VerifyingKey {
     scalar: FieldElement,
 }

--- a/starknet-signers/src/local_wallet.rs
+++ b/starknet-signers/src/local_wallet.rs
@@ -6,6 +6,7 @@ use starknet_core::{
     types::FieldElement,
 };
 
+#[derive(Debug, Clone)]
 pub struct LocalWallet {
     private_key: SigningKey,
 }


### PR DESCRIPTION
Aaaaaahhhh I am clooooniiiiinnng!!!!

The scope of the changes is limited to `starknet-signers` and `starknet-accounts` structs [excluding AttachedAccountCall] due to the immediate necessity encountered during the development of a personnal project.

:warning: Freshly converted rustacean :warning: