### PR TITLE
feat(providers): Instantiate localhost provider

### DIFF
--- a/starknet-providers/src/sequencer_gateway.rs
+++ b/starknet-providers/src/sequencer_gateway.rs
@@ -58,7 +58,7 @@ impl SequencerGatewayProvider {
         )
     }
 
-    pub fn starknet_alpha_localhost() -> Self {
+    pub fn starknet_nile_localhost() -> Self {
         Self::new(
             Url::parse("http://127.0.0.1:5000/gateway").unwrap(),
             Url::parse("http://127.0.0.1:5000/feeder_gateway").unwrap(),

--- a/starknet-providers/src/sequencer_gateway.rs
+++ b/starknet-providers/src/sequencer_gateway.rs
@@ -57,6 +57,13 @@ impl SequencerGatewayProvider {
             Url::parse("https://alpha4.starknet.io/feeder_gateway").unwrap(),
         )
     }
+
+    pub fn starknet_alpha_localhost() -> Self {
+        Self::new(
+            Url::parse("http://127.0.0.1:5000/gateway").unwrap(),
+            Url::parse("http://127.0.0.1:5000/feeder_gateway").unwrap(),
+        )
+    }
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Added another function to create an instance of `SequencerGatewayProvider` with the appropriate args for a local dev node.

I am referring to the default parameters nile is [using](https://github.com/OpenZeppelin/nile/blob/main/src/nile/core/node.py).

