### PR TITLE
feat: use thread safe RNG for `ContractFactory`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,14 +1255,13 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
@@ -1282,15 +1281,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = "1.0.74"
 serde_with = "1.12.0"
 flate2 = "1.0.22"
 thiserror = "1.0.30"
-rand = "0.8.4"
+rand = { version = "0.8.5", features=["std_rng"] }
 
 [dev-dependencies]
 tokio = { version = "1.15.0", features = ["full"] }

--- a/starknet-contract/src/factory.rs
+++ b/starknet-contract/src/factory.rs
@@ -1,5 +1,5 @@
 use flate2::{write::GzEncoder, Compression};
-use rand::{thread_rng, RngCore};
+use rand::{prelude::StdRng, RngCore, SeedableRng};
 use starknet_core::types::{
     AbiEntry, AddTransactionResult, ContractArtifact, ContractDefinition, DeployTransactionRequest,
     EntryPointsByType, FieldElement, TransactionRequest,
@@ -57,7 +57,7 @@ impl<P: Provider> Factory<P> {
 
         // Generate 31 bytes only here to avoid out of range error
         // TODO: change to cover full range
-        let mut rng = thread_rng();
+        let mut rng = StdRng::from_entropy();
         rng.fill_bytes(&mut salt_buffer[1..]);
 
         self.provider


### PR DESCRIPTION
Similar to #97, this PR replaces the non-thread-safe RNG `thread_rng` with a thread-safe one, except this one actually works on all supported platforms.