### PR TITLE
feat: make `Provider` and `Signer` `Send`

### DIFF
--- a/starknet-providers/src/provider.rs
+++ b/starknet-providers/src/provider.rs
@@ -7,7 +7,8 @@ use starknet_core::types::{
 };
 use std::error::Error;
 
-#[async_trait(?Send)]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait Provider {
     type Error: Error + Send;
 

--- a/starknet-providers/src/sequencer_gateway.rs
+++ b/starknet-providers/src/sequencer_gateway.rs
@@ -143,7 +143,8 @@ impl SequencerGatewayProvider {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Provider for SequencerGatewayProvider {
     type Error = ProviderError;
 

--- a/starknet-signers/src/local_wallet.rs
+++ b/starknet-signers/src/local_wallet.rs
@@ -23,7 +23,8 @@ impl LocalWallet {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Signer for LocalWallet {
     type GetPublicKeyError = Infallible;
     type SignError = SignError;

--- a/starknet-signers/src/signer.rs
+++ b/starknet-signers/src/signer.rs
@@ -4,7 +4,8 @@ use async_trait::async_trait;
 use starknet_core::{crypto::Signature, types::FieldElement};
 use std::error::Error;
 
-#[async_trait(?Send)]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait Signer {
     type GetPublicKeyError: Error + Send;
     type SignError: Error + Send;


### PR DESCRIPTION
This PR makes `Provider` and `Signer` `Send` so that they can be sent across threads.

This PR builds on the staled PR #92, but instead of simply dropping `?Send`, it only does so on non-wasm32 targets, otherwise wasm builds would break.