### PR TITLE
feat: expose `TransactionFailureReason`

### DIFF
--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -6,8 +6,8 @@ pub use block::{Block, BlockId};
 
 mod transaction;
 pub use transaction::{
-    DeployTransaction, EntryPointType, InvokeFunctionTransaction, TransactionInfo,
-    TransactionStatusInfo, TransactionType,
+    DeployTransaction, EntryPointType, InvokeFunctionTransaction, TransactionFailureReason,
+    TransactionInfo, TransactionStatusInfo, TransactionType,
 };
 
 mod transaction_receipt;


### PR DESCRIPTION
This PR exports `TransactionFailureReason` so that other applications can use it.