### PR TITLE
feat: wrap `SingleOwnerAccount` fields with `Arc`

### DIFF
--- a/examples/mint_tokens.rs
+++ b/examples/mint_tokens.rs
@@ -4,13 +4,14 @@ use starknet::{
     providers::SequencerGatewayProvider,
     signers::{LocalWallet, SigningKey},
 };
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() {
-    let provider = SequencerGatewayProvider::starknet_alpha_goerli();
-    let signer = LocalWallet::from(SigningKey::from_secret_scalar(
+    let provider = Arc::new(SequencerGatewayProvider::starknet_alpha_goerli());
+    let signer = Arc::new(LocalWallet::from(SigningKey::from_secret_scalar(
         FieldElement::from_hex_be("YOUR_PRIVATE_KEY_IN_HEX_HERE").unwrap(),
-    ));
+    )));
     let address = FieldElement::from_hex_be("YOUR_ACCOUNT_CONTRACT_ADDRESS_IN_HEX_HERE").unwrap();
     let tst_token_address = FieldElement::from_hex_be(
         "07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10",

--- a/starknet-accounts/src/single_owner.rs
+++ b/starknet-accounts/src/single_owner.rs
@@ -14,6 +14,7 @@ use starknet_core::{
 };
 use starknet_providers::Provider;
 use starknet_signers::Signer;
+use std::sync::Arc;
 
 /// Cairo string for "invoke"
 const PREFIX_INVOKE: FieldElement = FieldElement::from_mont([
@@ -37,9 +38,8 @@ where
     P: Provider + Send,
     S: Signer + Send,
 {
-    provider: P,
-    #[allow(unused)]
-    signer: S,
+    provider: Arc<P>,
+    signer: Arc<S>,
     address: FieldElement,
     chain_id: FieldElement,
 }
@@ -67,7 +67,12 @@ where
     P: Provider + Sync + Send,
     S: Signer + Sync + Send,
 {
-    pub fn new(provider: P, signer: S, address: FieldElement, chain_id: FieldElement) -> Self {
+    pub fn new(
+        provider: Arc<P>,
+        signer: Arc<S>,
+        address: FieldElement,
+        chain_id: FieldElement,
+    ) -> Self {
         Self {
             provider,
             signer,

--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -6,16 +6,17 @@ use starknet_core::{
 };
 use starknet_providers::SequencerGatewayProvider;
 use starknet_signers::{LocalWallet, SigningKey};
+use std::sync::Arc;
 
 #[tokio::test]
 async fn can_get_nonce() {
-    let provider = SequencerGatewayProvider::starknet_alpha_goerli();
-    let signer = LocalWallet::from(SigningKey::from_secret_scalar(
+    let provider = Arc::new(SequencerGatewayProvider::starknet_alpha_goerli());
+    let signer = Arc::new(LocalWallet::from(SigningKey::from_secret_scalar(
         FieldElement::from_hex_be(
             "00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
         )
         .unwrap(),
-    ));
+    )));
     let address = FieldElement::from_hex_be(
         "01352dd0ac2a462cb53e4f125169b28f13bd6199091a9815c444dcae83056bbc",
     )
@@ -31,13 +32,13 @@ async fn can_get_nonce() {
 
 #[tokio::test]
 async fn can_estimate_fee() {
-    let provider = SequencerGatewayProvider::starknet_alpha_goerli();
-    let signer = LocalWallet::from(SigningKey::from_secret_scalar(
+    let provider = Arc::new(SequencerGatewayProvider::starknet_alpha_goerli());
+    let signer = Arc::new(LocalWallet::from(SigningKey::from_secret_scalar(
         FieldElement::from_hex_be(
             "00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
         )
         .unwrap(),
-    ));
+    )));
     let address = FieldElement::from_hex_be(
         "01352dd0ac2a462cb53e4f125169b28f13bd6199091a9815c444dcae83056bbc",
     )
@@ -86,13 +87,13 @@ async fn can_execute_tst_mint() {
     //   - change to use a local testing network similar to Ganacha for Ethereum; or
     //   - poll the transaction hash until it's processed.
 
-    let provider = SequencerGatewayProvider::starknet_alpha_goerli();
-    let signer = LocalWallet::from(SigningKey::from_secret_scalar(
+    let provider = Arc::new(SequencerGatewayProvider::starknet_alpha_goerli());
+    let signer = Arc::new(LocalWallet::from(SigningKey::from_secret_scalar(
         FieldElement::from_hex_be(
             "00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
         )
         .unwrap(),
-    ));
+    )));
     let address = FieldElement::from_hex_be(
         "01352dd0ac2a462cb53e4f125169b28f13bd6199091a9815c444dcae83056bbc",
     )


### PR DESCRIPTION
**This is a breaking change.**

Similar to #120, this PR wraps `provider` and `signer` in `SingleOwnerAccount` with `Arc`.