### PR TITLE
feat: implement `Provider` for smart pointers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_impl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,6 +1242,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1744,6 +1780,7 @@ name = "starknet-providers"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "auto_impl",
  "reqwest",
  "serde",
  "serde_json",

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["ethereum", "starknet", "web3"]
 [dependencies]
 starknet-core = { version = "0.1.0", path = "../starknet-core" }
 async-trait = "0.1.52"
+auto_impl = "0.5.0"
 url = "2.2.2"
 reqwest = { version = "0.11.8" }
 thiserror = "1.0.30"

--- a/starknet-providers/src/provider.rs
+++ b/starknet-providers/src/provider.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use auto_impl::auto_impl;
 use starknet_core::types::{
     AddTransactionResult, Block, BlockId, CallContractResult, ContractAddresses, ContractArtifact,
     ContractCode, FeeEstimate, FieldElement, InvokeFunctionTransactionRequest, StateUpdate,
@@ -9,6 +10,7 @@ use std::error::Error;
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[auto_impl(&, Box, Arc)]
 pub trait Provider {
     type Error: Error + Send;
 


### PR DESCRIPTION
This PR uses `auto_impl` to implement `Provider` for `&Provider`, `Box<T> where T: Provider` and `Arc<T> where T: Provider`.

Changes in #120 should be reverted after this PR, as it achieves essentially the same thing without imposing the restriction on using `Arc` for users.