### PR TITLE
feat: remove `Arc` wrapper in `ContractFactory`

### DIFF
--- a/examples/deploy_contract.rs
+++ b/examples/deploy_contract.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use starknet::{
     contract::ContractFactory,
     core::types::{ContractArtifact, FieldElement},
@@ -11,7 +9,7 @@ async fn main() {
     let contract_artifact: ContractArtifact =
         serde_json::from_reader(std::fs::File::open("/path/to/contract/artifact.json").unwrap())
             .unwrap();
-    let provider = Arc::new(SequencerGatewayProvider::starknet_alpha_goerli());
+    let provider = SequencerGatewayProvider::starknet_alpha_goerli();
 
     let contract_factory = ContractFactory::new(contract_artifact, provider).unwrap();
     contract_factory

--- a/starknet-contract/src/factory.rs
+++ b/starknet-contract/src/factory.rs
@@ -5,7 +5,7 @@ use starknet_core::types::{
     EntryPointsByType, FieldElement, TransactionRequest,
 };
 use starknet_providers::Provider;
-use std::{io::Write, sync::Arc};
+use std::io::Write;
 
 pub struct Factory<P>
 where
@@ -14,7 +14,7 @@ where
     compressed_program: Vec<u8>,
     entry_points_by_type: EntryPointsByType,
     abi: Vec<AbiEntry>,
-    provider: Arc<P>,
+    provider: P,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -26,7 +26,7 @@ pub enum FactoryError {
 }
 
 impl<P: Provider> Factory<P> {
-    pub fn new(artifact: ContractArtifact, provider: Arc<P>) -> Result<Self, FactoryError> {
+    pub fn new(artifact: ContractArtifact, provider: P) -> Result<Self, FactoryError> {
         let program_json = serde_json::to_string(&artifact.program)
             .map_err(FactoryError::CannotSerializeProgram)?;
 

--- a/starknet-contract/tests/contract_deployment.rs
+++ b/starknet-contract/tests/contract_deployment.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use starknet_contract::ContractFactory;
 use starknet_core::types::{ContractArtifact, FieldElement};
 
@@ -9,7 +7,7 @@ async fn can_deploy_contract_to_alpha_goerli() {
         "../test-data/artifacts/oz_account.txt"
     ))
     .unwrap();
-    let provider = Arc::new(starknet_providers::SequencerGatewayProvider::starknet_alpha_goerli());
+    let provider = starknet_providers::SequencerGatewayProvider::starknet_alpha_goerli();
 
     let factory = ContractFactory::new(artifact, provider).unwrap();
 


### PR DESCRIPTION
Thanks to #131, changes made in #120 can now be reverted while still allowing users to pass in `Arc`-wrapped instances.

This PR reverts changes made in #120.