### PR TITLE
ci: speed up lint CI with Rust cache

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
+      - name: Use Rust cache
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
       - name: Install prettier
         run: |
           yarn global add prettier


### PR DESCRIPTION
This PR adds caching to the `lint` CI pipeline to speed things up.