### PR TITLE
fix: fix deserialization error on get_full_contract

### DIFF
--- a/starknet-core/src/types/contract_artifact.rs
+++ b/starknet-core/src/types/contract_artifact.rs
@@ -25,7 +25,7 @@ pub struct Program {
     pub data: Vec<FieldElement>,
     #[serde(skip_serializing)]
     pub debug_info: Option<serde::de::IgnoredAny>, // Skipped since it's not used in deployment
-    pub hints: BTreeMap<u64, Vec<Hint>>,
+    pub hints: BTreeMap<String, Vec<Hint>>,
     pub identifiers: BTreeMap<String, Identifier>,
     pub main_scope: String,
     // Impossible to use [FieldElement] here as by definition field elements are smaller

--- a/starknet-providers/src/sequencer_gateway.rs
+++ b/starknet-providers/src/sequencer_gateway.rs
@@ -541,4 +541,13 @@ mod tests {
         ))
         .unwrap();
     }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    fn test_get_full_contract_deser() {
+        serde_json::from_str::<GatewayResponse<ContractArtifact>>(include_str!(
+            "../test-data/get_full_contract/1_code.txt"
+        ))
+        .unwrap();
+    }
 }


### PR DESCRIPTION
This PR fixes yet another clashing of `untagged` and `arbitrary_precision`.

Reference: https://github.com/xJonathanLEI/starknet-rs/issues/76#issuecomment-1058193448