### PR TITLE
release: publish packages to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,7 +1571,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "starknet"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde_json",
  "starknet-accounts",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "ethereum-types",
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -27,8 +27,8 @@ members = [
 ]
 
 [dependencies]
-starknet-core = { version = "0.1.0", path = "./starknet-core" }
-starknet-providers = { version = "0.1.0", path = "./starknet-providers" }
+starknet-core = { version = "0.2.0", path = "./starknet-core" }
+starknet-providers = { version = "0.2.0", path = "./starknet-providers" }
 starknet-contract = { version = "0.1.0", path = "./starknet-contract" }
 starknet-signers = { version = "0.1.0", path = "./starknet-signers" }
 starknet-accounts = { version = "0.1.0", path = "./starknet-accounts" }

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -13,8 +13,8 @@ Types for handling StarkNet account abstraction
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.1.0", path = "../starknet-core" }
-starknet-providers = { version = "0.1.0", path = "../starknet-providers" }
+starknet-core = { version = "0.2.0", path = "../starknet-core" }
+starknet-providers = { version = "0.2.0", path = "../starknet-providers" }
 starknet-signers = { version = "0.1.0", path = "../starknet-signers" }
 async-trait = "0.1.52"
 thiserror = "1.0.30"

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -13,8 +13,8 @@ Types and utilities for StarkNet smart contract deployment and interaction
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.1.0", path = "../starknet-core" }
-starknet-providers = { version = "0.1.0", path = "../starknet-providers" }
+starknet-core = { version = "0.2.0", path = "../starknet-core" }
+starknet-providers = { version = "0.2.0", path = "../starknet-providers" }
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
 serde_with = "1.12.0"

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-core"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-providers"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,7 +13,7 @@ Provider implementations for the starknet crate
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.1.0", path = "../starknet-core" }
+starknet-core = { version = "0.2.0", path = "../starknet-core" }
 async-trait = "0.1.52"
 auto_impl = "0.5.0"
 url = "2.2.2"

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -13,7 +13,7 @@ StarkNet signer implementations
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.1.0", path = "../starknet-core" }
+starknet-core = { version = "0.2.0", path = "../starknet-core" }
 starknet-crypto = { version = "0.1.0", path = "../starknet-crypto" }
 async-trait = "0.1.52"
 thiserror = "1.0.30"


### PR DESCRIPTION
Releasing the following crates:

- `starknet-ff` v0.1.0
- `starknet-crypto` v0.1.0
- `starknet-core` v0.2.0
- `starknet-providers` v0.2.0
- `starknet-signers` v0.1.0
- `starknet-contract` v0.1.0
- `starknet-accounts` v0.1.0
- `starknet` v0.2.0