### PR TITLE
feat: export BlockStatus

### DIFF
--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -2,7 +2,7 @@
 pub use ethereum_types::Address as L1Address;
 
 mod block;
-pub use block::{Block, BlockId};
+pub use block::{Block, BlockId, BlockStatus};
 
 mod transaction;
 pub use transaction::{


### PR DESCRIPTION
Block status is also needed when interacting with the new json rpc.﻿
