### PR TITLE
feat: implement basic JSON-RPC client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,6 +1580,7 @@ dependencies = [
  "starknet-providers",
  "starknet-signers",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,6 +1673,7 @@ dependencies = [
  "serde_with",
  "starknet-core",
  "thiserror",
+ "tokio",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,6 @@ starknet-signers = { version = "0.1.0", path = "./starknet-signers" }
 starknet-accounts = { version = "0.1.0", path = "./starknet-accounts" }
 
 [dev-dependencies]
-tokio = { version = "1.15.0", features = ["full"] }
 serde_json = "1.0.74"
+tokio = { version = "1.15.0", features = ["full"] }
+url = "2.2.2"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Examples can be found in the [examples folder](./examples):
 
 4. [Declare contract on `alpha-goerli` testnet](./examples/declare_contract.rs)
 
+5. [Query the latest block number with JSON-RPC](./examples/jsonrpc.rs)
+
 ## License
 
 Licensed under either of

--- a/examples/jsonrpc.rs
+++ b/examples/jsonrpc.rs
@@ -1,0 +1,12 @@
+use starknet_providers::jsonrpc::{HttpTransport, JsonRpcClient};
+use url::Url;
+
+#[tokio::main]
+async fn main() {
+    let rpc_client = JsonRpcClient::new(HttpTransport::new(
+        Url::parse("https://starknet-goerli.cartridge.gg/").unwrap(),
+    ));
+
+    let block_number = rpc_client.block_number().await.unwrap();
+    println!("{}", block_number);
+}

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -17,8 +17,11 @@ starknet-core = { version = "0.2.0", path = "../starknet-core" }
 async-trait = "0.1.52"
 auto_impl = "0.5.0"
 url = "2.2.2"
-reqwest = { version = "0.11.8", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11.8", default-features = false, features = ["json", "rustls-tls"] }
 thiserror = "1.0.30"
 serde = "1.0.133"
 serde_json = "1.0.74"
 serde_with = "1.12.0"
+
+[dev-dependencies]
+tokio = { version = "1.15.0", features = ["full"] }

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -1,0 +1,50 @@
+use serde::{Deserialize, Serialize};
+
+mod transports;
+pub use transports::{HttpTransport, JsonRpcTransport};
+
+#[derive(Debug)]
+pub struct JsonRpcClient<T> {
+    transport: T,
+}
+
+#[derive(Debug, Serialize)]
+pub enum JsonRpcMethod {
+    #[serde(rename = "starknet_blockNumber")]
+    BlockNumber,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcRequest<T> {
+    id: u64,
+    jsonrpc: &'static str,
+    method: JsonRpcMethod,
+    params: T,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcResponse<T> {
+    #[allow(unused)]
+    id: u64,
+    #[allow(unused)]
+    jsonrpc: String,
+    result: T,
+}
+
+impl<T> JsonRpcClient<T> {
+    pub fn new(transport: T) -> Self {
+        Self { transport }
+    }
+}
+
+impl<T> JsonRpcClient<T>
+where
+    T: JsonRpcTransport,
+{
+    /// Get the most recent accepted block number
+    pub async fn block_number(&self) -> Result<u64, T::Error> {
+        self.transport
+            .send_request(JsonRpcMethod::BlockNumber, ())
+            .await
+    }
+}

--- a/starknet-providers/src/jsonrpc/transports/http.rs
+++ b/starknet-providers/src/jsonrpc/transports/http.rs
@@ -1,0 +1,45 @@
+use async_trait::async_trait;
+use reqwest::{Client, Url};
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::jsonrpc::{
+    transports::JsonRpcTransport, JsonRpcMethod, JsonRpcRequest, JsonRpcResponse,
+};
+
+#[derive(Debug)]
+pub struct HttpTransport {
+    client: Client,
+    url: Url,
+}
+
+impl HttpTransport {
+    pub fn new(url: impl Into<Url>) -> Self {
+        Self {
+            client: Client::new(),
+            url: url.into(),
+        }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl JsonRpcTransport for HttpTransport {
+    type Error = reqwest::Error;
+
+    async fn send_request<P, R>(&self, method: JsonRpcMethod, params: P) -> Result<R, Self::Error>
+    where
+        P: Serialize + Send,
+        R: DeserializeOwned,
+    {
+        let request = self.client.post(self.url.clone()).json(&JsonRpcRequest {
+            id: 1,
+            jsonrpc: "2.0",
+            method,
+            params,
+        });
+        let response = request.send().await?;
+
+        let body: JsonRpcResponse<R> = response.json().await?;
+        Ok(body.result)
+    }
+}

--- a/starknet-providers/src/jsonrpc/transports/mod.rs
+++ b/starknet-providers/src/jsonrpc/transports/mod.rs
@@ -1,0 +1,20 @@
+use async_trait::async_trait;
+use auto_impl::auto_impl;
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::jsonrpc::JsonRpcMethod;
+
+mod http;
+pub use http::HttpTransport;
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[auto_impl(&, Box, Arc)]
+pub trait JsonRpcTransport {
+    type Error;
+
+    async fn send_request<P, R>(&self, method: JsonRpcMethod, params: P) -> Result<R, Self::Error>
+    where
+        P: Serialize + Send,
+        R: DeserializeOwned;
+}

--- a/starknet-providers/src/lib.rs
+++ b/starknet-providers/src/lib.rs
@@ -5,3 +5,5 @@ pub use provider::Provider;
 
 mod sequencer_gateway;
 pub use sequencer_gateway::SequencerGatewayProvider;
+
+pub mod jsonrpc;

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -1,0 +1,16 @@
+use starknet_providers::jsonrpc::{HttpTransport, JsonRpcClient};
+use url::Url;
+
+fn create_jsonrpc_client() -> JsonRpcClient<HttpTransport> {
+    JsonRpcClient::new(HttpTransport::new(
+        Url::parse("https://starknet-goerli.cartridge.gg/").unwrap(),
+    ))
+}
+
+#[tokio::test]
+async fn jsonrpc_block_number() {
+    let rpc_client = create_jsonrpc_client();
+
+    let block_number = rpc_client.block_number().await.unwrap();
+    assert!(block_number > 0);
+}


### PR DESCRIPTION
This PR partially implements #77 by adding a basic JSON-RPC client over HTTP.

Currently, the client only implements a single method `starknet_blockNumber`, with more methods to be implemented by future PRs.