### PR TITLE
feat(jsonrpc): implement starknet_call

### DIFF
--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -1,7 +1,16 @@
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_with::serde_as;
+use starknet_core::{serde::unsigned_field_element::UfeHex, types::FieldElement};
+
+use crate::jsonrpc::models::*;
 
 mod transports;
 pub use transports::{HttpTransport, JsonRpcTransport};
+
+/// Temporary module for holding JSON-RPC data models until the provider switch:
+///
+/// https://github.com/xJonathanLEI/starknet-rs/issues/77#issuecomment-1150184364
+pub mod models;
 
 #[derive(Debug)]
 pub struct JsonRpcClient<T> {
@@ -12,10 +21,14 @@ pub struct JsonRpcClient<T> {
 pub enum JsonRpcMethod {
     #[serde(rename = "starknet_blockNumber")]
     BlockNumber,
+    #[serde(rename = "starknet_call")]
+    Call,
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum JsonRpcClientError<T> {
+    #[error(transparent)]
+    JsonError(serde_json::Error),
     #[error(transparent)]
     TransportError(T),
     #[error(transparent)]
@@ -44,6 +57,10 @@ struct JsonRpcRequest<T> {
     params: T,
 }
 
+#[serde_as]
+#[derive(Deserialize)]
+struct FeltArray(#[serde_as(as = "Vec<UfeHex>")] pub Vec<FieldElement>);
+
 impl<T> JsonRpcClient<T> {
     pub fn new(transport: T) -> Self {
         Self { transport }
@@ -56,14 +73,50 @@ where
 {
     /// Get the most recent accepted block number
     pub async fn block_number(&self) -> Result<u64, JsonRpcClientError<T::Error>> {
+        self.send_request(JsonRpcMethod::BlockNumber, ()).await
+    }
+
+    /// Call a starknet function without creating a StarkNet transaction
+    pub async fn call(
+        &self,
+        request: &FunctionCall,
+        block_hash: &BlockHashOrTag,
+    ) -> Result<Vec<FieldElement>, JsonRpcClientError<T::Error>> {
+        Ok(self
+            .send_request::<_, FeltArray>(
+                JsonRpcMethod::Call,
+                [
+                    serde_json::to_value(request)?,
+                    serde_json::to_value(block_hash)?,
+                ],
+            )
+            .await?
+            .0)
+    }
+
+    async fn send_request<P, R>(
+        &self,
+        method: JsonRpcMethod,
+        params: P,
+    ) -> Result<R, JsonRpcClientError<T::Error>>
+    where
+        P: Serialize + Send,
+        R: DeserializeOwned,
+    {
         match self
             .transport
-            .send_request(JsonRpcMethod::BlockNumber, ())
+            .send_request(method, params)
             .await
             .map_err(JsonRpcClientError::TransportError)?
         {
             JsonRpcResponse::Success { result, .. } => Ok(result),
             JsonRpcResponse::Error { error, .. } => Err(JsonRpcClientError::RpcError(error)),
         }
+    }
+}
+
+impl<T> From<serde_json::Error> for JsonRpcClientError<T> {
+    fn from(value: serde_json::Error) -> Self {
+        Self::JsonError(value)
     }
 }

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use starknet_core::{serde::unsigned_field_element::UfeHex, types::FieldElement};
+
+/// Function call information
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionCall {
+    #[serde_as(as = "UfeHex")]
+    pub contract_address: FieldElement,
+    #[serde_as(as = "UfeHex")]
+    pub entry_point_selector: FieldElement,
+    /// The parameters passed to the function
+    #[serde_as(as = "Vec<UfeHex>")]
+    pub calldata: Vec<FieldElement>,
+}
+
+/// Block hash or tag
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum BlockHashOrTag {
+    Hash(#[serde_as(as = "UfeHex")] FieldElement),
+    Tag(BlockTag),
+}
+
+/// A tag specifying a dynamic reference to a block
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum BlockTag {
+    #[serde(rename = "latest")]
+    Latest,
+    // The current spec doesn't allow `pending` but is probably inaccurate:
+    //   https://github.com/starkware-libs/starknet-specs/blob/bcce12075ef4cde19fc62b47ed2162292e0ed70d/api/starknet_api_openrpc.json#L821-L828
+    #[serde(rename = "pending")]
+    Pending,
+}

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -1,4 +1,8 @@
-use starknet_providers::jsonrpc::{HttpTransport, JsonRpcClient};
+use starknet_core::{types::FieldElement, utils::get_selector_from_name};
+use starknet_providers::jsonrpc::{
+    models::{BlockHashOrTag, BlockTag, FunctionCall},
+    HttpTransport, JsonRpcClient,
+};
 use url::Url;
 
 fn create_jsonrpc_client() -> JsonRpcClient<HttpTransport> {
@@ -13,4 +17,30 @@ async fn jsonrpc_block_number() {
 
     let block_number = rpc_client.block_number().await.unwrap();
     assert!(block_number > 0);
+}
+
+#[tokio::test]
+async fn jsonrpc_call() {
+    let rpc_client = create_jsonrpc_client();
+
+    // Checks L2 ETH balance
+    let eth_balance = rpc_client
+        .call(
+            &FunctionCall {
+                contract_address: FieldElement::from_hex_be(
+                    "049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                )
+                .unwrap(),
+                entry_point_selector: get_selector_from_name("balanceOf").unwrap(),
+                calldata: vec![FieldElement::from_hex_be(
+                    "01352dd0ac2a462cb53e4f125169b28f13bd6199091a9815c444dcae83056bbc",
+                )
+                .unwrap()],
+            },
+            &BlockHashOrTag::Tag(BlockTag::Latest),
+        )
+        .await
+        .unwrap();
+
+    assert!(eth_balance[0] > FieldElement::ZERO);
 }


### PR DESCRIPTION
This PR partially implements #77 by implementing the `starknet_call` JSON-RPC method.