### PR TITLE
feat(jsonrpc): implement more JSON-RPC methods

### DIFF
--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -23,6 +23,8 @@ pub enum JsonRpcMethod {
     BlockNumber,
     #[serde(rename = "starknet_chainId")]
     ChainId,
+    #[serde(rename = "starknet_syncing")]
+    Syncing,
     #[serde(rename = "starknet_call")]
     Call,
 }
@@ -88,6 +90,11 @@ where
             .send_request::<_, Felt>(JsonRpcMethod::ChainId, ())
             .await?
             .0)
+    }
+
+    /// Returns an object about the sync status, or false if the node is not synching
+    pub async fn syncing(&self) -> Result<SyncStatusType, JsonRpcClientError<T::Error>> {
+        self.send_request(JsonRpcMethod::Syncing, ()).await
     }
 
     /// Call a starknet function without creating a StarkNet transaction

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -21,6 +21,8 @@ pub struct JsonRpcClient<T> {
 pub enum JsonRpcMethod {
     #[serde(rename = "starknet_blockNumber")]
     BlockNumber,
+    #[serde(rename = "starknet_chainId")]
+    ChainId,
     #[serde(rename = "starknet_call")]
     Call,
 }
@@ -59,6 +61,10 @@ struct JsonRpcRequest<T> {
 
 #[serde_as]
 #[derive(Deserialize)]
+struct Felt(#[serde_as(as = "UfeHex")] pub FieldElement);
+
+#[serde_as]
+#[derive(Deserialize)]
 struct FeltArray(#[serde_as(as = "Vec<UfeHex>")] pub Vec<FieldElement>);
 
 impl<T> JsonRpcClient<T> {
@@ -74,6 +80,14 @@ where
     /// Get the most recent accepted block number
     pub async fn block_number(&self) -> Result<u64, JsonRpcClientError<T::Error>> {
         self.send_request(JsonRpcMethod::BlockNumber, ()).await
+    }
+
+    /// Return the currently configured StarkNet chain id
+    pub async fn chain_id(&self) -> Result<FieldElement, JsonRpcClientError<T::Error>> {
+        Ok(self
+            .send_request::<_, Felt>(JsonRpcMethod::ChainId, ())
+            .await?
+            .0)
     }
 
     /// Call a starknet function without creating a StarkNet transaction

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -2,6 +2,11 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use starknet_core::{serde::unsigned_field_element::UfeHex, types::FieldElement};
 
+use crate::jsonrpc::models::serde_impls::NumAsHex;
+
+// Not exposed by design
+mod serde_impls;
+
 /// Function call information
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -33,4 +38,34 @@ pub enum BlockTag {
     //   https://github.com/starkware-libs/starknet-specs/blob/bcce12075ef4cde19fc62b47ed2162292e0ed70d/api/starknet_api_openrpc.json#L821-L828
     #[serde(rename = "pending")]
     Pending,
+}
+
+#[derive(Debug, Clone)]
+pub enum SyncStatusType {
+    Syncing(SyncStatus),
+    NotSyncing,
+}
+
+/// An object describing the node synchronization status
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncStatus {
+    /// The hash of the block from which the sync started
+    #[serde_as(as = "UfeHex")]
+    pub starting_block_hash: FieldElement,
+    /// The number (height) of the block from which the sync started
+    #[serde_as(as = "NumAsHex")]
+    pub starting_block_num: u64,
+    /// The hash of the current block being synchronized
+    #[serde_as(as = "UfeHex")]
+    pub current_block_hash: FieldElement,
+    /// The number (height) of the current block being synchronized
+    #[serde_as(as = "NumAsHex")]
+    pub current_block_num: u64,
+    /// The hash of the estimated highest block to be synchronized
+    #[serde_as(as = "UfeHex")]
+    pub highest_block_hash: FieldElement,
+    /// The number (height) of the estimated highest block to be synchronized
+    #[serde_as(as = "NumAsHex")]
+    pub highest_block_num: u64,
 }

--- a/starknet-providers/src/jsonrpc/models/serde_impls.rs
+++ b/starknet-providers/src/jsonrpc/models/serde_impls.rs
@@ -1,0 +1,66 @@
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_with::{DeserializeAs, SerializeAs};
+
+use super::{SyncStatus, SyncStatusType};
+
+pub(crate) struct NumAsHex;
+
+impl SerializeAs<u64> for NumAsHex {
+    fn serialize_as<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&format!("{:#x}", value))
+    }
+}
+
+impl<'de> DeserializeAs<'de, u64> for NumAsHex {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        match u64::from_str_radix(&value[2..], 16) {
+            Ok(value) => Ok(value),
+            Err(err) => Err(serde::de::Error::custom(format!(
+                "invalid hex string: {}",
+                err
+            ))),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum SyncStatusTypeDe {
+    Boolean(bool),
+    SyncStatus(SyncStatus),
+}
+
+impl Serialize for SyncStatusType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            SyncStatusType::NotSyncing => serializer.serialize_bool(false),
+            SyncStatusType::Syncing(sync_status) => SyncStatus::serialize(sync_status, serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SyncStatusType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match SyncStatusTypeDe::deserialize(deserializer)? {
+            SyncStatusTypeDe::Boolean(value) => match value {
+                true => Err(serde::de::Error::custom("invalid boolean value")),
+
+                false => Ok(Self::NotSyncing),
+            },
+            SyncStatusTypeDe::SyncStatus(value) => Ok(SyncStatusType::Syncing(value)),
+        }
+    }
+}

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -1,6 +1,6 @@
 use starknet_core::{types::FieldElement, utils::get_selector_from_name};
 use starknet_providers::jsonrpc::{
-    models::{BlockHashOrTag, BlockTag, FunctionCall},
+    models::{BlockHashOrTag, BlockTag, FunctionCall, SyncStatusType},
     HttpTransport, JsonRpcClient,
 };
 use url::Url;
@@ -25,6 +25,16 @@ async fn jsonrpc_chain_id() {
 
     let chain_id = rpc_client.chain_id().await.unwrap();
     assert!(chain_id > FieldElement::ZERO);
+}
+
+#[tokio::test]
+async fn jsonrpc_syncing() {
+    let rpc_client = create_jsonrpc_client();
+
+    let syncing = rpc_client.syncing().await.unwrap();
+    if let SyncStatusType::Syncing(sync_status) = syncing {
+        assert!(sync_status.highest_block_num > 0);
+    }
 }
 
 #[tokio::test]

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -20,6 +20,14 @@ async fn jsonrpc_block_number() {
 }
 
 #[tokio::test]
+async fn jsonrpc_chain_id() {
+    let rpc_client = create_jsonrpc_client();
+
+    let chain_id = rpc_client.chain_id().await.unwrap();
+    assert!(chain_id > FieldElement::ZERO);
+}
+
+#[tokio::test]
 async fn jsonrpc_call() {
     let rpc_client = create_jsonrpc_client();
 


### PR DESCRIPTION
This PR partially implements #77 by adding support for the following methods:

- `starknet_chainId`
- `starknet_syncing`
- `starknet_getStorageAt`