### PR TITLE
feat(jsonrpc): implement block query methods

### DIFF
--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -19,6 +19,8 @@ pub struct JsonRpcClient<T> {
 
 #[derive(Debug, Serialize)]
 pub enum JsonRpcMethod {
+    #[serde(rename = "starknet_getBlockByHash")]
+    GetBlockByHash,
     #[serde(rename = "starknet_getStorageAt")]
     GetStorageAt,
     #[serde(rename = "starknet_blockNumber")]
@@ -63,6 +65,14 @@ struct JsonRpcRequest<T> {
     params: T,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum BlockResponseScopeOptions {
+    TxnHash,
+    FullTxns,
+    FullTxnAndReceipts,
+}
+
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 struct Felt(#[serde_as(as = "UfeHex")] pub FieldElement);
@@ -81,6 +91,51 @@ impl<T> JsonRpcClient<T>
 where
     T: JsonRpcTransport,
 {
+    /// Get block information given the block id
+    pub async fn get_block_by_hash(
+        &self,
+        block_hash: &BlockHashOrTag,
+    ) -> Result<Block, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetBlockByHash,
+            [
+                serde_json::to_value(block_hash)?,
+                serde_json::to_value(BlockResponseScopeOptions::TxnHash)?,
+            ],
+        )
+        .await
+    }
+
+    /// Get block information given the block id
+    pub async fn get_block_by_hash_with_txns(
+        &self,
+        block_hash: &BlockHashOrTag,
+    ) -> Result<BlockWithTxns, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetBlockByHash,
+            [
+                serde_json::to_value(block_hash)?,
+                serde_json::to_value(BlockResponseScopeOptions::FullTxns)?,
+            ],
+        )
+        .await
+    }
+
+    /// Get block information given the block id
+    pub async fn get_block_by_hash_with_receipts(
+        &self,
+        block_hash: &BlockHashOrTag,
+    ) -> Result<BlockWithReceipts, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetBlockByHash,
+            [
+                serde_json::to_value(block_hash)?,
+                serde_json::to_value(BlockResponseScopeOptions::FullTxnAndReceipts)?,
+            ],
+        )
+        .await
+    }
+
     /// Get the value of the storage at the given address and key
     pub async fn get_storage_at(
         &self,

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -21,6 +21,8 @@ pub struct JsonRpcClient<T> {
 pub enum JsonRpcMethod {
     #[serde(rename = "starknet_getBlockByHash")]
     GetBlockByHash,
+    #[serde(rename = "starknet_getBlockByNumber")]
+    GetBlockByNumber,
     #[serde(rename = "starknet_getStorageAt")]
     GetStorageAt,
     #[serde(rename = "starknet_blockNumber")]
@@ -130,6 +132,51 @@ where
             JsonRpcMethod::GetBlockByHash,
             [
                 serde_json::to_value(block_hash)?,
+                serde_json::to_value(BlockResponseScopeOptions::FullTxnAndReceipts)?,
+            ],
+        )
+        .await
+    }
+
+    /// Get block information given the block number (its height)
+    pub async fn get_block_by_number(
+        &self,
+        block_number: &BlockNumOrTag,
+    ) -> Result<Block, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetBlockByNumber,
+            [
+                serde_json::to_value(block_number)?,
+                serde_json::to_value(BlockResponseScopeOptions::TxnHash)?,
+            ],
+        )
+        .await
+    }
+
+    /// Get block information given the block number (its height)
+    pub async fn get_block_by_number_with_txns(
+        &self,
+        block_number: &BlockNumOrTag,
+    ) -> Result<BlockWithTxns, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetBlockByNumber,
+            [
+                serde_json::to_value(block_number)?,
+                serde_json::to_value(BlockResponseScopeOptions::FullTxns)?,
+            ],
+        )
+        .await
+    }
+
+    /// Get block information given the block number (its height)
+    pub async fn get_block_by_number_with_receipts(
+        &self,
+        block_number: &BlockNumOrTag,
+    ) -> Result<BlockWithReceipts, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetBlockByNumber,
+            [
+                serde_json::to_value(block_number)?,
                 serde_json::to_value(BlockResponseScopeOptions::FullTxnAndReceipts)?,
             ],
         )

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -7,6 +7,39 @@ use crate::jsonrpc::models::serde_impls::NumAsHex;
 // Not exposed by design
 mod serde_impls;
 
+pub use starknet_core::types::L1Address as EthAddress;
+
+/// A StarkNet event
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Event {
+    #[serde_as(as = "UfeHex")]
+    pub from_address: FieldElement,
+    #[serde(flatten)]
+    pub content: EventContent,
+}
+
+/// The content of an event
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventContent {
+    #[serde_as(as = "Vec<UfeHex>")]
+    pub keys: Vec<FieldElement>,
+    #[serde_as(as = "Vec<UfeHex>")]
+    pub data: Vec<FieldElement>,
+}
+
+/// The status of the block
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum BlockStatus {
+    Pending,
+    Proven,
+    AcceptedOnL2,
+    AcceptedOnL1,
+    Rejected,
+}
+
 /// Function call information
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31,12 +64,11 @@ pub enum BlockHashOrTag {
 
 /// A tag specifying a dynamic reference to a block
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum BlockTag {
-    #[serde(rename = "latest")]
     Latest,
     // The current spec doesn't allow `pending` but is probably inaccurate:
     //   https://github.com/starkware-libs/starknet-specs/blob/bcce12075ef4cde19fc62b47ed2162292e0ed70d/api/starknet_api_openrpc.json#L821-L828
-    #[serde(rename = "pending")]
     Pending,
 }
 
@@ -68,4 +100,167 @@ pub struct SyncStatus {
     /// The number (height) of the estimated highest block to be synchronized
     #[serde_as(as = "NumAsHex")]
     pub highest_block_num: u64,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Block {
+    #[serde(flatten)]
+    pub metadata: BlockMeta,
+    #[serde_as(as = "Vec<UfeHex>")]
+    pub transactions: Vec<FieldElement>,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockWithTxns {
+    #[serde(flatten)]
+    pub metadata: BlockMeta,
+    pub transactions: Vec<Transaction>,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockWithReceipts {
+    #[serde(flatten)]
+    pub metadata: BlockMeta,
+    pub transactions: Vec<TransactionWithReceipt>,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockMeta {
+    #[serde_as(as = "UfeHex")]
+    pub block_hash: FieldElement,
+    /// The hash of this block's parent
+    #[serde_as(as = "UfeHex")]
+    pub parent_hash: FieldElement,
+    /// The block number (its height)
+    pub block_number: u64,
+    pub status: BlockStatus,
+    /// The identity of the sequencer submitting this block
+    #[serde_as(as = "UfeHex")]
+    // This should be `ETH_ADDRESS` according to spec but it seems to be wrong
+    pub sequencer: FieldElement,
+    /// The new global state root
+    #[serde_as(as = "UfeHex")]
+    pub new_root: FieldElement,
+    /// The previous global state root
+    #[serde_as(as = "UfeHex")]
+    pub old_root: FieldElement,
+    /// When the block was accepted on L1. Formatted as...
+    pub accepted_time: u64,
+}
+
+// Cannot use `#[serde(flatten)]` here due to `tx_hash` field collision, so unfortunately we have
+// to write duplicate code.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransactionWithReceipt {
+    #[serde_as(as = "UfeHex")]
+    pub contract_address: FieldElement,
+    // None for deploy txs
+    #[serde(default)]
+    #[serde_as(as = "Option<UfeHex>")]
+    pub entry_point_selector: Option<FieldElement>,
+    // None for deploy txs
+    #[serde(default)]
+    #[serde_as(as = "Option<Vec<UfeHex>>")]
+    pub calldata: Option<Vec<FieldElement>>,
+    /// The hash identifying the transaction
+    #[serde_as(as = "UfeHex")]
+    pub txn_hash: FieldElement,
+    /// The maximal fee that can be charged for including the transaction (None for non-invoke
+    /// transactions).
+    #[serde(default)]
+    #[serde_as(as = "Option<UfeHex>")]
+    pub max_fee: Option<FieldElement>,
+    /// The fee that was charged by the sequencer
+    #[serde_as(as = "UfeHex")]
+    pub actual_fee: FieldElement,
+    pub status: TransactionStatus,
+    /// Extra information pertaining to the status
+    pub status_data: String,
+    pub messages_sent: Vec<MsgToL1>,
+    /// In case this transaction was an L1 handler, this is the original message that invoked it
+    pub l1_origin_message: Option<MsgToL2>,
+    /// The events emitted as part of this transaction
+    pub events: Vec<Event>,
+}
+
+// Manually porting the `FunctionCall` fields here instead of flattening like the specification
+// suggests because `entry_point_selector` and `calldata` can be `None` for non-invoke transactions
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Transaction {
+    #[serde_as(as = "UfeHex")]
+    pub contract_address: FieldElement,
+    // None for deploy txs
+    #[serde(default)]
+    #[serde_as(as = "Option<UfeHex>")]
+    pub entry_point_selector: Option<FieldElement>,
+    // None for deploy txs
+    #[serde(default)]
+    #[serde_as(as = "Option<Vec<UfeHex>>")]
+    pub calldata: Option<Vec<FieldElement>>,
+    /// The hash identifying the transaction
+    #[serde_as(as = "UfeHex")]
+    pub txn_hash: FieldElement,
+    /// The maximal fee that can be charged for including the transaction (None for non-invoke
+    /// transactions).
+    #[serde(default)]
+    #[serde_as(as = "Option<UfeHex>")]
+    pub max_fee: Option<FieldElement>,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransactionReceipt {
+    /// The hash identifying the transaction
+    #[serde_as(as = "UfeHex")]
+    pub txn_hash: FieldElement,
+    /// The fee that was charged by the sequencer
+    #[serde_as(as = "UfeHex")]
+    pub actual_fee: FieldElement,
+    pub status: TransactionStatus,
+    /// Extra information pertaining to the status
+    pub status_data: String,
+    pub messages_sent: Vec<MsgToL1>,
+    /// In case this transaction was an L1 handler, this is the original message that invoked it
+    pub l1_origin_message: Option<MsgToL2>,
+    /// The events emitted as part of this transaction
+    pub events: Vec<Event>,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MsgToL1 {
+    /// The target L1 address the message is sent to
+    #[serde_as(as = "UfeHex")]
+    pub to_address: FieldElement,
+    /// The payload of the message
+    #[serde_as(as = "Vec<UfeHex>")]
+    pub payload: Vec<FieldElement>,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MsgToL2 {
+    /// The originating L1 contract that sent the message
+    pub from_address: EthAddress,
+    /// The payload of the meesage. The call data to the L1 handler
+    #[serde_as(as = "Vec<UfeHex>")]
+    pub payload: Vec<FieldElement>,
+}
+
+/// The status of the transaction. May be unknown in case node is not aware of it
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TransactionStatus {
+    Unknown,
+    Received,
+    Pending,
+    AcceptedOnL2,
+    AcceptedOnL1,
+    Rejected,
 }

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -62,6 +62,15 @@ pub enum BlockHashOrTag {
     Tag(BlockTag),
 }
 
+/// Block number or tag
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum BlockNumOrTag {
+    Number(u64),
+    Tag(BlockTag),
+}
+
 /// A tag specifying a dynamic reference to a block
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -15,6 +15,39 @@ fn create_jsonrpc_client() -> JsonRpcClient<HttpTransport> {
 }
 
 #[tokio::test]
+async fn jsonrpc_get_block_by_hash() {
+    let rpc_client = create_jsonrpc_client();
+
+    let block = rpc_client
+        .get_block_by_hash(&BlockHashOrTag::Tag(BlockTag::Latest))
+        .await
+        .unwrap();
+    assert!(block.metadata.block_number > 0);
+}
+
+#[tokio::test]
+async fn jsonrpc_get_block_by_hash_with_txns() {
+    let rpc_client = create_jsonrpc_client();
+
+    let block = rpc_client
+        .get_block_by_hash_with_txns(&BlockHashOrTag::Tag(BlockTag::Latest))
+        .await
+        .unwrap();
+    assert!(block.metadata.block_number > 0);
+}
+
+#[tokio::test]
+async fn jsonrpc_get_block_by_hash_with_receipts() {
+    let rpc_client = create_jsonrpc_client();
+
+    let block = rpc_client
+        .get_block_by_hash_with_receipts(&BlockHashOrTag::Tag(BlockTag::Latest))
+        .await
+        .unwrap();
+    assert!(block.metadata.block_number > 0);
+}
+
+#[tokio::test]
 async fn jsonrpc_get_storage_at() {
     let rpc_client = create_jsonrpc_client();
 

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -3,7 +3,7 @@ use starknet_core::{
     utils::{get_selector_from_name, get_storage_var_address},
 };
 use starknet_providers::jsonrpc::{
-    models::{BlockHashOrTag, BlockTag, FunctionCall, SyncStatusType},
+    models::{BlockHashOrTag, BlockNumOrTag, BlockTag, FunctionCall, SyncStatusType},
     HttpTransport, JsonRpcClient,
 };
 use url::Url;
@@ -42,6 +42,39 @@ async fn jsonrpc_get_block_by_hash_with_receipts() {
 
     let block = rpc_client
         .get_block_by_hash_with_receipts(&BlockHashOrTag::Tag(BlockTag::Latest))
+        .await
+        .unwrap();
+    assert!(block.metadata.block_number > 0);
+}
+
+#[tokio::test]
+async fn jsonrpc_get_block_by_number() {
+    let rpc_client = create_jsonrpc_client();
+
+    let block = rpc_client
+        .get_block_by_number(&BlockNumOrTag::Number(234469))
+        .await
+        .unwrap();
+    assert!(block.metadata.block_number > 0);
+}
+
+#[tokio::test]
+async fn jsonrpc_get_block_by_number_with_txns() {
+    let rpc_client = create_jsonrpc_client();
+
+    let block = rpc_client
+        .get_block_by_number_with_txns(&BlockNumOrTag::Number(234469))
+        .await
+        .unwrap();
+    assert!(block.metadata.block_number > 0);
+}
+
+#[tokio::test]
+async fn jsonrpc_get_block_by_number_with_receipts() {
+    let rpc_client = create_jsonrpc_client();
+
+    let block = rpc_client
+        .get_block_by_number_with_receipts(&BlockNumOrTag::Number(234469))
         .await
         .unwrap();
     assert!(block.metadata.block_number > 0);


### PR DESCRIPTION
This PR partially implements #77 by adding support for the following methods:

- `starknet_getBlockByHash`
- `starknet_getBlockByNumber`