### PR TITLE
feat(jsonrpc): implement transaction query methods

### DIFF
--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -29,6 +29,8 @@ pub enum JsonRpcMethod {
     GetTransactionByHash,
     #[serde(rename = "starknet_getTransactionByBlockHashAndIndex")]
     GetTransactionByBlockHashAndIndex,
+    #[serde(rename = "starknet_getTransactionByBlockNumberAndIndex")]
+    GetTransactionByBlockNumberAndIndex,
     #[serde(rename = "starknet_blockNumber")]
     BlockNumber,
     #[serde(rename = "starknet_chainId")]
@@ -229,6 +231,22 @@ where
             JsonRpcMethod::GetTransactionByBlockHashAndIndex,
             [
                 serde_json::to_value(block_hash)?,
+                serde_json::to_value(index)?,
+            ],
+        )
+        .await
+    }
+
+    /// Get the details of a transaction by a given block number and index
+    pub async fn get_transaction_by_block_number_and_index(
+        &self,
+        block_number: &BlockNumOrTag,
+        index: u64,
+    ) -> Result<Transaction, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetTransactionByBlockNumberAndIndex,
+            [
+                serde_json::to_value(block_number)?,
                 serde_json::to_value(index)?,
             ],
         )

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -27,6 +27,8 @@ pub enum JsonRpcMethod {
     GetStorageAt,
     #[serde(rename = "starknet_getTransactionByHash")]
     GetTransactionByHash,
+    #[serde(rename = "starknet_getTransactionByBlockHashAndIndex")]
+    GetTransactionByBlockHashAndIndex,
     #[serde(rename = "starknet_blockNumber")]
     BlockNumber,
     #[serde(rename = "starknet_chainId")]
@@ -213,6 +215,22 @@ where
         self.send_request(
             JsonRpcMethod::GetTransactionByHash,
             [serde_json::to_value(Felt(transaction_hash))?],
+        )
+        .await
+    }
+
+    /// Get the details of a transaction by a given block hash and index
+    pub async fn get_transaction_by_block_hash_and_index(
+        &self,
+        block_hash: &BlockHashOrTag,
+        index: u64,
+    ) -> Result<Transaction, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetTransactionByBlockHashAndIndex,
+            [
+                serde_json::to_value(block_hash)?,
+                serde_json::to_value(index)?,
+            ],
         )
         .await
     }

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -25,6 +25,8 @@ pub enum JsonRpcMethod {
     GetBlockByNumber,
     #[serde(rename = "starknet_getStorageAt")]
     GetStorageAt,
+    #[serde(rename = "starknet_getTransactionByHash")]
+    GetTransactionByHash,
     #[serde(rename = "starknet_blockNumber")]
     BlockNumber,
     #[serde(rename = "starknet_chainId")]
@@ -201,6 +203,18 @@ where
             )
             .await?
             .0)
+    }
+
+    /// Get the details and status of a submitted transaction
+    pub async fn get_transaction_by_hash(
+        &self,
+        transaction_hash: FieldElement,
+    ) -> Result<Transaction, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetTransactionByHash,
+            [serde_json::to_value(Felt(transaction_hash))?],
+        )
+        .await
     }
 
     /// Get the most recent accepted block number

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -163,6 +163,18 @@ async fn jsonrpc_get_transaction_by_block_hash_and_index() {
 }
 
 #[tokio::test]
+async fn jsonrpc_get_transaction_by_block_number_and_index() {
+    let rpc_client = create_jsonrpc_client();
+
+    let tx = rpc_client
+        .get_transaction_by_block_number_and_index(&BlockNumOrTag::Number(234500), 0)
+        .await
+        .unwrap();
+
+    assert!(tx.entry_point_selector.is_some());
+}
+
+#[tokio::test]
 async fn jsonrpc_block_number() {
     let rpc_client = create_jsonrpc_client();
 

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -143,6 +143,26 @@ async fn jsonrpc_get_transaction_by_hash_non_existent_tx() {
 }
 
 #[tokio::test]
+async fn jsonrpc_get_transaction_by_block_hash_and_index() {
+    let rpc_client = create_jsonrpc_client();
+
+    let tx = rpc_client
+        .get_transaction_by_block_hash_and_index(
+            &BlockHashOrTag::Hash(
+                FieldElement::from_hex_be(
+                    "04d893935543cc0a39d1ce1597695e0fc02f9512781e0b23f41bbb01b0c6b5f1",
+                )
+                .unwrap(),
+            ),
+            0,
+        )
+        .await
+        .unwrap();
+
+    assert!(tx.entry_point_selector.is_some());
+}
+
+#[tokio::test]
 async fn jsonrpc_block_number() {
     let rpc_client = create_jsonrpc_client();
 


### PR DESCRIPTION
This PR partially implements #77 by adding support for the following methods:

- `starknet_getTransactionByHash`
- `starknet_getTransactionByBlockHashAndIndex`
- `starknet_getTransactionByBlockNumberAndIndex`