### PR TITLE
feat(jsonrpc): implement remaining query methods

### DIFF
--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -31,6 +31,8 @@ pub enum JsonRpcMethod {
     GetTransactionByBlockHashAndIndex,
     #[serde(rename = "starknet_getTransactionByBlockNumberAndIndex")]
     GetTransactionByBlockNumberAndIndex,
+    #[serde(rename = "starknet_getTransactionReceipt")]
+    GetTransactionReceipt,
     #[serde(rename = "starknet_blockNumber")]
     BlockNumber,
     #[serde(rename = "starknet_chainId")]
@@ -249,6 +251,18 @@ where
                 serde_json::to_value(block_number)?,
                 serde_json::to_value(index)?,
             ],
+        )
+        .await
+    }
+
+    /// Get the details of a transaction by a given block number and index
+    pub async fn get_transaction_receipt(
+        &self,
+        transaction_hash: FieldElement,
+    ) -> Result<TransactionReceipt, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetTransactionReceipt,
+            [serde_json::to_value(Felt(transaction_hash))?],
         )
         .await
     }

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -35,6 +35,8 @@ pub enum JsonRpcMethod {
     GetTransactionReceipt,
     #[serde(rename = "starknet_getBlockTransactionCountByHash")]
     GetBlockTransactionCountByHash,
+    #[serde(rename = "starknet_getBlockTransactionCountByNumber")]
+    GetBlockTransactionCountByNumber,
     #[serde(rename = "starknet_blockNumber")]
     BlockNumber,
     #[serde(rename = "starknet_chainId")]
@@ -277,6 +279,18 @@ where
         self.send_request(
             JsonRpcMethod::GetBlockTransactionCountByHash,
             [serde_json::to_value(block_hash)?],
+        )
+        .await
+    }
+
+    /// Get the number of transactions in a block given a block number (height)
+    pub async fn get_block_transaction_count_by_number(
+        &self,
+        block_number: &BlockNumOrTag,
+    ) -> Result<u64, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetBlockTransactionCountByNumber,
+            [serde_json::to_value(block_number)?],
         )
         .await
     }

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -33,6 +33,8 @@ pub enum JsonRpcMethod {
     GetTransactionByBlockNumberAndIndex,
     #[serde(rename = "starknet_getTransactionReceipt")]
     GetTransactionReceipt,
+    #[serde(rename = "starknet_getBlockTransactionCountByHash")]
+    GetBlockTransactionCountByHash,
     #[serde(rename = "starknet_blockNumber")]
     BlockNumber,
     #[serde(rename = "starknet_chainId")]
@@ -263,6 +265,18 @@ where
         self.send_request(
             JsonRpcMethod::GetTransactionReceipt,
             [serde_json::to_value(Felt(transaction_hash))?],
+        )
+        .await
+    }
+
+    /// Get the number of transactions in a block given a block hash
+    pub async fn get_block_transaction_count_by_hash(
+        &self,
+        block_hash: &BlockHashOrTag,
+    ) -> Result<u64, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetBlockTransactionCountByHash,
+            [serde_json::to_value(block_hash)?],
         )
         .await
     }

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -9,6 +9,32 @@ mod serde_impls;
 
 pub use starknet_core::types::L1Address as EthAddress;
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventsPage {
+    pub events: Vec<EmittedEvent>,
+    /// The returned page number
+    pub page_number: u64,
+    /// A flag indicating whether this is the end of the stream of events
+    pub is_last_page: bool,
+}
+
+/// An event emitted as a result of transaction execution
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmittedEvent {
+    /// The hash of the block in which the event was emitted
+    #[serde_as(as = "UfeHex")]
+    pub block_hash: FieldElement,
+    /// The number of the block in which the event was emitted
+    pub block_number: u64,
+    /// The transaction that emitted the event
+    #[serde_as(as = "UfeHex")]
+    pub transaction_hash: FieldElement,
+    /// The event information
+    #[serde(flatten)]
+    pub event: Event,
+}
+
 /// A StarkNet event
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -51,6 +77,23 @@ pub struct FunctionCall {
     /// The parameters passed to the function
     #[serde_as(as = "Vec<UfeHex>")]
     pub calldata: Vec<FieldElement>,
+}
+
+/// An event filter/query
+#[serde_as]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EventFilter {
+    #[serde(rename = "fromBlock", skip_serializing_if = "Option::is_none")]
+    pub from_block: Option<u64>,
+    #[serde(rename = "toBlock", skip_serializing_if = "Option::is_none")]
+    pub to_block: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<UfeHex>")]
+    pub address: Option<FieldElement>,
+    /// The values used to filter the events
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<Vec<UfeHex>>")]
+    pub keys: Option<Vec<FieldElement>>,
 }
 
 /// Block hash or tag

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -178,7 +178,7 @@ async fn jsonrpc_get_transaction_by_block_number_and_index() {
 async fn jsonrpc_get_transaction_receipt() {
     let rpc_client = create_jsonrpc_client();
 
-    let tx = rpc_client
+    let receipt = rpc_client
         .get_transaction_receipt(
             FieldElement::from_hex_be(
                 "05b08d06a7f6422881d6461175f325844d179ca9018dbab5e92dc34e5c176ff1",
@@ -188,7 +188,24 @@ async fn jsonrpc_get_transaction_receipt() {
         .await
         .unwrap();
 
-    assert!(tx.actual_fee > FieldElement::ZERO);
+    assert!(receipt.actual_fee > FieldElement::ZERO);
+}
+
+#[tokio::test]
+async fn jsonrpc_get_block_transaction_count_by_hash() {
+    let rpc_client = create_jsonrpc_client();
+
+    let tx_count = rpc_client
+        .get_block_transaction_count_by_hash(&BlockHashOrTag::Hash(
+            FieldElement::from_hex_be(
+                "0ef4773e814cf100e0535fe5ddffcb8d1d966fc81a9cdf9ca94b2672e130334",
+            )
+            .unwrap(),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(tx_count, 45);
 }
 
 #[tokio::test]

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -3,7 +3,7 @@ use starknet_core::{
     utils::{get_selector_from_name, get_storage_var_address},
 };
 use starknet_providers::jsonrpc::{
-    models::{BlockHashOrTag, BlockNumOrTag, BlockTag, FunctionCall, SyncStatusType},
+    models::{BlockHashOrTag, BlockNumOrTag, BlockTag, EventFilter, FunctionCall, SyncStatusType},
     HttpTransport, JsonRpcClient, JsonRpcClientError,
 };
 use url::Url;
@@ -244,6 +244,27 @@ async fn jsonrpc_syncing() {
     if let SyncStatusType::Syncing(sync_status) = syncing {
         assert!(sync_status.highest_block_num > 0);
     }
+}
+
+#[tokio::test]
+async fn jsonrpc_get_events() {
+    let rpc_client = create_jsonrpc_client();
+
+    let events = rpc_client
+        .get_events(
+            EventFilter {
+                from_block: Some(234500),
+                to_block: None,
+                address: None,
+                keys: None,
+            },
+            20,
+            10,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(events.events.len(), 20);
 }
 
 #[tokio::test]

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -209,6 +209,18 @@ async fn jsonrpc_get_block_transaction_count_by_hash() {
 }
 
 #[tokio::test]
+async fn jsonrpc_get_block_transaction_count_by_number() {
+    let rpc_client = create_jsonrpc_client();
+
+    let tx_count = rpc_client
+        .get_block_transaction_count_by_number(&BlockNumOrTag::Number(234519))
+        .await
+        .unwrap();
+
+    assert_eq!(tx_count, 45);
+}
+
+#[tokio::test]
 async fn jsonrpc_block_number() {
     let rpc_client = create_jsonrpc_client();
 

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -175,6 +175,23 @@ async fn jsonrpc_get_transaction_by_block_number_and_index() {
 }
 
 #[tokio::test]
+async fn jsonrpc_get_transaction_receipt() {
+    let rpc_client = create_jsonrpc_client();
+
+    let tx = rpc_client
+        .get_transaction_receipt(
+            FieldElement::from_hex_be(
+                "05b08d06a7f6422881d6461175f325844d179ca9018dbab5e92dc34e5c176ff1",
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(tx.actual_fee > FieldElement::ZERO);
+}
+
+#[tokio::test]
 async fn jsonrpc_block_number() {
     let rpc_client = create_jsonrpc_client();
 


### PR DESCRIPTION
This PR partially implements #77 by adding support for the following methods:

- `starknet_getTransactionReceipt`
- `starknet_getBlockTransactionCountByHash`
- `starknet_getBlockTransactionCountByNumber`
- `starknet_getEvents`