### PR TITLE
feat: remove zero padding for `UfeHex` serialization

### DIFF
--- a/starknet-core/src/serde/unsigned_field_element.rs
+++ b/starknet-core/src/serde/unsigned_field_element.rs
@@ -14,7 +14,7 @@ impl SerializeAs<FieldElement> for UfeHex {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&format!("{:#064x}", value))
+        serializer.serialize_str(&format!("{:#x}", value))
     }
 }
 


### PR DESCRIPTION
This PR removes the zero padding when serializing `FieldElement` as `UfeHex`. It's a breaking change for applications relying on this behavior.