### PR TITLE
feat(jsonrpc): implement write methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,6 +1668,7 @@ version = "0.2.0"
 dependencies = [
  "async-trait",
  "auto_impl",
+ "flate2",
  "reqwest",
  "serde",
  "serde_json",

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -24,4 +24,5 @@ serde_json = "1.0.74"
 serde_with = "1.12.0"
 
 [dev-dependencies]
+flate2 = "1.0.22"
 tokio = { version = "1.15.0", features = ["full"] }

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -51,6 +51,8 @@ pub enum JsonRpcMethod {
     AddInvokeTransaction,
     #[serde(rename = "starknet_addDeclareTransaction")]
     AddDeclareTransaction,
+    #[serde(rename = "starknet_addDeployTransaction")]
+    AddDeployTransaction,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -394,6 +396,24 @@ where
             [
                 serde_json::to_value(contract_class)?,
                 serde_json::to_value(Felt(version))?,
+            ],
+        )
+        .await
+    }
+
+    /// Submit a new deploy contract transaction
+    pub async fn add_deploy_transaction(
+        &self,
+        contract_address_salt: FieldElement,
+        constructor_calldata: Vec<FieldElement>,
+        contract_definition: &ContractClass,
+    ) -> Result<DeployTransactionResult, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::AddDeployTransaction,
+            [
+                serde_json::to_value(Felt(contract_address_salt))?,
+                serde_json::to_value(FeltArray(constructor_calldata))?,
+                serde_json::to_value(contract_definition)?,
             ],
         )
         .await

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -49,6 +49,8 @@ pub enum JsonRpcMethod {
     Call,
     #[serde(rename = "starknet_addInvokeTransaction")]
     AddInvokeTransaction,
+    #[serde(rename = "starknet_addDeclareTransaction")]
+    AddDeclareTransaction,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -375,6 +377,22 @@ where
                 serde_json::to_value(function_invocation)?,
                 serde_json::to_value(FeltArray(signature))?,
                 serde_json::to_value(Felt(max_fee))?,
+                serde_json::to_value(Felt(version))?,
+            ],
+        )
+        .await
+    }
+
+    /// Submit a new transaction to be added to the chain
+    pub async fn add_declare_transaction(
+        &self,
+        contract_class: &ContractClass,
+        version: FieldElement,
+    ) -> Result<DeclareTransactionResult, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::AddDeclareTransaction,
+            [
+                serde_json::to_value(contract_class)?,
                 serde_json::to_value(Felt(version))?,
             ],
         )

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -47,6 +47,8 @@ pub enum JsonRpcMethod {
     GetEvents,
     #[serde(rename = "starknet_call")]
     Call,
+    #[serde(rename = "starknet_addInvokeTransaction")]
+    AddInvokeTransaction,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -357,6 +359,26 @@ where
             )
             .await?
             .0)
+    }
+
+    /// Submit a new transaction to be added to the chain
+    pub async fn add_invoke_transaction(
+        &self,
+        function_invocation: &FunctionCall,
+        signature: Vec<FieldElement>,
+        max_fee: FieldElement,
+        version: FieldElement,
+    ) -> Result<InvokeTransactionResult, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::AddInvokeTransaction,
+            [
+                serde_json::to_value(function_invocation)?,
+                serde_json::to_value(FeltArray(signature))?,
+                serde_json::to_value(Felt(max_fee))?,
+                serde_json::to_value(Felt(version))?,
+            ],
+        )
+        .await
     }
 
     async fn send_request<P, R>(

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -316,3 +316,10 @@ pub enum TransactionStatus {
     AcceptedOnL1,
     Rejected,
 }
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InvokeTransactionResult {
+    #[serde_as(as = "UfeHex")]
+    pub transaction_hash: FieldElement,
+}

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -370,3 +370,14 @@ pub struct DeclareTransactionResult {
     #[serde_as(as = "UfeHex")]
     pub class_hash: FieldElement,
 }
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeployTransactionResult {
+    /// The hash of the deploy transaction
+    #[serde_as(as = "UfeHex")]
+    pub transaction_hash: FieldElement,
+    /// The address of the new contract
+    #[serde_as(as = "UfeHex")]
+    pub contract_address: FieldElement,
+}

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -292,3 +292,28 @@ async fn jsonrpc_call() {
 
     assert!(eth_balance[0] > FieldElement::ZERO);
 }
+
+#[tokio::test]
+async fn jsonrpc_add_invoke_transaction() {
+    let rpc_client = create_jsonrpc_client();
+
+    // This is an invalid made-up transaction but the sequencer will happily accept it anyways
+    let add_tx_result = rpc_client
+        .add_invoke_transaction(
+            &FunctionCall {
+                contract_address: FieldElement::from_hex_be(
+                    "049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                )
+                .unwrap(),
+                entry_point_selector: get_selector_from_name("__execute__").unwrap(),
+                calldata: vec![FieldElement::from_hex_be("1234").unwrap()],
+            },
+            vec![],
+            FieldElement::ONE,
+            FieldElement::ZERO,
+        )
+        .await
+        .unwrap();
+
+    assert!(add_tx_result.transaction_hash > FieldElement::ZERO);
+}

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -381,3 +381,21 @@ async fn jsonrpc_add_declare_transaction() {
 
     assert!(add_tx_result.class_hash > FieldElement::ZERO);
 }
+
+#[tokio::test]
+async fn jsonrpc_add_deploy_transaction() {
+    let rpc_client = create_jsonrpc_client();
+
+    let add_tx_result = rpc_client
+        .add_deploy_transaction(
+            FieldElement::ONE,
+            // We can't test constructor calldata yet due to a bug on `pathfinder`:
+            // https://github.com/eqlabs/pathfinder/issues/370
+            vec![],
+            &create_contract_class(),
+        )
+        .await
+        .unwrap();
+
+    assert!(add_tx_result.contract_address > FieldElement::ZERO);
+}


### PR DESCRIPTION
This PR partially implements #77 by adding support for the following methods:

- `starknet_addInvokeTransaction`
- `starknet_addDeclareTransaction`
- `starknet_addDeployTransaction`