### PR TITLE
docs: declare JSON-RPC support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ starknet = { git = "https://github.com/xJonathanLEI/starknet-rs" }
 ## Features
 
 - [x] Sequencer gateway / feeder gateway client
-- [ ] Full node JSON-RPC API client
+- [x] Full node JSON-RPC API client
 - [x] Smart contract deployment
 - [x] Signer for using [IAccount](https://github.com/OpenZeppelin/cairo-contracts/blob/main/src/openzeppelin/account/IAccount.cairo) account contracts
 - [ ] Strongly-typed smart contract binding code generation from ABI


### PR DESCRIPTION
Resolves #77.

We can now declare JSON-RPC support as all methods currently implemented by `pathfinder` are supported.

Support for new methods will be added as they are implemented by `pathfinder`.