### PR TITLE
feat(jsonrpc): use AsRef for call()

### DIFF
--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -348,16 +348,19 @@ where
     }
 
     /// Call a starknet function without creating a StarkNet transaction
-    pub async fn call(
+    pub async fn call<R>(
         &self,
-        request: &FunctionCall,
+        request: R,
         block_hash: &BlockHashOrTag,
-    ) -> Result<Vec<FieldElement>, JsonRpcClientError<T::Error>> {
+    ) -> Result<Vec<FieldElement>, JsonRpcClientError<T::Error>>
+    where
+        R: AsRef<FunctionCall>,
+    {
         Ok(self
             .send_request::<_, FeltArray>(
                 JsonRpcMethod::Call,
                 [
-                    serde_json::to_value(request)?,
+                    serde_json::to_value(request.as_ref())?,
                     serde_json::to_value(block_hash)?,
                 ],
             )

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -381,3 +381,9 @@ pub struct DeployTransactionResult {
     #[serde_as(as = "UfeHex")]
     pub contract_address: FieldElement,
 }
+
+impl AsRef<FunctionCall> for FunctionCall {
+    fn as_ref(&self) -> &FunctionCall {
+        self
+    }
+}


### PR DESCRIPTION
This PR changes `call()` signature to accept `AsRef<FunctionCall>` so that both `FunctionCall` and `&FunctionCall` can be accepted.