### PR TITLE
feat: add macros crate with `selector` macro

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -114,3 +114,7 @@ jobs:
       - name: Run starknet-signers tests
         run: |
           (cd ./starknet-signers && wasm-pack test --node)
+
+      - name: Run starknet-macros tests
+        run: |
+          (cd ./starknet-macros && wasm-pack test --node)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,6 +1577,7 @@ dependencies = [
  "starknet-accounts",
  "starknet-contract",
  "starknet-core",
+ "starknet-macros",
  "starknet-providers",
  "starknet-signers",
  "tokio",
@@ -1660,6 +1661,14 @@ dependencies = [
  "serde",
  "thiserror",
  "wasm-bindgen-test",
+]
+
+[[package]]
+name = "starknet-macros"
+version = "0.1.0"
+dependencies = [
+ "starknet-core",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "starknet-signers",
     "starknet-accounts",
     "starknet-ff",
+    "starknet-macros",
     "examples/starknet-wasm",
 ]
 
@@ -32,6 +33,7 @@ starknet-providers = { version = "0.2.0", path = "./starknet-providers" }
 starknet-contract = { version = "0.1.0", path = "./starknet-contract" }
 starknet-signers = { version = "0.1.0", path = "./starknet-signers" }
 starknet-accounts = { version = "0.1.0", path = "./starknet-accounts" }
+starknet-macros = { version = "0.1.0", path = "./starknet-macros" }
 
 [dev-dependencies]
 serde_json = "1.0.74"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This workspace contains the following crates:
 - `starknet-signers`: StarkNet signer implementations
 - `starknet-accounts`: Types for handling StarkNet account abstraction
 - `starknet-ff`: StarkNet field element type
+- `starknet-macros`: Useful macros for using the `starknet` crates
 
 ## Example
 

--- a/assets/MACROS_README.md
+++ b/assets/MACROS_README.md
@@ -1,0 +1,1 @@
+../starknet-macros/README.md

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,10 @@
 //! ## `accounts`
 //!
 //! Contains types for using account abstraction on StarkNet.
+//!
+//! ## `macros`
+//!
+//! Contains procedural macros useful for this crate.
 
 #[doc = include_str!("../assets/CORE_README.md")]
 pub mod core {
@@ -61,4 +65,9 @@ pub mod signers {
 #[doc = include_str!("../assets/ACCOUNTS_README.md")]
 pub mod accounts {
     pub use starknet_accounts::*;
+}
+
+#[doc = include_str!("../assets/MACROS_README.md")]
+pub mod macros {
+    pub use starknet_macros::*;
 }

--- a/starknet-ff/src/lib.rs
+++ b/starknet-ff/src/lib.rs
@@ -166,6 +166,11 @@ impl FieldElement {
         buffer
     }
 
+    /// Transforms [FieldElement] into its Montgomery representation
+    pub const fn into_mont(self) -> [u64; 4] {
+        self.inner.0 .0
+    }
+
     pub fn invert(&self) -> Option<FieldElement> {
         self.inner.inverse().map(|inner| Self { inner })
     }

--- a/starknet-macros/Cargo.toml
+++ b/starknet-macros/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "starknet-macros"
+version = "0.1.0"
+authors = ["Jonathan LEI <me@xjonathan.dev>"]
+license = "MIT OR Apache-2.0"
+edition = "2021"
+readme = "README.md"
+repository = "https://github.com/xJonathanLEI/starknet-rs"
+homepage = "https://starknet.rs/"
+description = """
+Procedural macros for `starknet`
+"""
+keywords = ["ethereum", "starknet", "web3"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+starknet-core = { version = "0.2.0", path = "../starknet-core" }
+syn = "1.0.96"

--- a/starknet-macros/README.md
+++ b/starknet-macros/README.md
@@ -1,0 +1,1 @@
+# Procedural macros for `starknet`

--- a/starknet-macros/src/lib.rs
+++ b/starknet-macros/src/lib.rs
@@ -1,0 +1,20 @@
+use proc_macro::TokenStream;
+use starknet_core::utils::get_selector_from_name;
+use syn::{parse_macro_input, LitStr};
+
+#[proc_macro]
+pub fn selector(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as LitStr);
+
+    let str_value = input.value();
+
+    let selector_value = get_selector_from_name(&str_value).expect("invalid selector name");
+    let selector_raw = selector_value.into_mont();
+
+    format!(
+        "::starknet::core::types::FieldElement::from_mont([{}, {}, {}, {}])",
+        selector_raw[0], selector_raw[1], selector_raw[2], selector_raw[3],
+    )
+    .parse()
+    .unwrap()
+}

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,0 +1,10 @@
+use starknet::{core::utils::get_selector_from_name, macros::selector};
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn selector_can_generate_correct_selector() {
+    let macro_value = selector!("balanceOf");
+    let function_call_value = get_selector_from_name("balanceOf").unwrap();
+
+    assert_eq!(macro_value, function_call_value);
+}


### PR DESCRIPTION
This PR adds a proc macro `selector` so that:

- users no longer need to call `unwrap()` on `get_selector_from_name` for string literals; and
- selector values can now be `const`.