### PR TITLE
test: switch to RPC node hosted by zkLend

### DIFF
--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -16,7 +16,7 @@ use url::Url;
 
 fn create_jsonrpc_client() -> JsonRpcClient<HttpTransport> {
     JsonRpcClient::new(HttpTransport::new(
-        Url::parse("https://starknet-goerli.cartridge.gg/").unwrap(),
+        Url::parse("https://starknet-goerli.rpc.zklend.com/").unwrap(),
     ))
 }
 


### PR DESCRIPTION
This PR changes the RPC node used for integration tests to: https://starknet-goerli.rpc.zklend.com/ since the one we're using right now fails with 502 for `starknet_call` calls, possibly related to: https://github.com/eqlabs/pathfinder/issues/354