### PR TITLE
feat: support FieldElement to BigDecimal conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bigdecimal"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1655,9 +1666,11 @@ name = "starknet-ff"
 version = "0.1.0"
 dependencies = [
  "ark-ff",
+ "bigdecimal",
  "crypto-bigint",
  "getrandom",
  "hex",
+ "num-bigint",
  "serde",
  "thiserror",
  "wasm-bindgen-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,11 @@ members = [
     "examples/starknet-wasm",
 ]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
-starknet-core = { version = "0.2.0", path = "./starknet-core" }
+starknet-core = { version = "0.2.0", path = "./starknet-core", default-features = false }
 starknet-providers = { version = "0.2.0", path = "./starknet-providers" }
 starknet-contract = { version = "0.1.0", path = "./starknet-contract" }
 starknet-signers = { version = "0.1.0", path = "./starknet-signers" }
@@ -39,3 +42,7 @@ starknet-macros = { version = "0.1.0", path = "./starknet-macros" }
 serde_json = "1.0.74"
 tokio = { version = "1.15.0", features = ["full"] }
 url = "2.2.2"
+
+[features]
+default = ["bigdecimal"]
+bigdecimal = ["starknet-core/bigdecimal"]

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -12,9 +12,12 @@ Core structures for the starknet crate
 """
 keywords = ["ethereum", "starknet", "web3"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 starknet-crypto = { version = "0.1.0", path = "../starknet-crypto" }
-starknet-ff = { version = "0.1.0", path = "../starknet-ff" }
+starknet-ff = { version = "0.1.0", path = "../starknet-ff", default-features = false }
 base64 = "0.13.0"
 ethereum-types = "0.12.1"
 hex = "0.4.3"
@@ -26,3 +29,7 @@ thiserror = "1.0.30"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.29"
+
+[features]
+default = ["bigdecimal"]
+bigdecimal = ["starknet-ff/bigdecimal"]

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -12,12 +12,15 @@ StarkNet field element type
 """
 keywords = ["ethereum", "starknet", "web3"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 ark-ff = "0.3.0"
-bigdecimal = "0.3.0"
+bigdecimal = { version = "0.3.0", optional = true }
 crypto-bigint = "0.3.2"
 hex = "0.4.3"
-num-bigint = "0.4.3"
+num-bigint = { version = "0.4.3", optional = true }
 serde = "1.0.133"
 thiserror = "1.0.30"
 
@@ -26,3 +29,7 @@ getrandom = { version = "0.2.3", features = ["js"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.29"
+
+[features]
+default = ["bigdecimal"]
+bigdecimal = ["dep:bigdecimal", "dep:num-bigint"]

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -14,8 +14,10 @@ keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
 ark-ff = "0.3.0"
+bigdecimal = "0.3.0"
 crypto-bigint = "0.3.2"
 hex = "0.4.3"
+num-bigint = "0.4.3"
 serde = "1.0.133"
 thiserror = "1.0.30"
 

--- a/starknet-ff/src/lib.rs
+++ b/starknet-ff/src/lib.rs
@@ -3,9 +3,7 @@
 use crate::fr::FrParameters;
 
 use ark_ff::{fields::Fp256, BigInteger, BigInteger256, Field, PrimeField, SquareRootField};
-use bigdecimal::BigDecimal;
 use crypto_bigint::{CheckedAdd, CheckedMul, Zero, U256};
-use num_bigint::{BigInt, Sign};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, LowerHex, UpperHex};
 
@@ -149,8 +147,11 @@ impl FieldElement {
     }
 
     /// Interprets the field element as a decimal number of a certain decimal places.
-    pub fn to_big_decimal<D: Into<i64>>(&self, decimals: D) -> BigDecimal {
-        BigDecimal::new(
+    #[cfg(feature = "bigdecimal")]
+    pub fn to_big_decimal<D: Into<i64>>(&self, decimals: D) -> bigdecimal::BigDecimal {
+        use num_bigint::{BigInt, Sign};
+
+        bigdecimal::BigDecimal::new(
             BigInt::from_bytes_be(Sign::Plus, &self.to_bytes_be()),
             decimals.into(),
         )
@@ -547,8 +548,6 @@ fn u256_to_u64_array(num: &U256) -> [u64; 4] {
 
 #[cfg(test)]
 mod tests {
-    use bigdecimal::Num;
-
     use super::*;
 
     #[test]
@@ -704,8 +703,11 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "bigdecimal")]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_to_big_decimal() {
+        use bigdecimal::{BigDecimal, Num};
+
         let nums = [
             (
                 "134500",


### PR DESCRIPTION
This PR adds `bigdecimal` integration to `starknet-ff` as an optional feature. `FieldElement` can now be interpreted as decimal numbers.