### PR TITLE
feat: add macros for FieldElement literals

### DIFF
--- a/starknet-macros/src/lib.rs
+++ b/starknet-macros/src/lib.rs
@@ -1,5 +1,5 @@
 use proc_macro::TokenStream;
-use starknet_core::utils::get_selector_from_name;
+use starknet_core::{types::FieldElement, utils::get_selector_from_name};
 use syn::{parse_macro_input, LitStr};
 
 #[proc_macro]
@@ -14,6 +14,40 @@ pub fn selector(input: TokenStream) -> TokenStream {
     format!(
         "::starknet::core::types::FieldElement::from_mont([{}, {}, {}, {}])",
         selector_raw[0], selector_raw[1], selector_raw[2], selector_raw[3],
+    )
+    .parse()
+    .unwrap()
+}
+
+#[proc_macro]
+pub fn felt_dec(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as LitStr);
+
+    let str_value = input.value();
+
+    let felt_value = FieldElement::from_dec_str(&str_value).expect("invalid FieldElement value");
+    let felt_raw = felt_value.into_mont();
+
+    format!(
+        "::starknet::core::types::FieldElement::from_mont([{}, {}, {}, {}])",
+        felt_raw[0], felt_raw[1], felt_raw[2], felt_raw[3],
+    )
+    .parse()
+    .unwrap()
+}
+
+#[proc_macro]
+pub fn felt_hex(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as LitStr);
+
+    let str_value = input.value();
+
+    let felt_value = FieldElement::from_hex_be(&str_value).expect("invalid FieldElement value");
+    let felt_raw = felt_value.into_mont();
+
+    format!(
+        "::starknet::core::types::FieldElement::from_mont([{}, {}, {}, {}])",
+        felt_raw[0], felt_raw[1], felt_raw[2], felt_raw[3],
     )
     .parse()
     .unwrap()

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,10 +1,32 @@
-use starknet::{core::utils::get_selector_from_name, macros::selector};
+use starknet::{
+    core::utils::get_selector_from_name,
+    macros::{felt_dec, felt_hex, selector},
+};
+use starknet_core::types::FieldElement;
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 fn selector_can_generate_correct_selector() {
     let macro_value = selector!("balanceOf");
     let function_call_value = get_selector_from_name("balanceOf").unwrap();
+
+    assert_eq!(macro_value, function_call_value);
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn felt_dec() {
+    let macro_value = felt_dec!("1234567");
+    let function_call_value = FieldElement::from_dec_str("1234567").unwrap();
+
+    assert_eq!(macro_value, function_call_value);
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn felt_hex() {
+    let macro_value = felt_hex!("0x123456789abcdef");
+    let function_call_value = FieldElement::from_hex_be("0x123456789abcdef").unwrap();
 
     assert_eq!(macro_value, function_call_value);
 }


### PR DESCRIPTION
This PR adds 2 new macros `felt_dec` and `felt_hex` for constructing `FieldElement` at compile time.