### PR TITLE
feat: add `felt` macro

### DIFF
--- a/starknet-macros/src/lib.rs
+++ b/starknet-macros/src/lib.rs
@@ -20,6 +20,28 @@ pub fn selector(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro]
+pub fn felt(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as LitStr);
+
+    let str_value = input.value();
+
+    let felt_value = if str_value.starts_with("0x") {
+        FieldElement::from_hex_be(&str_value).expect("invalid FieldElement value")
+    } else {
+        FieldElement::from_dec_str(&str_value).expect("invalid FieldElement value")
+    };
+
+    let felt_raw = felt_value.into_mont();
+
+    format!(
+        "::starknet::core::types::FieldElement::from_mont([{}, {}, {}, {}])",
+        felt_raw[0], felt_raw[1], felt_raw[2], felt_raw[3],
+    )
+    .parse()
+    .unwrap()
+}
+
+#[proc_macro]
 pub fn felt_dec(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as LitStr);
 

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,6 +1,6 @@
 use starknet::{
     core::utils::get_selector_from_name,
-    macros::{felt_dec, felt_hex, selector},
+    macros::{felt, felt_dec, felt_hex, selector},
 };
 use starknet_core::types::FieldElement;
 
@@ -9,6 +9,24 @@ use starknet_core::types::FieldElement;
 fn selector_can_generate_correct_selector() {
     let macro_value = selector!("balanceOf");
     let function_call_value = get_selector_from_name("balanceOf").unwrap();
+
+    assert_eq!(macro_value, function_call_value);
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn felt_with_dec_string() {
+    let macro_value = felt!("1234567");
+    let function_call_value = FieldElement::from_dec_str("1234567").unwrap();
+
+    assert_eq!(macro_value, function_call_value);
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn felt_with_hex_string() {
+    let macro_value = felt!("0x123456789abcdef");
+    let function_call_value = FieldElement::from_hex_be("0x123456789abcdef").unwrap();
 
     assert_eq!(macro_value, function_call_value);
 }


### PR DESCRIPTION
This PR adds another macro `felt` that accepts both decimal and hexadecimal representations.