### PR TITLE
test: jsonrpc deploy transaction calldata

### DIFF
--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -389,9 +389,7 @@ async fn jsonrpc_add_deploy_transaction() {
     let add_tx_result = rpc_client
         .add_deploy_transaction(
             FieldElement::ONE,
-            // We can't test constructor calldata yet due to a bug on `pathfinder`:
-            // https://github.com/eqlabs/pathfinder/issues/370
-            vec![],
+            vec![FieldElement::ONE],
             &create_contract_class(),
         )
         .await


### PR DESCRIPTION
Thanks to https://github.com/eqlabs/pathfinder/pull/372 we can now test calling `starknet_addDeployTransaction` with constructor calldata.