### PR TITLE
feat(jsonrpc): remove abi to align with spec

### DIFF
--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -5,7 +5,7 @@ use starknet_core::{
     types::FieldElement,
 };
 
-pub use starknet_core::types::{AbiEntry, L1Address as EthAddress};
+pub use starknet_core::types::L1Address as EthAddress;
 
 // Not exposed by design
 mod serde_impls;
@@ -88,10 +88,6 @@ pub struct ContractClass {
     #[serde(serialize_with = "serialize_as_base64")]
     pub program: Vec<u8>,
     pub entry_points_by_type: EntryPointsByType,
-    /// **WARNING**: This field is NON-STANDARD but required by `pathfinder`:
-    ///
-    /// https://github.com/eqlabs/pathfinder/issues/369
-    pub abi: Vec<AbiEntry>,
 }
 
 #[serde_as]

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -62,7 +62,6 @@ fn create_contract_class() -> ContractClass {
                 })
                 .collect(),
         },
-        abi: artifact.abi,
     }
 }
 


### PR DESCRIPTION
Thanks to https://github.com/eqlabs/pathfinder/pull/371 we can finally remove the spec-violating `abi` field in contract definition.