### PR TITLE
fix: null stateMutability incorrectly included

### DIFF
--- a/starknet-core/src/types/contract_code.rs
+++ b/starknet-core/src/types/contract_code.rs
@@ -36,6 +36,7 @@ pub struct Function {
     pub name: String,
     pub inputs: Vec<Input>,
     pub outputs: Vec<Output>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub state_mutability: Option<String>,
 }
 


### PR DESCRIPTION
This PR fixes an issue involving ABI serialization. This matters since the whole ABI definition is used for calculating the class hash. Incorrectly including `null` values results in different class hashes, and thus getting an otherwise-whitelisted contract rejected on mainnet.