### PR TITLE
feat: add address() to `Account`

### DIFF
--- a/starknet-accounts/src/account.rs
+++ b/starknet-accounts/src/account.rs
@@ -31,6 +31,8 @@ pub trait Account: Sized {
     type EstimateFeeError: Error + Send;
     type SendTransactionError: Error + Send;
 
+    fn address(&self) -> FieldElement;
+
     async fn get_nonce(
         &self,
         block_identifier: BlockId,

--- a/starknet-accounts/src/single_owner.rs
+++ b/starknet-accounts/src/single_owner.rs
@@ -161,6 +161,10 @@ where
     type EstimateFeeError = TransactionError<P::Error, S::SignError>;
     type SendTransactionError = TransactionError<P::Error, S::SignError>;
 
+    fn address(&self) -> FieldElement {
+        self.address
+    }
+
     async fn get_nonce(
         &self,
         block_identifier: BlockId,


### PR DESCRIPTION
Resolves #175.

Note that this is a breaking change for downstream applications/libraries with `Account` implementations.