### PR TITLE
fix(sequencer_gateway): derive Clone for sequencer SequencerGatewayPr…

### DIFF
--- a/starknet-providers/src/sequencer_gateway.rs
+++ b/starknet-providers/src/sequencer_gateway.rs
@@ -17,6 +17,7 @@ use starknet_core::{
 use thiserror::Error;
 use url::Url;
 
+#[derive(Clone)]
 pub struct SequencerGatewayProvider {
     client: Client,
     gateway_url: Url,


### PR DESCRIPTION
```rust
pub struct SequencerGatewayProvider {
    client: Client,
    gateway_url: Url,
    feeder_gateway_url: Url,
}
```
`Client` and `Url` are both Clone. So it can be derived.
It is used as provider in `SingleOwnerAccount`, which is also Clone.
