### PR TITLE
docs: add example for calling view function via sequencer gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Examples can be found in the [examples folder](./examples):
 
 5. [Query the latest block number with JSON-RPC](./examples/jsonrpc.rs)
 
+6. [Call a contract view function via sequencer gateway](./examples/sequencer_erc20_balance.rs)
+
 ## License
 
 Licensed under either of

--- a/examples/sequencer_erc20_balance.rs
+++ b/examples/sequencer_erc20_balance.rs
@@ -1,0 +1,31 @@
+use starknet::{
+    core::types::{BlockId, FieldElement, InvokeFunctionTransactionRequest},
+    macros::{felt, selector},
+    providers::{Provider, SequencerGatewayProvider},
+};
+
+#[tokio::main]
+async fn main() {
+    let provider = SequencerGatewayProvider::starknet_alpha_goerli();
+    let tst_token_address =
+        felt!("0x07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10");
+
+    let call_result = provider
+        .call_contract(
+            InvokeFunctionTransactionRequest {
+                contract_address: tst_token_address,
+                entry_point_selector: selector!("balanceOf"),
+                calldata: vec![FieldElement::from_hex_be(
+                    "YOUR_ACCOUNT_CONTRACT_ADDRESS_IN_HEX_HERE",
+                )
+                .unwrap()],
+                signature: vec![],
+                max_fee: FieldElement::ZERO,
+            },
+            BlockId::Latest,
+        )
+        .await
+        .expect("failed to call contract");
+
+    dbg!(call_result);
+}


### PR DESCRIPTION
This PR adds an example for callling view functions via the sequencer gateway. It also uses macros for removing the need to call `unwrap()` in some cases.