### PR TITLE
docs: bump supported StarkNet version to 0.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Complete StarkNet library in Rust**
 
-![starknet-version-v0.9.0](https://img.shields.io/badge/StarkNet_Version-v0.9.0-2ea44f?logo=ethereum)
+![starknet-version-v0.9.1](https://img.shields.io/badge/StarkNet_Version-v0.9.1-2ea44f?logo=ethereum)
 [![linting-badge](https://github.com/xJonathanLEI/starknet-rs/actions/workflows/lint.yaml/badge.svg?branch=master)](https://github.com/xJonathanLEI/starknet-rs/actions/workflows/lint.yaml)
 [![crates-badge](https://img.shields.io/crates/v/starknet.svg)](https://crates.io/crates/starknet)
 


### PR DESCRIPTION
Closes #196.