### PR TITLE
feat(jsonrpc): support specification v0.1.0

### DIFF
--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -19,18 +19,10 @@ pub struct JsonRpcClient<T> {
 
 #[derive(Debug, Serialize)]
 pub enum JsonRpcMethod {
-    #[serde(rename = "starknet_getBlockByHash")]
-    GetBlockByHash,
-    #[serde(rename = "starknet_getBlockByNumber")]
-    GetBlockByNumber,
     #[serde(rename = "starknet_getStorageAt")]
     GetStorageAt,
     #[serde(rename = "starknet_getTransactionByHash")]
     GetTransactionByHash,
-    #[serde(rename = "starknet_getTransactionByBlockHashAndIndex")]
-    GetTransactionByBlockHashAndIndex,
-    #[serde(rename = "starknet_getTransactionByBlockNumberAndIndex")]
-    GetTransactionByBlockNumberAndIndex,
     #[serde(rename = "starknet_getTransactionReceipt")]
     GetTransactionReceipt,
     #[serde(rename = "starknet_getClass")]
@@ -39,10 +31,6 @@ pub enum JsonRpcMethod {
     GetClassHashAt,
     #[serde(rename = "starknet_getClassAt")]
     GetClassAt,
-    #[serde(rename = "starknet_getBlockTransactionCountByHash")]
-    GetBlockTransactionCountByHash,
-    #[serde(rename = "starknet_getBlockTransactionCountByNumber")]
-    GetBlockTransactionCountByNumber,
     #[serde(rename = "starknet_blockNumber")]
     BlockNumber,
     #[serde(rename = "starknet_chainId")]
@@ -95,14 +83,6 @@ struct JsonRpcRequest<T> {
     params: T,
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-enum BlockResponseScopeOptions {
-    TxnHash,
-    FullTxns,
-    FullTxnAndReceipts,
-}
-
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 struct Felt(#[serde_as(as = "UfeHex")] pub FieldElement);
@@ -129,96 +109,6 @@ impl<T> JsonRpcClient<T>
 where
     T: JsonRpcTransport,
 {
-    /// Get block information given the block id
-    pub async fn get_block_by_hash(
-        &self,
-        block_hash: &BlockHashOrTag,
-    ) -> Result<Block, JsonRpcClientError<T::Error>> {
-        self.send_request(
-            JsonRpcMethod::GetBlockByHash,
-            [
-                serde_json::to_value(block_hash)?,
-                serde_json::to_value(BlockResponseScopeOptions::TxnHash)?,
-            ],
-        )
-        .await
-    }
-
-    /// Get block information given the block id
-    pub async fn get_block_by_hash_with_txns(
-        &self,
-        block_hash: &BlockHashOrTag,
-    ) -> Result<BlockWithTxns, JsonRpcClientError<T::Error>> {
-        self.send_request(
-            JsonRpcMethod::GetBlockByHash,
-            [
-                serde_json::to_value(block_hash)?,
-                serde_json::to_value(BlockResponseScopeOptions::FullTxns)?,
-            ],
-        )
-        .await
-    }
-
-    /// Get block information given the block id
-    pub async fn get_block_by_hash_with_receipts(
-        &self,
-        block_hash: &BlockHashOrTag,
-    ) -> Result<BlockWithReceipts, JsonRpcClientError<T::Error>> {
-        self.send_request(
-            JsonRpcMethod::GetBlockByHash,
-            [
-                serde_json::to_value(block_hash)?,
-                serde_json::to_value(BlockResponseScopeOptions::FullTxnAndReceipts)?,
-            ],
-        )
-        .await
-    }
-
-    /// Get block information given the block number (its height)
-    pub async fn get_block_by_number(
-        &self,
-        block_number: &BlockNumOrTag,
-    ) -> Result<Block, JsonRpcClientError<T::Error>> {
-        self.send_request(
-            JsonRpcMethod::GetBlockByNumber,
-            [
-                serde_json::to_value(block_number)?,
-                serde_json::to_value(BlockResponseScopeOptions::TxnHash)?,
-            ],
-        )
-        .await
-    }
-
-    /// Get block information given the block number (its height)
-    pub async fn get_block_by_number_with_txns(
-        &self,
-        block_number: &BlockNumOrTag,
-    ) -> Result<BlockWithTxns, JsonRpcClientError<T::Error>> {
-        self.send_request(
-            JsonRpcMethod::GetBlockByNumber,
-            [
-                serde_json::to_value(block_number)?,
-                serde_json::to_value(BlockResponseScopeOptions::FullTxns)?,
-            ],
-        )
-        .await
-    }
-
-    /// Get block information given the block number (its height)
-    pub async fn get_block_by_number_with_receipts(
-        &self,
-        block_number: &BlockNumOrTag,
-    ) -> Result<BlockWithReceipts, JsonRpcClientError<T::Error>> {
-        self.send_request(
-            JsonRpcMethod::GetBlockByNumber,
-            [
-                serde_json::to_value(block_number)?,
-                serde_json::to_value(BlockResponseScopeOptions::FullTxnAndReceipts)?,
-            ],
-        )
-        .await
-    }
-
     /// Get the value of the storage at the given address and key
     pub async fn get_storage_at(
         &self,
@@ -247,38 +137,6 @@ where
         self.send_request(
             JsonRpcMethod::GetTransactionByHash,
             [serde_json::to_value(Felt(transaction_hash))?],
-        )
-        .await
-    }
-
-    /// Get the details of a transaction by a given block hash and index
-    pub async fn get_transaction_by_block_hash_and_index(
-        &self,
-        block_hash: &BlockHashOrTag,
-        index: u64,
-    ) -> Result<Transaction, JsonRpcClientError<T::Error>> {
-        self.send_request(
-            JsonRpcMethod::GetTransactionByBlockHashAndIndex,
-            [
-                serde_json::to_value(block_hash)?,
-                serde_json::to_value(index)?,
-            ],
-        )
-        .await
-    }
-
-    /// Get the details of a transaction by a given block number and index
-    pub async fn get_transaction_by_block_number_and_index(
-        &self,
-        block_number: &BlockNumOrTag,
-        index: u64,
-    ) -> Result<Transaction, JsonRpcClientError<T::Error>> {
-        self.send_request(
-            JsonRpcMethod::GetTransactionByBlockNumberAndIndex,
-            [
-                serde_json::to_value(block_number)?,
-                serde_json::to_value(index)?,
-            ],
         )
         .await
     }
@@ -329,30 +187,6 @@ where
         self.send_request(
             JsonRpcMethod::GetClassAt,
             [serde_json::to_value(Felt(contract_address))?],
-        )
-        .await
-    }
-
-    /// Get the number of transactions in a block given a block hash
-    pub async fn get_block_transaction_count_by_hash(
-        &self,
-        block_hash: &BlockHashOrTag,
-    ) -> Result<u64, JsonRpcClientError<T::Error>> {
-        self.send_request(
-            JsonRpcMethod::GetBlockTransactionCountByHash,
-            [serde_json::to_value(block_hash)?],
-        )
-        .await
-    }
-
-    /// Get the number of transactions in a block given a block number (height)
-    pub async fn get_block_transaction_count_by_number(
-        &self,
-        block_number: &BlockNumOrTag,
-    ) -> Result<u64, JsonRpcClientError<T::Error>> {
-        self.send_request(
-            JsonRpcMethod::GetBlockTransactionCountByNumber,
-            [serde_json::to_value(block_number)?],
         )
         .await
     }

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -251,14 +251,18 @@ where
             .0)
     }
 
-    /// Get the contract class definition at the given address
+    /// Get the contract class definition in the given block at the given address
     pub async fn get_class_at(
         &self,
+        block_id: &BlockId,
         contract_address: FieldElement,
     ) -> Result<ContractClass, JsonRpcClientError<T::Error>> {
         self.send_request(
             JsonRpcMethod::GetClassAt,
-            [serde_json::to_value(Felt(contract_address))?],
+            [
+                serde_json::to_value(block_id)?,
+                serde_json::to_value(Felt(contract_address))?,
+            ],
         )
         .await
     }

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -356,7 +356,7 @@ where
     pub async fn estimate_fee<R>(
         &self,
         request: R,
-        block_hash: &BlockHashOrTag,
+        block_id: &BlockId,
     ) -> Result<FeeEstimate, JsonRpcClientError<T::Error>>
     where
         R: AsRef<FunctionCall>,
@@ -365,7 +365,7 @@ where
             JsonRpcMethod::EstimateFee,
             [
                 serde_json::to_value(request.as_ref())?,
-                serde_json::to_value(block_hash)?,
+                serde_json::to_value(block_id)?,
             ],
         )
         .await

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -39,6 +39,12 @@ pub enum JsonRpcMethod {
     GetClassHashAt,
     #[serde(rename = "starknet_getClassAt")]
     GetClassAt,
+    #[serde(rename = "starknet_getBlockTransactionCount")]
+    GetBlockTransactionCount,
+    #[serde(rename = "starknet_call")]
+    Call,
+    #[serde(rename = "starknet_estimateFee")]
+    EstimateFee,
     #[serde(rename = "starknet_blockNumber")]
     BlockNumber,
     #[serde(rename = "starknet_blockHashAndNumber")]
@@ -51,12 +57,6 @@ pub enum JsonRpcMethod {
     Syncing,
     #[serde(rename = "starknet_getEvents")]
     GetEvents,
-    #[serde(rename = "starknet_getBlockTransactionCount")]
-    GetBlockTransactionCount,
-    #[serde(rename = "starknet_call")]
-    Call,
-    #[serde(rename = "starknet_estimateFee")]
-    EstimateFee,
     #[serde(rename = "starknet_getNonce")]
     GetNonce,
     #[serde(rename = "starknet_addInvokeTransaction")]
@@ -267,58 +267,6 @@ where
         .await
     }
 
-    /// Get the most recent accepted block number
-    pub async fn block_number(&self) -> Result<u64, JsonRpcClientError<T::Error>> {
-        self.send_request(JsonRpcMethod::BlockNumber, ()).await
-    }
-
-    /// Get the most recent accepted block hash and number
-    pub async fn block_hash_and_number(
-        &self,
-    ) -> Result<BlockHashAndNumber, JsonRpcClientError<T::Error>> {
-        self.send_request(JsonRpcMethod::BlockHashAndNumber, ())
-            .await
-    }
-
-    /// Return the currently configured StarkNet chain id
-    pub async fn chain_id(&self) -> Result<FieldElement, JsonRpcClientError<T::Error>> {
-        Ok(self
-            .send_request::<_, Felt>(JsonRpcMethod::ChainId, ())
-            .await?
-            .0)
-    }
-
-    /// Returns the transactions in the transaction pool, recognized by this sequencer
-    pub async fn pending_transactions(
-        &self,
-    ) -> Result<Vec<Transaction>, JsonRpcClientError<T::Error>> {
-        self.send_request(JsonRpcMethod::PendingTransactions, ())
-            .await
-    }
-
-    /// Returns an object about the sync status, or false if the node is not synching
-    pub async fn syncing(&self) -> Result<SyncStatusType, JsonRpcClientError<T::Error>> {
-        self.send_request(JsonRpcMethod::Syncing, ()).await
-    }
-
-    /// Returns all events matching the given filter
-    pub async fn get_events(
-        &self,
-        filter: EventFilter,
-        page_size: u64,
-        page_number: u64,
-    ) -> Result<EventsPage, JsonRpcClientError<T::Error>> {
-        self.send_request(
-            JsonRpcMethod::GetEvents,
-            [serde_json::to_value(EventFilterWithPage {
-                filter,
-                page_size,
-                page_number,
-            })?],
-        )
-        .await
-    }
-
     /// Get the number of transactions in a block given a block id
     pub async fn get_block_transaction_count(
         &self,
@@ -367,6 +315,58 @@ where
                 serde_json::to_value(request.as_ref())?,
                 serde_json::to_value(block_id)?,
             ],
+        )
+        .await
+    }
+
+    /// Get the most recent accepted block number
+    pub async fn block_number(&self) -> Result<u64, JsonRpcClientError<T::Error>> {
+        self.send_request(JsonRpcMethod::BlockNumber, ()).await
+    }
+
+    /// Get the most recent accepted block hash and number
+    pub async fn block_hash_and_number(
+        &self,
+    ) -> Result<BlockHashAndNumber, JsonRpcClientError<T::Error>> {
+        self.send_request(JsonRpcMethod::BlockHashAndNumber, ())
+            .await
+    }
+
+    /// Return the currently configured StarkNet chain id
+    pub async fn chain_id(&self) -> Result<FieldElement, JsonRpcClientError<T::Error>> {
+        Ok(self
+            .send_request::<_, Felt>(JsonRpcMethod::ChainId, ())
+            .await?
+            .0)
+    }
+
+    /// Returns the transactions in the transaction pool, recognized by this sequencer
+    pub async fn pending_transactions(
+        &self,
+    ) -> Result<Vec<Transaction>, JsonRpcClientError<T::Error>> {
+        self.send_request(JsonRpcMethod::PendingTransactions, ())
+            .await
+    }
+
+    /// Returns an object about the sync status, or false if the node is not synching
+    pub async fn syncing(&self) -> Result<SyncStatusType, JsonRpcClientError<T::Error>> {
+        self.send_request(JsonRpcMethod::Syncing, ()).await
+    }
+
+    /// Returns all events matching the given filter
+    pub async fn get_events(
+        &self,
+        filter: EventFilter,
+        page_size: u64,
+        page_number: u64,
+    ) -> Result<EventsPage, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetEvents,
+            [serde_json::to_value(EventFilterWithPage {
+                filter,
+                page_size,
+                page_number,
+            })?],
         )
         .await
     }

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -23,6 +23,8 @@ pub enum JsonRpcMethod {
     GetBlockWithTxHashes,
     #[serde(rename = "starknet_getBlockWithTxs")]
     GetBlockWithTxs,
+    #[serde(rename = "starknet_getStateUpdate")]
+    GetStateUpdate,
     #[serde(rename = "starknet_getStorageAt")]
     GetStorageAt,
     #[serde(rename = "starknet_getTransactionByHash")]
@@ -132,6 +134,18 @@ where
     ) -> Result<MaybePendingBlockWithTxs, JsonRpcClientError<T::Error>> {
         self.send_request(
             JsonRpcMethod::GetBlockWithTxs,
+            [serde_json::to_value(block_id)?],
+        )
+        .await
+    }
+
+    /// Get the information about the result of executing the requested block
+    pub async fn get_state_update(
+        &self,
+        block_id: &BlockId,
+    ) -> Result<StateUpdate, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetStateUpdate,
             [serde_json::to_value(block_id)?],
         )
         .await

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -19,6 +19,8 @@ pub struct JsonRpcClient<T> {
 
 #[derive(Debug, Serialize)]
 pub enum JsonRpcMethod {
+    #[serde(rename = "starknet_getBlockWithTxHashes")]
+    GetBlockWithTxHashes,
     #[serde(rename = "starknet_getStorageAt")]
     GetStorageAt,
     #[serde(rename = "starknet_getTransactionByHash")]
@@ -109,6 +111,18 @@ impl<T> JsonRpcClient<T>
 where
     T: JsonRpcTransport,
 {
+    /// Get block information with transaction hashes given the block id
+    pub async fn get_block_with_tx_hashes(
+        &self,
+        block_id: &BlockId,
+    ) -> Result<MaybePendingBlockWithTxHashes, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetBlockWithTxHashes,
+            [serde_json::to_value(block_id)?],
+        )
+        .await
+    }
+
     /// Get the value of the storage at the given address and key
     pub async fn get_storage_at(
         &self,

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -21,6 +21,8 @@ pub struct JsonRpcClient<T> {
 pub enum JsonRpcMethod {
     #[serde(rename = "starknet_getBlockWithTxHashes")]
     GetBlockWithTxHashes,
+    #[serde(rename = "starknet_getBlockWithTxs")]
+    GetBlockWithTxs,
     #[serde(rename = "starknet_getStorageAt")]
     GetStorageAt,
     #[serde(rename = "starknet_getTransactionByHash")]
@@ -118,6 +120,18 @@ where
     ) -> Result<MaybePendingBlockWithTxHashes, JsonRpcClientError<T::Error>> {
         self.send_request(
             JsonRpcMethod::GetBlockWithTxHashes,
+            [serde_json::to_value(block_id)?],
+        )
+        .await
+    }
+
+    /// Get block information with full transactions given the block id
+    pub async fn get_block_with_txs(
+        &self,
+        block_id: &BlockId,
+    ) -> Result<MaybePendingBlockWithTxs, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetBlockWithTxs,
             [serde_json::to_value(block_id)?],
         )
         .await

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -41,6 +41,8 @@ pub enum JsonRpcMethod {
     GetClassAt,
     #[serde(rename = "starknet_blockNumber")]
     BlockNumber,
+    #[serde(rename = "starknet_blockHashAndNumber")]
+    BlockHashAndNumber,
     #[serde(rename = "starknet_chainId")]
     ChainId,
     #[serde(rename = "starknet_syncing")]
@@ -258,6 +260,14 @@ where
     /// Get the most recent accepted block number
     pub async fn block_number(&self) -> Result<u64, JsonRpcClientError<T::Error>> {
         self.send_request(JsonRpcMethod::BlockNumber, ()).await
+    }
+
+    /// Get the most recent accepted block hash and number
+    pub async fn block_hash_and_number(
+        &self,
+    ) -> Result<BlockHashAndNumber, JsonRpcClientError<T::Error>> {
+        self.send_request(JsonRpcMethod::BlockHashAndNumber, ())
+            .await
     }
 
     /// Return the currently configured StarkNet chain id

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -166,7 +166,7 @@ where
         &self,
         contract_address: FieldElement,
         key: FieldElement,
-        block_hash: &BlockHashOrTag,
+        block_id: &BlockId,
     ) -> Result<FieldElement, JsonRpcClientError<T::Error>> {
         Ok(self
             .send_request::<_, Felt>(
@@ -174,7 +174,7 @@ where
                 [
                     serde_json::to_value(Felt(contract_address))?,
                     serde_json::to_value(Felt(key))?,
-                    serde_json::to_value(block_hash)?,
+                    serde_json::to_value(block_id)?,
                 ],
             )
             .await?

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -47,6 +47,8 @@ pub enum JsonRpcMethod {
     Syncing,
     #[serde(rename = "starknet_getEvents")]
     GetEvents,
+    #[serde(rename = "starknet_getBlockTransactionCount")]
+    GetBlockTransactionCount,
     #[serde(rename = "starknet_call")]
     Call,
     #[serde(rename = "starknet_estimateFee")]
@@ -283,6 +285,18 @@ where
                 page_size,
                 page_number,
             })?],
+        )
+        .await
+    }
+
+    /// Get the number of transactions in a block given a block id
+    pub async fn get_block_transaction_count(
+        &self,
+        block_id: &BlockId,
+    ) -> Result<u64, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetBlockTransactionCount,
+            [serde_json::to_value(block_id)?],
         )
         .await
     }

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -45,6 +45,8 @@ pub enum JsonRpcMethod {
     BlockHashAndNumber,
     #[serde(rename = "starknet_chainId")]
     ChainId,
+    #[serde(rename = "starknet_pendingTransactions")]
+    PendingTransactions,
     #[serde(rename = "starknet_syncing")]
     Syncing,
     #[serde(rename = "starknet_getEvents")]
@@ -276,6 +278,14 @@ where
             .send_request::<_, Felt>(JsonRpcMethod::ChainId, ())
             .await?
             .0)
+    }
+
+    /// Returns the transactions in the transaction pool, recognized by this sequencer
+    pub async fn pending_transactions(
+        &self,
+    ) -> Result<Vec<Transaction>, JsonRpcClientError<T::Error>> {
+        self.send_request(JsonRpcMethod::PendingTransactions, ())
+            .await
     }
 
     /// Returns an object about the sync status, or false if the node is not synching

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -29,6 +29,8 @@ pub enum JsonRpcMethod {
     GetStorageAt,
     #[serde(rename = "starknet_getTransactionByHash")]
     GetTransactionByHash,
+    #[serde(rename = "starknet_getTransactionByBlockIdAndIndex")]
+    GetTransactionByBlockIdAndIndex,
     #[serde(rename = "starknet_getTransactionReceipt")]
     GetTransactionReceipt,
     #[serde(rename = "starknet_getClass")]
@@ -179,6 +181,22 @@ where
         self.send_request(
             JsonRpcMethod::GetTransactionByHash,
             [serde_json::to_value(Felt(transaction_hash))?],
+        )
+        .await
+    }
+
+    /// Get the details of a transaction by a given block id and index
+    pub async fn get_transaction_by_block_id_and_index(
+        &self,
+        block_id: &BlockId,
+        index: u64,
+    ) -> Result<Transaction, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::GetTransactionByBlockIdAndIndex,
+            [
+                serde_json::to_value(block_id)?,
+                serde_json::to_value(index)?,
+            ],
         )
         .await
     }

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -335,7 +335,7 @@ where
     pub async fn call<R>(
         &self,
         request: R,
-        block_hash: &BlockHashOrTag,
+        block_id: &BlockId,
     ) -> Result<Vec<FieldElement>, JsonRpcClientError<T::Error>>
     where
         R: AsRef<FunctionCall>,
@@ -345,7 +345,7 @@ where
                 JsonRpcMethod::Call,
                 [
                     serde_json::to_value(request.as_ref())?,
-                    serde_json::to_value(block_hash)?,
+                    serde_json::to_value(block_id)?,
                 ],
             )
             .await?

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -233,15 +233,19 @@ where
         .await
     }
 
-    /// Get the contract class hash for the contract deployed at the given address
+    /// Get the contract class hash in the given block for the contract deployed at the given address
     pub async fn get_class_hash_at(
         &self,
+        block_id: &BlockId,
         contract_address: FieldElement,
     ) -> Result<FieldElement, JsonRpcClientError<T::Error>> {
         Ok(self
             .send_request::<_, Felt>(
                 JsonRpcMethod::GetClassHashAt,
-                [serde_json::to_value(Felt(contract_address))?],
+                [
+                    serde_json::to_value(block_id)?,
+                    serde_json::to_value(Felt(contract_address))?,
+                ],
             )
             .await?
             .0)

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -213,7 +213,7 @@ where
     pub async fn get_transaction_receipt(
         &self,
         transaction_hash: FieldElement,
-    ) -> Result<TransactionReceipt, JsonRpcClientError<T::Error>> {
+    ) -> Result<MaybePendingTransactionReceipt, JsonRpcClientError<T::Error>> {
         self.send_request(
             JsonRpcMethod::GetTransactionReceipt,
             [serde_json::to_value(Felt(transaction_hash))?],

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -53,6 +53,8 @@ pub enum JsonRpcMethod {
     Call,
     #[serde(rename = "starknet_estimateFee")]
     EstimateFee,
+    #[serde(rename = "starknet_getNonce")]
+    GetNonce,
     #[serde(rename = "starknet_addInvokeTransaction")]
     AddInvokeTransaction,
     #[serde(rename = "starknet_addDeclareTransaction")]
@@ -339,6 +341,20 @@ where
             ],
         )
         .await
+    }
+
+    /// Get the latest nonce associated with the given address
+    pub async fn get_nonce(
+        &self,
+        contract_address: FieldElement,
+    ) -> Result<FieldElement, JsonRpcClientError<T::Error>> {
+        Ok(self
+            .send_request::<_, Felt>(
+                JsonRpcMethod::GetNonce,
+                [serde_json::to_value(Felt(contract_address))?],
+            )
+            .await?
+            .0)
     }
 
     /// Submit a new transaction to be added to the chain

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -386,15 +386,6 @@ pub struct EventFilter {
     pub keys: Option<Vec<FieldElement>>,
 }
 
-/// Block hash or tag
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum BlockHashOrTag {
-    Hash(#[serde_as(as = "UfeHex")] FieldElement),
-    Tag(BlockTag),
-}
-
 #[derive(Debug, Clone)]
 pub enum SyncStatusType {
     Syncing(SyncStatus),
@@ -481,6 +472,7 @@ pub enum TransactionStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FeeEstimate {
     /// The Ethereum gas cost of the transaction
+    /// (see https://docs.starknet.io/docs/Fees/fee-mechanism for more info)
     #[serde_as(as = "UfeHex")]
     pub gas_consumed: FieldElement,
     /// The gas price (in gwei) that was used in the cost estimation

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -296,6 +296,7 @@ pub struct FunctionCall {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EventsPage {
+    /// Matching events
     pub events: Vec<EmittedEvent>,
     /// The returned page number
     pub page_number: u64,
@@ -371,12 +372,16 @@ pub struct ContractEntryPoint {
 
 /// An event filter/query
 #[serde_as]
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct EventFilter {
+    // Using `fromBlock` instead of `from_block` for now due to pathfinder bug:
+    //   https://github.com/eqlabs/pathfinder/issues/536
     #[serde(rename = "fromBlock", skip_serializing_if = "Option::is_none")]
-    pub from_block: Option<u64>,
+    pub from_block: Option<BlockId>,
+    // Using `toBlock` instead of `to_block` for now due to pathfinder bug:
+    //   https://github.com/eqlabs/pathfinder/issues/536
     #[serde(rename = "toBlock", skip_serializing_if = "Option::is_none")]
-    pub to_block: Option<u64>,
+    pub to_block: Option<BlockId>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[serde_as(as = "Option<UfeHex>")]
     pub address: Option<FieldElement>,

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -43,6 +43,42 @@ pub enum BlockTag {
 
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateUpdate {
+    #[serde_as(as = "UfeHex")]
+    pub block_hash: FieldElement,
+    /// The new global state root
+    #[serde_as(as = "UfeHex")]
+    pub new_root: FieldElement,
+    /// The previous global state root
+    #[serde_as(as = "UfeHex")]
+    pub old_root: FieldElement,
+    /// The change in state applied in this block, given as a mapping of addresses to the new values
+    /// and/or new contracts
+    pub state_diff: StateDiff,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateDiff {
+    pub storage_diffs: Vec<StorageDiffItem>,
+    pub declared_contracts: Vec<DeclaredContractItem>,
+    pub deployed_contracts: Vec<DeployedContractItem>,
+    pub nonces: Vec<NonceUpdate>,
+}
+
+/// The updated nonce per contract address
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NonceUpdate {
+    /// The address of the contract
+    #[serde_as(as = "UfeHex")]
+    pub contract_address: FieldElement,
+    /// The nonce for the given address at the end of the block
+    #[serde_as(as = "UfeHex")]
+    pub nonce: FieldElement,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlockHeader {
     #[serde_as(as = "UfeHex")]
     pub block_hash: FieldElement,
@@ -117,6 +153,42 @@ pub struct PendingBlockWithTxs {
     /// The hash of this block's parent
     #[serde_as(as = "UfeHex")]
     pub parent_hash: FieldElement,
+}
+
+/// A new contract declared as part of the new state
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeclaredContractItem {
+    /// The hash of the contract code
+    #[serde_as(as = "UfeHex")]
+    pub class_hash: FieldElement,
+}
+
+/// A new contract deployed as part of the new state
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeployedContractItem {
+    /// The address of the contract
+    #[serde_as(as = "UfeHex")]
+    pub address: FieldElement,
+    /// The hash of the contract code
+    #[serde_as(as = "UfeHex")]
+    pub class_hash: FieldElement,
+}
+
+/// A change in a single storage item
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageDiffItem {
+    /// The contract address for which the state changed
+    #[serde_as(as = "UfeHex")]
+    pub address: FieldElement,
+    /// The key of the changed value
+    #[serde_as(as = "UfeHex")]
+    pub key: FieldElement,
+    /// The new value applied to the given address
+    #[serde_as(as = "UfeHex")]
+    pub value: FieldElement,
 }
 
 /// Transaction (`TXN`)

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -493,6 +493,14 @@ pub struct FeeEstimate {
 
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockHashAndNumber {
+    #[serde_as(as = "UfeHex")]
+    pub block_hash: FieldElement,
+    pub block_number: u64,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InvokeTransactionResult {
     /// The hash of the invoke transaction
     #[serde_as(as = "UfeHex")]

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -57,17 +57,6 @@ pub struct EventContent {
     pub data: Vec<FieldElement>,
 }
 
-/// The status of the block
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum BlockStatus {
-    Pending,
-    Proven,
-    AcceptedOnL2,
-    AcceptedOnL1,
-    Rejected,
-}
-
 /// Function call information
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -136,15 +125,6 @@ pub enum BlockHashOrTag {
     Tag(BlockTag),
 }
 
-/// Block number or tag
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum BlockNumOrTag {
-    Number(u64),
-    Tag(BlockTag),
-}
-
 /// A tag specifying a dynamic reference to a block
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -183,92 +163,6 @@ pub struct SyncStatus {
     /// The number (height) of the estimated highest block to be synchronized
     #[serde_as(as = "NumAsHex")]
     pub highest_block_num: u64,
-}
-
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Block {
-    #[serde(flatten)]
-    pub metadata: BlockMeta,
-    #[serde_as(as = "Vec<UfeHex>")]
-    pub transactions: Vec<FieldElement>,
-}
-
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlockWithTxns {
-    #[serde(flatten)]
-    pub metadata: BlockMeta,
-    pub transactions: Vec<Transaction>,
-}
-
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlockWithReceipts {
-    #[serde(flatten)]
-    pub metadata: BlockMeta,
-    pub transactions: Vec<TransactionWithReceipt>,
-}
-
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlockMeta {
-    #[serde_as(as = "UfeHex")]
-    pub block_hash: FieldElement,
-    /// The hash of this block's parent
-    #[serde_as(as = "UfeHex")]
-    pub parent_hash: FieldElement,
-    /// The block number (its height)
-    pub block_number: u64,
-    pub status: BlockStatus,
-    /// The identity of the sequencer submitting this block
-    #[serde_as(as = "UfeHex")]
-    // This should be `ETH_ADDRESS` according to spec but it seems to be wrong
-    pub sequencer: FieldElement,
-    /// The new global state root
-    #[serde_as(as = "UfeHex")]
-    pub new_root: FieldElement,
-    /// The previous global state root
-    #[serde_as(as = "UfeHex")]
-    pub old_root: FieldElement,
-    /// When the block was accepted on L1. Formatted as...
-    pub accepted_time: u64,
-}
-
-// Cannot use `#[serde(flatten)]` here due to `tx_hash` field collision, so unfortunately we have
-// to write duplicate code.
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TransactionWithReceipt {
-    #[serde_as(as = "UfeHex")]
-    pub contract_address: FieldElement,
-    // None for deploy txs
-    #[serde(default)]
-    #[serde_as(as = "Option<UfeHex>")]
-    pub entry_point_selector: Option<FieldElement>,
-    // None for deploy txs
-    #[serde(default)]
-    #[serde_as(as = "Option<Vec<UfeHex>>")]
-    pub calldata: Option<Vec<FieldElement>>,
-    /// The hash identifying the transaction
-    #[serde_as(as = "UfeHex")]
-    pub txn_hash: FieldElement,
-    /// The maximal fee that can be charged for including the transaction (None for non-invoke
-    /// transactions).
-    #[serde(default)]
-    #[serde_as(as = "Option<UfeHex>")]
-    pub max_fee: Option<FieldElement>,
-    /// The fee that was charged by the sequencer
-    #[serde_as(as = "UfeHex")]
-    pub actual_fee: FieldElement,
-    pub status: TransactionStatus,
-    /// Extra information pertaining to the status
-    pub status_data: String,
-    pub messages_sent: Vec<MsgToL1>,
-    /// In case this transaction was an L1 handler, this is the original message that invoked it
-    pub l1_origin_message: Option<MsgToL2>,
-    /// The events emitted as part of this transaction
-    pub events: Vec<Event>,
 }
 
 // Manually porting the `FunctionCall` fields here instead of flattening like the specification

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -7,9 +7,9 @@ use starknet_core::{
 };
 use starknet_providers::jsonrpc::{
     models::{
-        BlockHashOrTag, BlockId, BlockTag, ContractClass, ContractEntryPoint, EntryPointsByType,
-        EventFilter, FunctionCall, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs,
-        SyncStatusType, Transaction,
+        BlockId, BlockTag, ContractClass, ContractEntryPoint, EntryPointsByType, EventFilter,
+        FunctionCall, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs, SyncStatusType,
+        Transaction,
     },
     HttpTransport, JsonRpcClient, JsonRpcClientError,
 };
@@ -392,7 +392,7 @@ async fn jsonrpc_estimate_fee() {
                 )
                 .unwrap()],
             },
-            &BlockHashOrTag::Tag(BlockTag::Latest),
+            &BlockId::Tag(BlockTag::Latest),
         )
         .await
         .unwrap();

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -260,6 +260,7 @@ async fn jsonrpc_get_class_at() {
 
     let class = rpc_client
         .get_class_at(
+            &BlockId::Tag(BlockTag::Latest),
             FieldElement::from_hex_be(
                 "06b3dab9c563083e7e74d9a7ab7649f7af4564cfef397f8e44233a1feffc7049",
             )

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -273,70 +273,6 @@ async fn jsonrpc_get_class_at() {
 }
 
 #[tokio::test]
-async fn jsonrpc_block_number() {
-    let rpc_client = create_jsonrpc_client();
-
-    let block_number = rpc_client.block_number().await.unwrap();
-    assert!(block_number > 0);
-}
-
-#[tokio::test]
-async fn jsonrpc_block_hash_and_number() {
-    let rpc_client = create_jsonrpc_client();
-
-    let id = rpc_client.block_hash_and_number().await.unwrap();
-
-    assert!(id.block_hash > FieldElement::ZERO);
-    assert!(id.block_number > 0);
-}
-
-#[tokio::test]
-async fn jsonrpc_chain_id() {
-    let rpc_client = create_jsonrpc_client();
-
-    let chain_id = rpc_client.chain_id().await.unwrap();
-    assert!(chain_id > FieldElement::ZERO);
-}
-
-#[tokio::test]
-async fn jsonrpc_pending_transactions() {
-    let rpc_client = create_jsonrpc_client();
-
-    rpc_client.pending_transactions().await.unwrap();
-}
-
-#[tokio::test]
-async fn jsonrpc_syncing() {
-    let rpc_client = create_jsonrpc_client();
-
-    let syncing = rpc_client.syncing().await.unwrap();
-    if let SyncStatusType::Syncing(sync_status) = syncing {
-        assert!(sync_status.highest_block_num > 0);
-    }
-}
-
-#[tokio::test]
-async fn jsonrpc_get_events() {
-    let rpc_client = create_jsonrpc_client();
-
-    let events = rpc_client
-        .get_events(
-            EventFilter {
-                from_block: Some(BlockId::Number(234500)),
-                to_block: None,
-                address: None,
-                keys: None,
-            },
-            20,
-            10,
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(events.events.len(), 20);
-}
-
-#[tokio::test]
 async fn jsonrpc_get_block_transaction_count() {
     let rpc_client = create_jsonrpc_client();
 
@@ -401,6 +337,70 @@ async fn jsonrpc_estimate_fee() {
     //   https://github.com/eqlabs/pathfinder/issues/412
     assert!(estimate.gas_price > FieldElement::ZERO);
     assert!(estimate.overall_fee > FieldElement::ZERO);
+}
+
+#[tokio::test]
+async fn jsonrpc_block_number() {
+    let rpc_client = create_jsonrpc_client();
+
+    let block_number = rpc_client.block_number().await.unwrap();
+    assert!(block_number > 0);
+}
+
+#[tokio::test]
+async fn jsonrpc_block_hash_and_number() {
+    let rpc_client = create_jsonrpc_client();
+
+    let id = rpc_client.block_hash_and_number().await.unwrap();
+
+    assert!(id.block_hash > FieldElement::ZERO);
+    assert!(id.block_number > 0);
+}
+
+#[tokio::test]
+async fn jsonrpc_chain_id() {
+    let rpc_client = create_jsonrpc_client();
+
+    let chain_id = rpc_client.chain_id().await.unwrap();
+    assert!(chain_id > FieldElement::ZERO);
+}
+
+#[tokio::test]
+async fn jsonrpc_pending_transactions() {
+    let rpc_client = create_jsonrpc_client();
+
+    rpc_client.pending_transactions().await.unwrap();
+}
+
+#[tokio::test]
+async fn jsonrpc_syncing() {
+    let rpc_client = create_jsonrpc_client();
+
+    let syncing = rpc_client.syncing().await.unwrap();
+    if let SyncStatusType::Syncing(sync_status) = syncing {
+        assert!(sync_status.highest_block_num > 0);
+    }
+}
+
+#[tokio::test]
+async fn jsonrpc_get_events() {
+    let rpc_client = create_jsonrpc_client();
+
+    let events = rpc_client
+        .get_events(
+            EventFilter {
+                from_block: Some(BlockId::Number(234500)),
+                to_block: None,
+                address: None,
+                keys: None,
+            },
+            20,
+            10,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(events.events.len(), 20);
 }
 
 #[tokio::test]

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -318,6 +318,18 @@ async fn jsonrpc_get_events() {
 }
 
 #[tokio::test]
+async fn jsonrpc_get_block_transaction_count() {
+    let rpc_client = create_jsonrpc_client();
+
+    let count = rpc_client
+        .get_block_transaction_count(&BlockId::Number(20_000))
+        .await
+        .unwrap();
+
+    assert_eq!(count, 4);
+}
+
+#[tokio::test]
 async fn jsonrpc_call() {
     let rpc_client = create_jsonrpc_client();
 

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -131,7 +131,7 @@ async fn jsonrpc_get_storage_at() {
                 .unwrap()],
             )
             .unwrap(),
-            &BlockHashOrTag::Tag(BlockTag::Latest),
+            &BlockId::Tag(BlockTag::Latest),
         )
         .await
         .unwrap();

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -8,8 +8,8 @@ use starknet_core::{
 use starknet_providers::jsonrpc::{
     models::{
         BlockId, BlockTag, ContractClass, ContractEntryPoint, EntryPointsByType, EventFilter,
-        FunctionCall, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs, SyncStatusType,
-        Transaction,
+        FunctionCall, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs,
+        MaybePendingTransactionReceipt, SyncStatusType, Transaction, TransactionReceipt,
     },
     HttpTransport, JsonRpcClient, JsonRpcClientError,
 };
@@ -210,7 +210,12 @@ async fn jsonrpc_get_transaction_receipt() {
         .await
         .unwrap();
 
-    assert!(receipt.actual_fee > FieldElement::ZERO);
+    let receipt = match receipt {
+        MaybePendingTransactionReceipt::Receipt(TransactionReceipt::Invoke(receipt)) => receipt,
+        _ => panic!("unexpected receipt response type"),
+    };
+
+    assert!(receipt.meta.actual_fee > FieldElement::ZERO);
 }
 
 #[tokio::test]

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -385,6 +385,23 @@ async fn jsonrpc_estimate_fee() {
 }
 
 #[tokio::test]
+async fn jsonrpc_get_nonce() {
+    let rpc_client = create_jsonrpc_client();
+
+    let nonce = rpc_client
+        .get_nonce(
+            FieldElement::from_hex_be(
+                "0661d341c2ba6f3c2b277e54d507e4b49b0c4d8973ac7366a035d0d3e8bdec47",
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(nonce, FieldElement::ZERO);
+}
+
+#[tokio::test]
 async fn jsonrpc_add_invoke_transaction() {
     let rpc_client = create_jsonrpc_client();
 

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -7,8 +7,8 @@ use starknet_core::{
 };
 use starknet_providers::jsonrpc::{
     models::{
-        BlockHashOrTag, BlockNumOrTag, BlockTag, ContractClass, ContractEntryPoint,
-        EntryPointsByType, EventFilter, FunctionCall, SyncStatusType,
+        BlockHashOrTag, BlockTag, ContractClass, ContractEntryPoint, EntryPointsByType,
+        EventFilter, FunctionCall, SyncStatusType,
     },
     HttpTransport, JsonRpcClient, JsonRpcClientError,
 };
@@ -63,72 +63,6 @@ fn create_contract_class() -> ContractClass {
                 .collect(),
         },
     }
-}
-
-#[tokio::test]
-async fn jsonrpc_get_block_by_hash() {
-    let rpc_client = create_jsonrpc_client();
-
-    let block = rpc_client
-        .get_block_by_hash(&BlockHashOrTag::Tag(BlockTag::Latest))
-        .await
-        .unwrap();
-    assert!(block.metadata.block_number > 0);
-}
-
-#[tokio::test]
-async fn jsonrpc_get_block_by_hash_with_txns() {
-    let rpc_client = create_jsonrpc_client();
-
-    let block = rpc_client
-        .get_block_by_hash_with_txns(&BlockHashOrTag::Tag(BlockTag::Latest))
-        .await
-        .unwrap();
-    assert!(block.metadata.block_number > 0);
-}
-
-#[tokio::test]
-async fn jsonrpc_get_block_by_hash_with_receipts() {
-    let rpc_client = create_jsonrpc_client();
-
-    let block = rpc_client
-        .get_block_by_hash_with_receipts(&BlockHashOrTag::Tag(BlockTag::Latest))
-        .await
-        .unwrap();
-    assert!(block.metadata.block_number > 0);
-}
-
-#[tokio::test]
-async fn jsonrpc_get_block_by_number() {
-    let rpc_client = create_jsonrpc_client();
-
-    let block = rpc_client
-        .get_block_by_number(&BlockNumOrTag::Number(234469))
-        .await
-        .unwrap();
-    assert!(block.metadata.block_number > 0);
-}
-
-#[tokio::test]
-async fn jsonrpc_get_block_by_number_with_txns() {
-    let rpc_client = create_jsonrpc_client();
-
-    let block = rpc_client
-        .get_block_by_number_with_txns(&BlockNumOrTag::Number(234469))
-        .await
-        .unwrap();
-    assert!(block.metadata.block_number > 0);
-}
-
-#[tokio::test]
-async fn jsonrpc_get_block_by_number_with_receipts() {
-    let rpc_client = create_jsonrpc_client();
-
-    let block = rpc_client
-        .get_block_by_number_with_receipts(&BlockNumOrTag::Number(234469))
-        .await
-        .unwrap();
-    assert!(block.metadata.block_number > 0);
 }
 
 #[tokio::test]
@@ -191,38 +125,6 @@ async fn jsonrpc_get_transaction_by_hash_non_existent_tx() {
         }
         _ => panic!("Unexpected error"),
     }
-}
-
-#[tokio::test]
-async fn jsonrpc_get_transaction_by_block_hash_and_index() {
-    let rpc_client = create_jsonrpc_client();
-
-    let tx = rpc_client
-        .get_transaction_by_block_hash_and_index(
-            &BlockHashOrTag::Hash(
-                FieldElement::from_hex_be(
-                    "04d893935543cc0a39d1ce1597695e0fc02f9512781e0b23f41bbb01b0c6b5f1",
-                )
-                .unwrap(),
-            ),
-            0,
-        )
-        .await
-        .unwrap();
-
-    assert!(tx.entry_point_selector.is_some());
-}
-
-#[tokio::test]
-async fn jsonrpc_get_transaction_by_block_number_and_index() {
-    let rpc_client = create_jsonrpc_client();
-
-    let tx = rpc_client
-        .get_transaction_by_block_number_and_index(&BlockNumOrTag::Number(234500), 0)
-        .await
-        .unwrap();
-
-    assert!(tx.entry_point_selector.is_some());
 }
 
 #[tokio::test]
@@ -297,35 +199,6 @@ async fn jsonrpc_get_class_at() {
         .unwrap();
 
     assert!(!class.program.is_empty());
-}
-
-#[tokio::test]
-async fn jsonrpc_get_block_transaction_count_by_hash() {
-    let rpc_client = create_jsonrpc_client();
-
-    let tx_count = rpc_client
-        .get_block_transaction_count_by_hash(&BlockHashOrTag::Hash(
-            FieldElement::from_hex_be(
-                "0ef4773e814cf100e0535fe5ddffcb8d1d966fc81a9cdf9ca94b2672e130334",
-            )
-            .unwrap(),
-        ))
-        .await
-        .unwrap();
-
-    assert_eq!(tx_count, 45);
-}
-
-#[tokio::test]
-async fn jsonrpc_get_block_transaction_count_by_number() {
-    let rpc_client = create_jsonrpc_client();
-
-    let tx_count = rpc_client
-        .get_block_transaction_count_by_number(&BlockNumOrTag::Number(234519))
-        .await
-        .unwrap();
-
-    assert_eq!(tx_count, 45);
 }
 
 #[tokio::test]

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -236,6 +236,7 @@ async fn jsonrpc_get_class_hash_at() {
 
     let class_hash = rpc_client
         .get_class_hash_at(
+            &BlockId::Tag(BlockTag::Latest),
             FieldElement::from_hex_be(
                 "06b3dab9c563083e7e74d9a7ab7649f7af4564cfef397f8e44233a1feffc7049",
             )

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -7,8 +7,8 @@ use starknet_core::{
 };
 use starknet_providers::jsonrpc::{
     models::{
-        BlockHashOrTag, BlockTag, ContractClass, ContractEntryPoint, EntryPointsByType,
-        EventFilter, FunctionCall, SyncStatusType,
+        BlockHashOrTag, BlockId, BlockTag, ContractClass, ContractEntryPoint, EntryPointsByType,
+        EventFilter, FunctionCall, MaybePendingBlockWithTxHashes, SyncStatusType,
     },
     HttpTransport, JsonRpcClient, JsonRpcClientError,
 };
@@ -63,6 +63,23 @@ fn create_contract_class() -> ContractClass {
                 .collect(),
         },
     }
+}
+
+#[tokio::test]
+async fn jsonrpc_get_block_with_tx_hashes() {
+    let rpc_client = create_jsonrpc_client();
+
+    let block = rpc_client
+        .get_block_with_tx_hashes(&BlockId::Tag(BlockTag::Latest))
+        .await
+        .unwrap();
+
+    let block = match block {
+        MaybePendingBlockWithTxHashes::Block(block) => block,
+        _ => panic!("unexpected block response type"),
+    };
+
+    assert!(block.header.block_number > 0);
 }
 
 #[tokio::test]

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -366,7 +366,7 @@ async fn jsonrpc_call() {
                 )
                 .unwrap()],
             },
-            &BlockHashOrTag::Tag(BlockTag::Latest),
+            &BlockId::Tag(BlockTag::Latest),
         )
         .await
         .unwrap();

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -279,6 +279,16 @@ async fn jsonrpc_block_number() {
 }
 
 #[tokio::test]
+async fn jsonrpc_block_hash_and_number() {
+    let rpc_client = create_jsonrpc_client();
+
+    let id = rpc_client.block_hash_and_number().await.unwrap();
+
+    assert!(id.block_hash > FieldElement::ZERO);
+    assert!(id.block_number > 0);
+}
+
+#[tokio::test]
 async fn jsonrpc_chain_id() {
     let rpc_client = create_jsonrpc_client();
 

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -101,6 +101,18 @@ async fn jsonrpc_get_block_with_txs() {
 }
 
 #[tokio::test]
+async fn jsonrpc_get_state_update() {
+    let rpc_client = create_jsonrpc_client();
+
+    let state_update = rpc_client
+        .get_state_update(&BlockId::Tag(BlockTag::Latest))
+        .await
+        .unwrap();
+
+    assert!(state_update.new_root > FieldElement::ZERO);
+}
+
+#[tokio::test]
 async fn jsonrpc_get_storage_at() {
     let rpc_client = create_jsonrpc_client();
 

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -297,6 +297,13 @@ async fn jsonrpc_chain_id() {
 }
 
 #[tokio::test]
+async fn jsonrpc_pending_transactions() {
+    let rpc_client = create_jsonrpc_client();
+
+    rpc_client.pending_transactions().await.unwrap();
+}
+
+#[tokio::test]
 async fn jsonrpc_syncing() {
     let rpc_client = create_jsonrpc_client();
 

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -162,6 +162,23 @@ async fn jsonrpc_get_transaction_by_hash() {
 }
 
 #[tokio::test]
+async fn jsonrpc_get_transaction_by_block_id_and_index() {
+    let rpc_client = create_jsonrpc_client();
+
+    let tx = rpc_client
+        .get_transaction_by_block_id_and_index(&BlockId::Number(10_000), 1)
+        .await
+        .unwrap();
+
+    let tx = match tx {
+        Transaction::Invoke(tx) => tx,
+        _ => panic!("unexpected tx response type"),
+    };
+
+    assert!(tx.function_call.entry_point_selector > FieldElement::ZERO);
+}
+
+#[tokio::test]
 async fn jsonrpc_get_transaction_by_hash_non_existent_tx() {
     let rpc_client = create_jsonrpc_client();
 

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -322,7 +322,7 @@ async fn jsonrpc_get_events() {
     let events = rpc_client
         .get_events(
             EventFilter {
-                from_block: Some(234500),
+                from_block: Some(BlockId::Number(234500)),
                 to_block: None,
                 address: None,
                 keys: None,


### PR DESCRIPTION
Resolves #200.

**:warning: This PR contains breaking changes since the spec itself introduced many such changes :warning:**

The official StarkNet JSON-RPC specification had been quite messy and inconsistent until the v0.1.0 release, which was why `starknet-rs` didn't attempt to catch up with the spec before. However, with the v0.1.0 release, despite some small issues, the quality of the spec has improved drastically. `pathfinder` also supported this spec version in their [v0.3.0 release](https://github.com/eqlabs/pathfinder/releases/tag/v0.3.0-alpha), with minor deviations:

- the `starknet_protocolVersion` method is not implemented by design (method to be removed in spec v0.2.0); and
- incorrect param names in `starknet_getEvents`: https://github.com/eqlabs/pathfinder/issues/536 (this issue has already been fixed; release pending).

For the sake of maximizing compatibility, this PR follows these deviations (so _technically_ we do not fully support spec v0.1.0), but will fix them as soon as `pathfinder` itself does.