### PR TITLE
docs: add supported JSON-RPC spec version to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 **Complete StarkNet library in Rust**
 
 ![starknet-version-v0.9.1](https://img.shields.io/badge/StarkNet_Version-v0.9.1-2ea44f?logo=ethereum)
+[![jsonrpc-spec-v0.1.0](https://img.shields.io/badge/JSON--RPC-v0.1.0-2ea44f?logo=ethereum)](https://github.com/starkware-libs/starknet-specs/tree/v0.1.0)
 [![linting-badge](https://github.com/xJonathanLEI/starknet-rs/actions/workflows/lint.yaml/badge.svg?branch=master)](https://github.com/xJonathanLEI/starknet-rs/actions/workflows/lint.yaml)
 [![crates-badge](https://img.shields.io/crates/v/starknet.svg)](https://crates.io/crates/starknet)
 


### PR DESCRIPTION
This PR adds yet another badge to README showing the supported JSON-RPC specification version, linking to the spec repo with the specific version tag.