### PR TITLE
feat: resolve sequencer API changes

### DIFF
--- a/examples/sequencer_erc20_balance.rs
+++ b/examples/sequencer_erc20_balance.rs
@@ -1,5 +1,5 @@
 use starknet::{
-    core::types::{BlockId, FieldElement, InvokeFunctionTransactionRequest},
+    core::types::{BlockId, CallFunction, FieldElement},
     macros::{felt, selector},
     providers::{Provider, SequencerGatewayProvider},
 };
@@ -12,15 +12,13 @@ async fn main() {
 
     let call_result = provider
         .call_contract(
-            InvokeFunctionTransactionRequest {
+            CallFunction {
                 contract_address: tst_token_address,
                 entry_point_selector: selector!("balanceOf"),
                 calldata: vec![FieldElement::from_hex_be(
                     "YOUR_ACCOUNT_CONTRACT_ADDRESS_IN_HEX_HERE",
                 )
                 .unwrap()],
-                signature: vec![],
-                max_fee: FieldElement::ZERO,
             },
             BlockId::Latest,
         )

--- a/starknet-accounts/src/single_owner.rs
+++ b/starknet-accounts/src/single_owner.rs
@@ -7,8 +7,8 @@ use async_trait::async_trait;
 use starknet_core::{
     crypto::compute_hash_on_elements,
     types::{
-        AddTransactionResult, BlockId, FeeEstimate, FieldElement, InvokeFunctionTransactionRequest,
-        TransactionRequest,
+        AddTransactionResult, BlockId, CallFunction, FeeEstimate, FieldElement,
+        InvokeFunctionTransactionRequest, TransactionRequest,
     },
     utils::get_selector_from_name,
 };
@@ -188,12 +188,10 @@ where
         let call_result = self
             .provider
             .call_contract(
-                InvokeFunctionTransactionRequest {
+                CallFunction {
                     contract_address: self.address,
                     entry_point_selector: get_selector_from_name("get_nonce").unwrap(),
                     calldata: vec![],
-                    signature: vec![],
-                    max_fee: FieldElement::ZERO,
                 },
                 block_identifier,
             )

--- a/starknet-accounts/src/single_owner.rs
+++ b/starknet-accounts/src/single_owner.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use starknet_core::{
     crypto::compute_hash_on_elements,
     types::{
-        AddTransactionResult, BlockId, CallFunction, FeeEstimate, FieldElement,
+        AccountTransaction, AddTransactionResult, BlockId, CallFunction, FeeEstimate, FieldElement,
         InvokeFunctionTransactionRequest, TransactionRequest,
     },
     utils::get_selector_from_name,
@@ -160,7 +160,10 @@ where
             .await
             .map_err(TransactionError::SignerError)?;
         self.provider
-            .estimate_fee(estimate_fee_request, BlockId::Latest)
+            .estimate_fee(
+                AccountTransaction::InvokeFunction(estimate_fee_request),
+                BlockId::Latest,
+            )
             .await
             .map_err(TransactionError::ProviderError)
     }

--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -34,7 +34,7 @@ pub use call_contract::CallContractResult;
 
 mod transaction_request;
 pub use transaction_request::{
-    AddTransactionResult, AddTransactionResultCode, ContractDefinition,
+    AddTransactionResult, AddTransactionResultCode, CallFunction, ContractDefinition,
     DeclareTransaction as DeclareTransactionRequest, DeployTransaction as DeployTransactionRequest,
     EntryPoint, EntryPointsByType, InvokeFunctionTransaction as InvokeFunctionTransactionRequest,
     TransactionRequest,

--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -34,10 +34,10 @@ pub use call_contract::CallContractResult;
 
 mod transaction_request;
 pub use transaction_request::{
-    AddTransactionResult, AddTransactionResultCode, CallFunction, ContractDefinition,
-    DeclareTransaction as DeclareTransactionRequest, DeployTransaction as DeployTransactionRequest,
-    EntryPoint, EntryPointsByType, InvokeFunctionTransaction as InvokeFunctionTransactionRequest,
-    TransactionRequest,
+    AccountTransaction, AddTransactionResult, AddTransactionResultCode, CallFunction,
+    ContractDefinition, DeclareTransaction as DeclareTransactionRequest,
+    DeployTransaction as DeployTransactionRequest, EntryPoint, EntryPointsByType,
+    InvokeFunctionTransaction as InvokeFunctionTransactionRequest, TransactionRequest,
 };
 
 pub use starknet_ff::*;

--- a/starknet-core/src/types/transaction_request.rs
+++ b/starknet-core/src/types/transaction_request.rs
@@ -39,6 +39,17 @@ pub enum TransactionRequest {
     InvokeFunction(InvokeFunctionTransaction),
 }
 
+/// Represents a contract function call in the StarkNet network.
+#[serde_as]
+#[derive(Debug, Serialize)]
+pub struct CallFunction {
+    #[serde_as(as = "UfeHex")]
+    pub contract_address: FieldElement,
+    #[serde_as(as = "UfeHex")]
+    pub entry_point_selector: FieldElement,
+    pub calldata: Vec<FieldElement>,
+}
+
 #[serde_as]
 #[derive(Debug, Serialize)]
 pub struct DeclareTransaction {

--- a/starknet-core/src/types/transaction_request.rs
+++ b/starknet-core/src/types/transaction_request.rs
@@ -39,6 +39,15 @@ pub enum TransactionRequest {
     InvokeFunction(InvokeFunctionTransaction),
 }
 
+/// Represents a transaction in the StarkNet network that is originated from an action of an
+/// account.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AccountTransaction {
+    Declare(DeclareTransaction),
+    InvokeFunction(InvokeFunctionTransaction),
+}
+
 /// Represents a contract function call in the StarkNet network.
 #[serde_as]
 #[derive(Debug, Serialize)]

--- a/starknet-providers/src/provider.rs
+++ b/starknet-providers/src/provider.rs
@@ -1,10 +1,10 @@
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 use starknet_core::types::{
-    AddTransactionResult, Block, BlockId, BlockTraces, CallContractResult, ContractAddresses,
-    ContractArtifact, ContractCode, FeeEstimate, FieldElement, InvokeFunctionTransactionRequest,
-    StateUpdate, TransactionInfo, TransactionReceipt, TransactionRequest, TransactionStatusInfo,
-    TransactionTrace,
+    AddTransactionResult, Block, BlockId, BlockTraces, CallContractResult, CallFunction,
+    ContractAddresses, ContractArtifact, ContractCode, FeeEstimate, FieldElement,
+    InvokeFunctionTransactionRequest, StateUpdate, TransactionInfo, TransactionReceipt,
+    TransactionRequest, TransactionStatusInfo, TransactionTrace,
 };
 use std::error::Error;
 
@@ -24,7 +24,7 @@ pub trait Provider {
 
     async fn call_contract(
         &self,
-        invoke_tx: InvokeFunctionTransactionRequest,
+        call_function: CallFunction,
         block_identifier: BlockId,
     ) -> Result<CallContractResult, Self::Error>;
 

--- a/starknet-providers/src/provider.rs
+++ b/starknet-providers/src/provider.rs
@@ -1,10 +1,10 @@
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 use starknet_core::types::{
-    AddTransactionResult, Block, BlockId, BlockTraces, CallContractResult, CallFunction,
-    ContractAddresses, ContractArtifact, ContractCode, FeeEstimate, FieldElement,
-    InvokeFunctionTransactionRequest, StateUpdate, TransactionInfo, TransactionReceipt,
-    TransactionRequest, TransactionStatusInfo, TransactionTrace,
+    AccountTransaction, AddTransactionResult, Block, BlockId, BlockTraces, CallContractResult,
+    CallFunction, ContractAddresses, ContractArtifact, ContractCode, FeeEstimate, FieldElement,
+    StateUpdate, TransactionInfo, TransactionReceipt, TransactionRequest, TransactionStatusInfo,
+    TransactionTrace,
 };
 use std::error::Error;
 
@@ -30,7 +30,7 @@ pub trait Provider {
 
     async fn estimate_fee(
         &self,
-        invoke_tx: InvokeFunctionTransactionRequest,
+        tx: AccountTransaction,
         block_identifier: BlockId,
     ) -> Result<FeeEstimate, Self::Error>;
 

--- a/starknet-providers/src/sequencer_gateway.rs
+++ b/starknet-providers/src/sequencer_gateway.rs
@@ -8,10 +8,10 @@ use serde_with::serde_as;
 use starknet_core::{
     serde::unsigned_field_element::UfeHex,
     types::{
-        AddTransactionResult, Block, BlockId, BlockTraces, CallContractResult, CallFunction,
-        ContractAddresses, ContractArtifact, ContractCode, FeeEstimate, FieldElement,
-        InvokeFunctionTransactionRequest, StarknetError, StateUpdate, TransactionInfo,
-        TransactionReceipt, TransactionRequest, TransactionStatusInfo, TransactionTrace,
+        AccountTransaction, AddTransactionResult, Block, BlockId, BlockTraces, CallContractResult,
+        CallFunction, ContractAddresses, ContractArtifact, ContractCode, FeeEstimate, FieldElement,
+        StarknetError, StateUpdate, TransactionInfo, TransactionReceipt, TransactionRequest,
+        TransactionStatusInfo, TransactionTrace,
     },
 };
 use thiserror::Error;
@@ -199,13 +199,13 @@ impl Provider for SequencerGatewayProvider {
 
     async fn estimate_fee(
         &self,
-        invoke_tx: InvokeFunctionTransactionRequest,
+        tx: AccountTransaction,
         block_identifier: BlockId,
     ) -> Result<FeeEstimate, Self::Error> {
         let mut request_url = self.extend_feeder_gateway_url("estimate_fee");
         append_block_id(&mut request_url, block_identifier);
 
-        match self.send_post_request(request_url, &invoke_tx).await? {
+        match self.send_post_request(request_url, &tx).await? {
             GatewayResponse::Data(data) => Ok(data),
             GatewayResponse::StarknetError(starknet_err) => {
                 Err(ProviderError::StarknetError(starknet_err))

--- a/starknet-providers/src/sequencer_gateway.rs
+++ b/starknet-providers/src/sequencer_gateway.rs
@@ -8,8 +8,8 @@ use serde_with::serde_as;
 use starknet_core::{
     serde::unsigned_field_element::UfeHex,
     types::{
-        AddTransactionResult, Block, BlockId, BlockTraces, CallContractResult, ContractAddresses,
-        ContractArtifact, ContractCode, FeeEstimate, FieldElement,
+        AddTransactionResult, Block, BlockId, BlockTraces, CallContractResult, CallFunction,
+        ContractAddresses, ContractArtifact, ContractCode, FeeEstimate, FieldElement,
         InvokeFunctionTransactionRequest, StarknetError, StateUpdate, TransactionInfo,
         TransactionReceipt, TransactionRequest, TransactionStatusInfo, TransactionTrace,
     },
@@ -183,13 +183,13 @@ impl Provider for SequencerGatewayProvider {
 
     async fn call_contract(
         &self,
-        invoke_tx: InvokeFunctionTransactionRequest,
+        call_function: CallFunction,
         block_identifier: BlockId,
     ) -> Result<CallContractResult, Self::Error> {
         let mut request_url = self.extend_feeder_gateway_url("call_contract");
         append_block_id(&mut request_url, block_identifier);
 
-        match self.send_post_request(request_url, &invoke_tx).await? {
+        match self.send_post_request(request_url, &call_function).await? {
             GatewayResponse::Data(data) => Ok(data),
             GatewayResponse::StarknetError(starknet_err) => {
                 Err(ProviderError::StarknetError(starknet_err))


### PR DESCRIPTION
This PR further resolves API changes from StarkNet v0.10.1, on top of the work already done in #206:

- `call_contract`

  Uses a new struct `CallFunction` for request body, which essentially removes `signature` and `max_fee` compared to the type used before.

  Note that technically the sequencer run by StarkWare seems to still accept these fields, but they've [changed]() the client to not send those fields so I'm aligning the behavior here. To get call result using those fields, users can use the new `simulate_transaction` to be supported in another PR.

- `estimate_fee`

  This method now accepts declare transactions on top of the already supported invoke transactions.