### PR TITLE
chore: resolve clippy warnings

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -45,4 +45,4 @@ jobs:
           cargo fmt --all -- --check
       - name: Run Clippy lints
         run: |
-          cargo clippy --all --all-targets
+          cargo clippy --all --all-targets -- -D warnings

--- a/starknet-core/src/crypto.rs
+++ b/starknet-core/src/crypto.rs
@@ -24,7 +24,7 @@ pub fn compute_hash_on_elements(data: &[FieldElement]) -> FieldElement {
     let mut current_hash = FieldElement::ZERO;
 
     for item in data.iter() {
-        current_hash = pedersen_hash(&current_hash, &(*item));
+        current_hash = pedersen_hash(&current_hash, item);
     }
 
     let data_len = FieldElement::from(data.len());

--- a/starknet-core/src/types/block.rs
+++ b/starknet-core/src/types/block.rs
@@ -13,7 +13,7 @@ pub enum BlockId {
     Latest,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum BlockStatus {

--- a/starknet-core/src/types/starknet_error.rs
+++ b/starknet-core/src/types/starknet_error.rs
@@ -15,7 +15,7 @@ impl std::fmt::Display for Error {
     }
 }
 
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum ErrorCode {
     #[serde(rename = "StarknetErrorCode.BLOCK_NOT_FOUND")]

--- a/starknet-core/src/types/trace.rs
+++ b/starknet-core/src/types/trace.rs
@@ -39,7 +39,7 @@ pub struct TransactionTraceWithHash {
     pub transaction_hash: FieldElement,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum CallType {

--- a/starknet-core/src/types/transaction.rs
+++ b/starknet-core/src/types/transaction.rs
@@ -53,7 +53,7 @@ pub struct TransactionInfo {
     pub transaction_index: Option<u64>,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum EntryPointType {

--- a/starknet-core/src/types/transaction_receipt.rs
+++ b/starknet-core/src/types/transaction_receipt.rs
@@ -47,7 +47,7 @@ pub struct ConfirmedReceipt {
     pub actual_fee: FieldElement,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum TransactionStatus {


### PR DESCRIPTION
Turns out the linting CI workflow ignores clippy warnings. This PR fixes that and resolves some existing clippy warnings.