### PR TITLE
feat: support v1 invoke transaction

### DIFF
--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -17,7 +17,7 @@ async fn can_get_nonce() {
         .unwrap(),
     ));
     let address = FieldElement::from_hex_be(
-        "01352dd0ac2a462cb53e4f125169b28f13bd6199091a9815c444dcae83056bbc",
+        "02da37a17affbd2df4ede7120dae305ec36dfe94ec96a8c3f49bbf59f4e9a9fa",
     )
     .unwrap();
 
@@ -39,7 +39,7 @@ async fn can_estimate_fee() {
         .unwrap(),
     ));
     let address = FieldElement::from_hex_be(
-        "01352dd0ac2a462cb53e4f125169b28f13bd6199091a9815c444dcae83056bbc",
+        "02da37a17affbd2df4ede7120dae305ec36dfe94ec96a8c3f49bbf59f4e9a9fa",
     )
     .unwrap();
     let tst_token_address = FieldElement::from_hex_be(
@@ -94,7 +94,7 @@ async fn can_execute_tst_mint() {
         .unwrap(),
     ));
     let address = FieldElement::from_hex_be(
-        "01352dd0ac2a462cb53e4f125169b28f13bd6199091a9815c444dcae83056bbc",
+        "02da37a17affbd2df4ede7120dae305ec36dfe94ec96a8c3f49bbf59f4e9a9fa",
     )
     .unwrap();
     let tst_token_address = FieldElement::from_hex_be(

--- a/starknet-core/src/types/transaction_request.rs
+++ b/starknet-core/src/types/transaction_request.rs
@@ -97,10 +97,10 @@ pub struct DeployTransaction {
 #[derive(Debug)]
 pub struct InvokeFunctionTransaction {
     pub contract_address: FieldElement,
-    pub entry_point_selector: FieldElement,
     pub calldata: Vec<FieldElement>,
     pub signature: Vec<FieldElement>,
     pub max_fee: FieldElement,
+    pub nonce: FieldElement,
 }
 
 #[derive(Debug, Serialize)]
@@ -203,21 +203,21 @@ impl Serialize for InvokeFunctionTransaction {
             version: FieldElement,
             #[serde_as(as = "UfeHex")]
             contract_address: &'a FieldElement,
-            #[serde_as(as = "UfeHex")]
-            entry_point_selector: &'a FieldElement,
             calldata: &'a Vec<FieldElement>,
             signature: &'a Vec<FieldElement>,
             #[serde_as(as = "UfeHex")]
             max_fee: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            nonce: &'a FieldElement,
         }
 
         let versioned = Versioned {
-            version: FieldElement::ZERO,
+            version: FieldElement::ONE,
             contract_address: &self.contract_address,
-            entry_point_selector: &self.entry_point_selector,
             calldata: &self.calldata,
             signature: &self.signature,
             max_fee: &self.max_fee,
+            nonce: &self.nonce,
         };
 
         Versioned::serialize(&versioned, serializer)

--- a/starknet-core/src/types/transaction_request.rs
+++ b/starknet-core/src/types/transaction_request.rs
@@ -74,42 +74,32 @@ pub struct CallL1Handler {
     pub payload: Vec<FieldElement>,
 }
 
-#[serde_as]
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub struct DeclareTransaction {
     pub contract_class: ContractDefinition,
     /// The address of the account contract sending the declaration transaction.
-    #[serde_as(as = "UfeHex")]
     pub sender_address: FieldElement,
     /// The maximal fee to be paid in Wei for declaring a contract class.
-    #[serde_as(as = "UfeHex")]
     pub max_fee: FieldElement,
     /// Additional information given by the caller that represents the signature of the transaction.
     pub signature: Vec<FieldElement>,
     /// A sequential integer used to distinguish between transactions and order them.
-    #[serde_as(as = "UfeHex")]
     pub nonce: FieldElement,
 }
 
-#[serde_as]
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub struct DeployTransaction {
     pub constructor_calldata: Vec<FieldElement>,
-    #[serde_as(as = "UfeHex")]
     pub contract_address_salt: FieldElement,
     pub contract_definition: ContractDefinition,
 }
 
-#[serde_as]
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub struct InvokeFunctionTransaction {
-    #[serde_as(as = "UfeHex")]
     pub contract_address: FieldElement,
-    #[serde_as(as = "UfeHex")]
     pub entry_point_selector: FieldElement,
     pub calldata: Vec<FieldElement>,
     pub signature: Vec<FieldElement>,
-    #[serde_as(as = "UfeHex")]
     pub max_fee: FieldElement,
 }
 
@@ -139,6 +129,99 @@ pub struct EntryPoint {
     pub selector: FieldElement,
     #[serde_as(as = "UfeHex")]
     pub offset: FieldElement,
+}
+
+impl Serialize for DeclareTransaction {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Versioned<'a> {
+            #[serde_as(as = "UfeHex")]
+            version: FieldElement,
+            contract_class: &'a ContractDefinition,
+            #[serde_as(as = "UfeHex")]
+            sender_address: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            max_fee: &'a FieldElement,
+            signature: &'a Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            nonce: &'a FieldElement,
+        }
+
+        let versioned = Versioned {
+            version: FieldElement::ZERO,
+            contract_class: &self.contract_class,
+            sender_address: &self.sender_address,
+            max_fee: &self.max_fee,
+            signature: &self.signature,
+            nonce: &self.nonce,
+        };
+
+        Versioned::serialize(&versioned, serializer)
+    }
+}
+
+impl Serialize for DeployTransaction {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Versioned<'a> {
+            #[serde_as(as = "UfeHex")]
+            version: FieldElement,
+            constructor_calldata: &'a Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            contract_address_salt: &'a FieldElement,
+            contract_definition: &'a ContractDefinition,
+        }
+
+        let versioned = Versioned {
+            version: FieldElement::ZERO,
+            constructor_calldata: &self.constructor_calldata,
+            contract_address_salt: &self.contract_address_salt,
+            contract_definition: &self.contract_definition,
+        };
+
+        Versioned::serialize(&versioned, serializer)
+    }
+}
+
+impl Serialize for InvokeFunctionTransaction {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Versioned<'a> {
+            #[serde_as(as = "UfeHex")]
+            version: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            contract_address: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            entry_point_selector: &'a FieldElement,
+            calldata: &'a Vec<FieldElement>,
+            signature: &'a Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            max_fee: &'a FieldElement,
+        }
+
+        let versioned = Versioned {
+            version: FieldElement::ZERO,
+            contract_address: &self.contract_address,
+            entry_point_selector: &self.entry_point_selector,
+            calldata: &self.calldata,
+            signature: &self.signature,
+            max_fee: &self.max_fee,
+        };
+
+        Versioned::serialize(&versioned, serializer)
+    }
 }
 
 fn l1_addr_as_dec<S>(value: &L1Address, serializer: S) -> Result<S::Ok, S::Error>

--- a/starknet-providers/tests/sequencer_goerli.rs
+++ b/starknet-providers/tests/sequencer_goerli.rs
@@ -58,23 +58,65 @@ async fn sequencer_goerli_can_simulate_transaction() {
         .simulate_transaction(
             AccountTransaction::InvokeFunction(InvokeFunctionTransactionRequest {
                 contract_address: FieldElement::from_hex_be(
-                    "0x07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10",
-                )
-                .unwrap(),
-                entry_point_selector: FieldElement::from_hex_be(
-                    "0x02f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+                    "0x02643ad267d5f4035c57f33c4b521a539a0525f41ff8e885ce106b47a462ce5c",
                 )
                 .unwrap(),
                 calldata: vec![
                     FieldElement::from_hex_be(
-                        "0x59b844bae1727516c6d5c40d2540f6f0a0eebc7eed2adf760515b45dbc20593",
+                        "0x0000000000000000000000000000000000000000000000000000000000000001",
                     )
                     .unwrap(),
-                    FieldElement::from_dec_str("1000000000000000000000").unwrap(),
-                    FieldElement::from_dec_str("0").unwrap(),
+                    FieldElement::from_hex_be(
+                        "0x07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10",
+                    )
+                    .unwrap(),
+                    FieldElement::from_hex_be(
+                        "0x02f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+                    )
+                    .unwrap(),
+                    FieldElement::from_hex_be(
+                        "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    )
+                    .unwrap(),
+                    FieldElement::from_hex_be(
+                        "0x0000000000000000000000000000000000000000000000000000000000000003",
+                    )
+                    .unwrap(),
+                    FieldElement::from_hex_be(
+                        "0x0000000000000000000000000000000000000000000000000000000000000003",
+                    )
+                    .unwrap(),
+                    FieldElement::from_hex_be(
+                        "0x02643ad267d5f4035c57f33c4b521a539a0525f41ff8e885ce106b47a462ce5c",
+                    )
+                    .unwrap(),
+                    FieldElement::from_hex_be(
+                        "0x00000000000000000000000000000000000000000000003635c9adc5dea00000",
+                    )
+                    .unwrap(),
+                    FieldElement::from_hex_be(
+                        "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    )
+                    .unwrap(),
                 ],
-                signature: vec![],
-                max_fee: FieldElement::ZERO,
+                signature: vec![
+                    FieldElement::from_hex_be(
+                        "0x04404d064a487404a02b6eac3493938d4c5d4fc6fc44c5a573838790a3f0bd78",
+                    )
+                    .unwrap(),
+                    FieldElement::from_hex_be(
+                        "0x049cd4c19a92b4da46cc87f4a4f4b06dded9567db8bca8bf6279497777cf1fc2",
+                    )
+                    .unwrap(),
+                ],
+                max_fee: FieldElement::from_hex_be(
+                    "0x000000000000000000000000000000000000000000000000016345785d8a0000",
+                )
+                .unwrap(),
+                nonce: FieldElement::from_hex_be(
+                    "0x0000000000000000000000000000000000000000000000000000000000000000",
+                )
+                .unwrap(),
             }),
             BlockId::Latest,
         )


### PR DESCRIPTION
This PR adds support for `invoke` transaction v1, partially resolves task 3 of #207:

> abandon v0 transaction type in favor of v1