### PR TITLE
feat: contract class hash calculation

### DIFF
--- a/starknet-core/src/serde/json/mod.rs
+++ b/starknet-core/src/serde/json/mod.rs
@@ -1,0 +1,76 @@
+use serde::Serialize;
+use serde_json::{ser::Formatter, Serializer};
+use std::io;
+
+/// A `serde_json` formatter that mimicks the output of `json.dumps()` in Python. This is primarily
+/// used in `hinted_class_hash` calculation to obtain the exact same hash as in `cairo-lang`.
+#[derive(Debug)]
+pub struct PythonicJsonFormatter;
+
+impl Formatter for PythonicJsonFormatter {
+    #[inline]
+    fn begin_array_value<W>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        if first {
+            Ok(())
+        } else {
+            writer.write_all(b", ")
+        }
+    }
+
+    #[inline]
+    fn begin_object_key<W>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        if first {
+            Ok(())
+        } else {
+            writer.write_all(b", ")
+        }
+    }
+
+    #[inline]
+    fn begin_object_value<W>(&mut self, writer: &mut W) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        writer.write_all(b": ")
+    }
+}
+
+#[inline]
+pub fn to_string_pythonic<T>(value: &T) -> Result<String, serde_json::Error>
+where
+    T: ?Sized + Serialize,
+{
+    let vec = to_vec_pythonic(value)?;
+    let string = unsafe {
+        // We do not emit invalid UTF-8.
+        String::from_utf8_unchecked(vec)
+    };
+    Ok(string)
+}
+
+#[inline]
+fn to_vec_pythonic<T>(value: &T) -> Result<Vec<u8>, serde_json::Error>
+where
+    T: ?Sized + Serialize,
+{
+    let mut writer = Vec::with_capacity(128);
+    to_writer_pythonic(&mut writer, value)?;
+    Ok(writer)
+}
+
+#[inline]
+fn to_writer_pythonic<W, T>(writer: W, value: &T) -> Result<(), serde_json::Error>
+where
+    W: io::Write,
+    T: ?Sized + Serialize,
+{
+    let mut ser = Serializer::with_formatter(writer, PythonicJsonFormatter);
+    value.serialize(&mut ser)?;
+    Ok(())
+}

--- a/starknet-core/src/serde/mod.rs
+++ b/starknet-core/src/serde/mod.rs
@@ -1,3 +1,5 @@
 pub mod byte_array;
 
 pub mod unsigned_field_element;
+
+pub(crate) mod json;


### PR DESCRIPTION
Building on top of #216, this PR implements local contract class hash calculation that outputs the exact same class hash as `cairo-lang` when given the same artifact (see the 2 new test cases `test_contract_class_hash` and `test_contract_hinted_class_hash`.

A special JSON formatter `PythonicJsonFormatter` has been introduced to emit the same not-so-compact JSON representation as in Python. Without this we would be getting a different `hinted_class_hash`.

It's worth noting that calling `class_hash()` on large contracts is currently very slow, especially in debug mode. This is mostly due to the slow Pedersen hash implementation in `starknet-crypto`. We need to solve this performance issue, probably starting by picking up the work in #35.