### PR TITLE
feat: support v1 declare transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,6 +1600,7 @@ name = "starknet-accounts"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "serde_json",
  "starknet-core",
  "starknet-providers",
  "starknet-signers",
@@ -1611,7 +1612,6 @@ dependencies = [
 name = "starknet-contract"
 version = "0.1.0"
 dependencies = [
- "flate2",
  "rand",
  "serde",
  "serde_json",
@@ -1628,6 +1628,7 @@ version = "0.2.0"
 dependencies = [
  "base64",
  "ethereum-types",
+ "flate2",
  "hex",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Examples can be found in the [examples folder](./examples):
 
 4. [Declare contract on `alpha-goerli` testnet](./examples/declare_contract.rs)
 
+   Declaring contracts without going through an account (and thus not paying fees) has been deprecated, so please make sure your account has enough L2 Goerli ETH for the fees.
+
 5. [Query the latest block number with JSON-RPC](./examples/jsonrpc.rs)
 
 6. [Call a contract view function via sequencer gateway](./examples/sequencer_erc20_balance.rs)

--- a/examples/deploy_contract.rs
+++ b/examples/deploy_contract.rs
@@ -11,7 +11,7 @@ async fn main() {
             .unwrap();
     let provider = SequencerGatewayProvider::starknet_alpha_goerli();
 
-    let contract_factory = ContractFactory::new(contract_artifact, provider).unwrap();
+    let contract_factory = ContractFactory::new(&contract_artifact, provider).unwrap();
     contract_factory
         .deploy(vec![FieldElement::from_dec_str("123456").unwrap()], None)
         .await

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -20,4 +20,5 @@ async-trait = "0.1.52"
 thiserror = "1.0.30"
 
 [dev-dependencies]
+serde_json = "1.0.74"
 tokio = { version = "1.15.0", features = ["full"] }

--- a/starknet-accounts/src/account.rs
+++ b/starknet-accounts/src/account.rs
@@ -1,12 +1,23 @@
 use crate::Call;
 
 use async_trait::async_trait;
-use starknet_core::types::{AddTransactionResult, BlockId, FeeEstimate, FieldElement};
-use std::error::Error;
+use starknet_core::types::{
+    AddTransactionResult, BlockId, ContractDefinition, FeeEstimate, FieldElement,
+};
+use std::{error::Error, sync::Arc};
 
 #[derive(Debug)]
 pub struct AttachedAccountCall<'a, A> {
     pub calls: Vec<Call>,
+    pub nonce: Option<FieldElement>,
+    pub max_fee: Option<FieldElement>,
+    pub(crate) account: &'a A,
+}
+
+#[derive(Debug)]
+pub struct AttachedAccountDeclaration<'a, A> {
+    pub compressed_class: Arc<ContractDefinition>,
+    pub class_hash: FieldElement,
     pub nonce: Option<FieldElement>,
     pub max_fee: Option<FieldElement>,
     pub(crate) account: &'a A,
@@ -17,9 +28,23 @@ pub trait AccountCall {
 
     fn get_nonce(&self) -> &Option<FieldElement>;
 
+    fn nonce(self, nonce: FieldElement) -> Self;
+
     fn get_max_fee(&self) -> &Option<FieldElement>;
 
+    fn max_fee(self, max_fee: FieldElement) -> Self;
+}
+
+pub trait AccountDeclaration {
+    fn get_compressed_class(&self) -> Arc<ContractDefinition>;
+
+    fn get_class_hash(&self) -> FieldElement;
+
+    fn get_nonce(&self) -> &Option<FieldElement>;
+
     fn nonce(self, nonce: FieldElement) -> Self;
+
+    fn get_max_fee(&self) -> &Option<FieldElement>;
 
     fn max_fee(self, max_fee: FieldElement) -> Self;
 }
@@ -40,9 +65,22 @@ pub trait Account: Sized {
 
     fn execute(&self, calls: &[Call]) -> AttachedAccountCall<Self>;
 
+    fn declare(
+        &self,
+        compressed_class: Arc<ContractDefinition>,
+        class_hash: FieldElement,
+    ) -> AttachedAccountDeclaration<Self>;
+
     async fn estimate_fee<C>(&self, call: &C) -> Result<FeeEstimate, Self::EstimateFeeError>
     where
         C: AccountCall + Sync;
+
+    async fn estimate_declare_fee<D>(
+        &self,
+        declaration: &D,
+    ) -> Result<FeeEstimate, Self::EstimateFeeError>
+    where
+        D: AccountDeclaration + Sync;
 
     async fn send_transaction<C>(
         &self,
@@ -50,6 +88,13 @@ pub trait Account: Sized {
     ) -> Result<AddTransactionResult, Self::SendTransactionError>
     where
         C: AccountCall + Sync;
+
+    async fn send_declare_transaction<D>(
+        &self,
+        declaration: &D,
+    ) -> Result<AddTransactionResult, Self::SendTransactionError>
+    where
+        D: AccountDeclaration + Sync;
 }
 
 impl<'a, A> AttachedAccountCall<'a, A>
@@ -74,10 +119,6 @@ impl<'a, A> AccountCall for AttachedAccountCall<'a, A> {
         &self.nonce
     }
 
-    fn get_max_fee(&self) -> &Option<FieldElement> {
-        &self.max_fee
-    }
-
     fn nonce(self, nonce: FieldElement) -> Self {
         Self {
             calls: self.calls,
@@ -87,9 +128,64 @@ impl<'a, A> AccountCall for AttachedAccountCall<'a, A> {
         }
     }
 
+    fn get_max_fee(&self) -> &Option<FieldElement> {
+        &self.max_fee
+    }
+
     fn max_fee(self, max_fee: FieldElement) -> Self {
         Self {
             calls: self.calls,
+            nonce: self.nonce,
+            max_fee: Some(max_fee),
+            account: self.account,
+        }
+    }
+}
+
+impl<'a, A> AttachedAccountDeclaration<'a, A>
+where
+    A: Account + Sync,
+{
+    pub async fn estimate_fee(&self) -> Result<FeeEstimate, A::EstimateFeeError> {
+        self.account.estimate_declare_fee(self).await
+    }
+
+    pub async fn send(&self) -> Result<AddTransactionResult, A::SendTransactionError> {
+        self.account.send_declare_transaction(self).await
+    }
+}
+
+impl<'a, A> AccountDeclaration for AttachedAccountDeclaration<'a, A> {
+    fn get_compressed_class(&self) -> Arc<ContractDefinition> {
+        self.compressed_class.clone()
+    }
+
+    fn get_class_hash(&self) -> FieldElement {
+        self.class_hash
+    }
+
+    fn get_nonce(&self) -> &Option<FieldElement> {
+        &self.nonce
+    }
+
+    fn nonce(self, nonce: FieldElement) -> Self {
+        Self {
+            compressed_class: self.compressed_class,
+            class_hash: self.class_hash,
+            nonce: Some(nonce),
+            max_fee: self.max_fee,
+            account: self.account,
+        }
+    }
+
+    fn get_max_fee(&self) -> &Option<FieldElement> {
+        &self.max_fee
+    }
+
+    fn max_fee(self, max_fee: FieldElement) -> Self {
+        Self {
+            compressed_class: self.compressed_class,
+            class_hash: self.class_hash,
             nonce: self.nonce,
             max_fee: Some(max_fee),
             account: self.account,

--- a/starknet-accounts/src/lib.rs
+++ b/starknet-accounts/src/lib.rs
@@ -1,5 +1,7 @@
 mod account;
-pub use account::{Account, AccountCall, AttachedAccountCall};
+pub use account::{
+    Account, AccountCall, AccountDeclaration, AttachedAccountCall, AttachedAccountDeclaration,
+};
 
 mod call;
 pub use call::Call;

--- a/starknet-accounts/test-data
+++ b/starknet-accounts/test-data
@@ -1,0 +1,1 @@
+../starknet-core/test-data/contracts

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -18,7 +18,6 @@ starknet-providers = { version = "0.2.0", path = "../starknet-providers" }
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
 serde_with = "1.12.0"
-flate2 = "1.0.22"
 thiserror = "1.0.30"
 rand = { version = "0.8.5", features=["std_rng"] }
 

--- a/starknet-contract/src/factory.rs
+++ b/starknet-contract/src/factory.rs
@@ -1,12 +1,10 @@
-use flate2::{write::GzEncoder, Compression};
 use rand::{prelude::StdRng, RngCore, SeedableRng};
 use starknet_core::types::{
-    AbiEntry, AddTransactionResult, ContractArtifact, ContractDefinition,
-    DeclareTransactionRequest, DeployTransactionRequest, EntryPointsByType, FieldElement,
+    contract_artifact::CompressProgramError, AbiEntry, AddTransactionResult, ContractArtifact,
+    ContractDefinition, DeployTransactionRequest, EntryPointsByType, FieldElement,
     TransactionRequest,
 };
 use starknet_providers::Provider;
-use std::io::Write;
 
 pub struct Factory<P>
 where
@@ -18,33 +16,14 @@ where
     provider: P,
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum FactoryError {
-    #[error(transparent)]
-    CannotSerializeProgram(serde_json::Error),
-    #[error(transparent)]
-    CannotCompressProgram(std::io::Error),
-}
-
 impl<P: Provider> Factory<P> {
-    pub fn new(artifact: ContractArtifact, provider: P) -> Result<Self, FactoryError> {
-        let program_json = serde_json::to_string(&artifact.program)
-            .map_err(FactoryError::CannotSerializeProgram)?;
-
-        // Use best compression level to optimize for payload size
-        let mut gzip_encoder = GzEncoder::new(Vec::new(), Compression::best());
-        gzip_encoder
-            .write_all(program_json.as_bytes())
-            .map_err(FactoryError::CannotCompressProgram)?;
-
-        let compressed_program = gzip_encoder
-            .finish()
-            .map_err(FactoryError::CannotCompressProgram)?;
+    pub fn new(artifact: &ContractArtifact, provider: P) -> Result<Self, CompressProgramError> {
+        let compressed_program = artifact.program.compress()?;
 
         Ok(Self {
             compressed_program,
-            entry_points_by_type: artifact.entry_points_by_type,
-            abi: artifact.abi,
+            entry_points_by_type: artifact.entry_points_by_type.clone(),
+            abi: artifact.abi.clone(),
             provider,
         })
     }
@@ -71,25 +50,6 @@ impl<P: Provider> Factory<P> {
                         abi: Some(self.abi.clone()),
                     },
                     constructor_calldata,
-                }),
-                token,
-            )
-            .await
-    }
-
-    pub async fn declare(&self, token: Option<String>) -> Result<AddTransactionResult, P::Error> {
-        self.provider
-            .add_transaction(
-                TransactionRequest::Declare(DeclareTransactionRequest {
-                    contract_class: ContractDefinition {
-                        program: self.compressed_program.clone(),
-                        entry_points_by_type: self.entry_points_by_type.clone(),
-                        abi: Some(self.abi.clone()),
-                    },
-                    sender_address: FieldElement::ONE,
-                    max_fee: FieldElement::ZERO,
-                    signature: vec![],
-                    nonce: FieldElement::ZERO,
                 }),
                 token,
             )

--- a/starknet-contract/src/lib.rs
+++ b/starknet-contract/src/lib.rs
@@ -1,2 +1,2 @@
 mod factory;
-pub use factory::{Factory as ContractFactory, FactoryError as ContractFactoryError};
+pub use factory::Factory as ContractFactory;

--- a/starknet-contract/tests/contract_deployment.rs
+++ b/starknet-contract/tests/contract_deployment.rs
@@ -9,7 +9,7 @@ async fn can_deploy_contract_to_alpha_goerli() {
     .unwrap();
     let provider = starknet_providers::SequencerGatewayProvider::starknet_alpha_goerli();
 
-    let factory = ContractFactory::new(artifact, provider).unwrap();
+    let factory = ContractFactory::new(&artifact, provider).unwrap();
 
     let result = factory
         .deploy(vec![FieldElement::from_dec_str("1").unwrap()], None)
@@ -18,23 +18,5 @@ async fn can_deploy_contract_to_alpha_goerli() {
     match result {
         Ok(_) => {}
         Err(err) => panic!("Contract deployment failed: {}", err),
-    }
-}
-
-#[tokio::test]
-async fn can_declare_contract_on_alpha_goerli() {
-    let artifact = serde_json::from_str::<ContractArtifact>(include_str!(
-        "../test-data/artifacts/oz_account.txt"
-    ))
-    .unwrap();
-    let provider = starknet_providers::SequencerGatewayProvider::starknet_alpha_goerli();
-
-    let factory = ContractFactory::new(artifact, provider).unwrap();
-
-    let result = factory.declare(None).await;
-
-    match result {
-        Ok(_) => {}
-        Err(err) => panic!("Contract declaration failed: {}", err),
     }
 }

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -20,6 +20,7 @@ starknet-crypto = { version = "0.1.0", path = "../starknet-crypto" }
 starknet-ff = { version = "0.1.0", path = "../starknet-ff", default-features = false }
 base64 = "0.13.0"
 ethereum-types = "0.12.1"
+flate2 = "1.0.24"
 hex = "0.4.3"
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = { version = "1.0.74", features = ["arbitrary_precision"] }

--- a/starknet-core/src/types/transaction_request.rs
+++ b/starknet-core/src/types/transaction_request.rs
@@ -8,6 +8,7 @@ use super::{
 
 use serde::{Deserialize, Serialize, Serializer};
 use serde_with::serde_as;
+use std::sync::Arc;
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
@@ -76,7 +77,7 @@ pub struct CallL1Handler {
 
 #[derive(Debug)]
 pub struct DeclareTransaction {
-    pub contract_class: ContractDefinition,
+    pub contract_class: Arc<ContractDefinition>,
     /// The address of the account contract sending the declaration transaction.
     pub sender_address: FieldElement,
     /// The maximal fee to be paid in Wei for declaring a contract class.
@@ -152,7 +153,7 @@ impl Serialize for DeclareTransaction {
         }
 
         let versioned = Versioned {
-            version: FieldElement::ZERO,
+            version: FieldElement::ONE,
             contract_class: &self.contract_class,
             sender_address: &self.sender_address,
             max_fee: &self.max_fee,


### PR DESCRIPTION
Together with #215, resolves task 3 of #207:

> abandon v0 transaction type in favor of v1

This PR makes a lot of breaking changes, among others:

- it's no longer possible to send v0 `declare` transactions; and
- `ContractFactory` no longer offers `declare()` - declarations must go through `Account`.

You should update your codebase to work with these changes as the old v0 transaction type will be removed on live networks soon. It's technically possible for this library to support both v0 and v1 transactions at the same time, but it's deemed unnecessary as the old version is going away soon.