### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/starknet-crypto/src/ecdsa.rs
+++ b/starknet-crypto/src/ecdsa.rs
@@ -39,7 +39,7 @@ impl fmt::Display for Signature {
 ///
 /// * `private_key`: The private key
 pub fn get_public_key(private_key: &FieldElement) -> FieldElement {
-    (&CONSTANT_POINTS[1]).multiply(&private_key.to_bits_le()).x
+    CONSTANT_POINTS[1].multiply(&private_key.to_bits_le()).x
 }
 
 /// Computes ECDSA signature given a Stark private key and message hash.


### PR DESCRIPTION
This PR fixes a new Clippy warning likely introduced in Rust 1.64.0.