### PR TITLE
feat: make fee estimate buffer configurable

### DIFF
--- a/starknet-accounts/src/account.rs
+++ b/starknet-accounts/src/account.rs
@@ -11,6 +11,7 @@ pub struct AttachedAccountCall<'a, A> {
     pub calls: Vec<Call>,
     pub nonce: Option<FieldElement>,
     pub max_fee: Option<FieldElement>,
+    pub fee_estimate_multiplier: f32,
     pub(crate) account: &'a A,
 }
 
@@ -20,6 +21,7 @@ pub struct AttachedAccountDeclaration<'a, A> {
     pub class_hash: FieldElement,
     pub nonce: Option<FieldElement>,
     pub max_fee: Option<FieldElement>,
+    pub fee_estimate_multiplier: f32,
     pub(crate) account: &'a A,
 }
 
@@ -33,6 +35,10 @@ pub trait AccountCall {
     fn get_max_fee(&self) -> &Option<FieldElement>;
 
     fn max_fee(self, max_fee: FieldElement) -> Self;
+
+    fn get_fee_estimate_multiplier(&self) -> f32;
+
+    fn fee_estimate_multiplier(self, fee_estimate_multiplier: f32) -> Self;
 }
 
 pub trait AccountDeclaration {
@@ -47,6 +53,10 @@ pub trait AccountDeclaration {
     fn get_max_fee(&self) -> &Option<FieldElement>;
 
     fn max_fee(self, max_fee: FieldElement) -> Self;
+
+    fn get_fee_estimate_multiplier(&self) -> f32;
+
+    fn fee_estimate_multiplier(self, fee_estimate_multiplier: f32) -> Self;
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -124,6 +134,7 @@ impl<'a, A> AccountCall for AttachedAccountCall<'a, A> {
             calls: self.calls,
             nonce: Some(nonce),
             max_fee: self.max_fee,
+            fee_estimate_multiplier: self.fee_estimate_multiplier,
             account: self.account,
         }
     }
@@ -137,6 +148,21 @@ impl<'a, A> AccountCall for AttachedAccountCall<'a, A> {
             calls: self.calls,
             nonce: self.nonce,
             max_fee: Some(max_fee),
+            fee_estimate_multiplier: self.fee_estimate_multiplier,
+            account: self.account,
+        }
+    }
+
+    fn get_fee_estimate_multiplier(&self) -> f32 {
+        self.fee_estimate_multiplier
+    }
+
+    fn fee_estimate_multiplier(self, fee_estimate_multiplier: f32) -> Self {
+        Self {
+            calls: self.calls,
+            nonce: self.nonce,
+            max_fee: self.max_fee,
+            fee_estimate_multiplier,
             account: self.account,
         }
     }
@@ -174,6 +200,7 @@ impl<'a, A> AccountDeclaration for AttachedAccountDeclaration<'a, A> {
             class_hash: self.class_hash,
             nonce: Some(nonce),
             max_fee: self.max_fee,
+            fee_estimate_multiplier: self.fee_estimate_multiplier,
             account: self.account,
         }
     }
@@ -188,6 +215,22 @@ impl<'a, A> AccountDeclaration for AttachedAccountDeclaration<'a, A> {
             class_hash: self.class_hash,
             nonce: self.nonce,
             max_fee: Some(max_fee),
+            fee_estimate_multiplier: self.fee_estimate_multiplier,
+            account: self.account,
+        }
+    }
+
+    fn get_fee_estimate_multiplier(&self) -> f32 {
+        self.fee_estimate_multiplier
+    }
+
+    fn fee_estimate_multiplier(self, fee_estimate_multiplier: f32) -> Self {
+        Self {
+            compressed_class: self.compressed_class,
+            class_hash: self.class_hash,
+            nonce: self.nonce,
+            max_fee: self.max_fee,
+            fee_estimate_multiplier,
             account: self.account,
         }
     }

--- a/starknet-accounts/src/single_owner.rs
+++ b/starknet-accounts/src/single_owner.rs
@@ -236,6 +236,7 @@ where
             calls: calls.to_vec(),
             nonce: None,
             max_fee: None,
+            fee_estimate_multiplier: 1.1,
             account: self,
         }
     }
@@ -250,6 +251,7 @@ where
             class_hash,
             nonce: None,
             max_fee: None,
+            fee_estimate_multiplier: 1.1,
             account: self,
         }
     }
@@ -298,8 +300,9 @@ where
                     .estimate_fee_for_calls(call.get_calls(), Some(&nonce))
                     .await?;
 
-                // Adds 10% fee buffer
-                (fee_estimate.overall_fee * 11 / 10).into()
+                ((fee_estimate.overall_fee as f64 * call.get_fee_estimate_multiplier() as f64)
+                    as u64)
+                    .into()
             }
         };
 
@@ -341,8 +344,9 @@ where
                     )
                     .await?;
 
-                // Adds 10% fee buffer
-                (fee_estimate.overall_fee * 11 / 10).into()
+                ((fee_estimate.overall_fee as f64
+                    * declaration.get_fee_estimate_multiplier() as f64) as u64)
+                    .into()
             }
         };
 


### PR DESCRIPTION
Currently, the fee estimate buffer is hard-coded to 10%: whenever `max_fee` is not specified, the library estimates the fee via a call to the sequencer, and then adds 10% to it.

This PR makes this buffer value configurable, so you can now do something like:

```rust
account.execute(...).fee_estimate_multiplier(1.5).send().await
```

to make the buffer 50% instead, for example.