### PR TITLE
feat: support testnet 2

### DIFF
--- a/starknet-core/src/chain_id.rs
+++ b/starknet-core/src/chain_id.rs
@@ -13,3 +13,31 @@ pub const TESTNET: FieldElement = FieldElement::from_mont([
     18446744073709551615,
     398700013197595345,
 ]);
+
+pub const TESTNET2: FieldElement = FieldElement::from_mont([
+    1663542769632127759,
+    18446744073708869172,
+    18446744073709551615,
+    33650220878420990,
+]);
+
+#[cfg(test)]
+mod test {
+    use crate::utils::cairo_short_string_to_felt;
+
+    use super::*;
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    fn test_chain_ids() {
+        for (text, felt) in [
+            ("SN_MAIN", MAINNET),
+            ("SN_GOERLI", TESTNET),
+            ("SN_GOERLI2", TESTNET2),
+        ]
+        .into_iter()
+        {
+            assert_eq!(cairo_short_string_to_felt(text).unwrap(), felt);
+        }
+    }
+}

--- a/starknet-providers/src/sequencer_gateway.rs
+++ b/starknet-providers/src/sequencer_gateway.rs
@@ -59,6 +59,13 @@ impl SequencerGatewayProvider {
         )
     }
 
+    pub fn starknet_alpha_goerli_2() -> Self {
+        Self::new(
+            Url::parse("https://alpha4-2.starknet.io/gateway").unwrap(),
+            Url::parse("https://alpha4-2.starknet.io/feeder_gateway").unwrap(),
+        )
+    }
+
     pub fn starknet_nile_localhost() -> Self {
         Self::new(
             Url::parse("http://127.0.0.1:5000/gateway").unwrap(),


### PR DESCRIPTION
Due to the congestion on the original testnet, a new testnet with chain ID `SN_GOERLI2` has been launched. This PR:

- adds a new const `TESTNET2` the new chain ID; and
- adds a new constructor `starknet_alpha_goerli_2()` to `SequencerGatewayProvider`.