### PR TITLE
chore: add benchmark for class hash calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,6 +1627,7 @@ name = "starknet-core"
 version = "0.2.0"
 dependencies = [
  "base64",
+ "criterion",
  "ethereum-types",
  "flate2",
  "hex",

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -28,9 +28,16 @@ serde_with = "1.12.0"
 sha3 = "0.10.0"
 thiserror = "1.0.30"
 
+[dev-dependencies]
+criterion = "0.3.5"
+
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.29"
 
 [features]
 default = ["bigdecimal"]
 bigdecimal = ["starknet-ff/bigdecimal"]
+
+[[bench]]
+name = "class_hash"
+harness = false

--- a/starknet-core/README.md
+++ b/starknet-core/README.md
@@ -1,3 +1,11 @@
 # StarkNet data types
 
 // TODO: add `starknet-core` documentation
+
+## Benchmark
+
+On the author's machine with _AMD Ryzen 9 5950X 16-Core Processor_ running _Ubuntu 20.04.5 LTS_:
+
+```log
+class_hash              time:   [1.4011 s 1.4073 s 1.4131 s]
+```

--- a/starknet-core/benches/class_hash.rs
+++ b/starknet-core/benches/class_hash.rs
@@ -1,0 +1,19 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use starknet_core::types::ContractArtifact;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    // Using the latest OZ account contract for the benchmark
+    let contract_artifact: ContractArtifact = serde_json::from_str(include_str!(
+        "../test-data/contracts/artifacts/oz_account.txt"
+    ))
+    .unwrap();
+
+    c.bench_function("class_hash", |b| {
+        b.iter(|| {
+            black_box(&contract_artifact).class_hash().unwrap();
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
This PR adds a benchmark for `class_hash` calculation using the latest OpenZeppelin account contract. The current result is around 1.4 seconds on my machine with decent hardware, which is far from ideal.

#35 should significantly improve the performance on this.