### PR TITLE
perf: use projective points for Pedersen hash

### DIFF
--- a/starknet-core/README.md
+++ b/starknet-core/README.md
@@ -7,5 +7,5 @@
 On the author's machine with _AMD Ryzen 9 5950X 16-Core Processor_ running _Ubuntu 20.04.5 LTS_:
 
 ```log
-class_hash              time:   [1.4011 s 1.4073 s 1.4131 s]
+class_hash              time:   [124.28 ms 124.34 ms 124.39 ms]
 ```

--- a/starknet-crypto/README.md
+++ b/starknet-crypto/README.md
@@ -14,14 +14,14 @@ If you're a cryptographer, you're welcome to contribute by reviewing the impleme
 
 ## Benchmark
 
-On the author's machine with _Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz_ running _Ubuntu 20.04.2 LTS_:
+On the author's machine with _AMD Ryzen 9 5950X 16-Core Processor_ running _Ubuntu 20.04.5 LTS_:
 
 ```log
-ecdsa_get_public_key    time:   [1.6202 ms 1.6309 ms 1.6425 ms]
-ecdsa_sign              time:   [1.6612 ms 1.6754 ms 1.6912 ms]
-ecdsa_verify            time:   [5.4950 ms 5.5259 ms 5.5599 ms]
-pedersen_hash           time:   [3.1183 ms 3.1354 ms 3.1560 ms]
-rfc6979_generate_k      time:   [10.625 us 10.691 us 10.770 us]
+ecdsa_get_public_key    time:   [1.4307 ms 1.4328 ms 1.4356 ms]
+ecdsa_sign              time:   [1.4761 ms 1.4770 ms 1.4780 ms]
+ecdsa_verify            time:   [3.1532 ms 3.1556 ms 3.1590 ms]
+pedersen_hash           time:   [2.8102 ms 2.8145 ms 2.8193 ms]
+rfc6979_generate_k      time:   [2.1638 us 2.1800 us 2.1961 us]
 ```
 
 ## Credits

--- a/starknet-crypto/README.md
+++ b/starknet-crypto/README.md
@@ -17,11 +17,11 @@ If you're a cryptographer, you're welcome to contribute by reviewing the impleme
 On the author's machine with _AMD Ryzen 9 5950X 16-Core Processor_ running _Ubuntu 20.04.5 LTS_:
 
 ```log
-ecdsa_get_public_key    time:   [1.4307 ms 1.4328 ms 1.4356 ms]
-ecdsa_sign              time:   [1.4761 ms 1.4770 ms 1.4780 ms]
-ecdsa_verify            time:   [3.1532 ms 3.1556 ms 3.1590 ms]
-pedersen_hash           time:   [2.8102 ms 2.8145 ms 2.8193 ms]
-rfc6979_generate_k      time:   [2.1638 us 2.1800 us 2.1961 us]
+ecdsa_get_public_key    time:   [1.4792 ms 1.4795 ms 1.4799 ms]
+ecdsa_sign              time:   [1.4861 ms 1.4865 ms 1.4870 ms]
+ecdsa_verify            time:   [3.1352 ms 3.1405 ms 3.1470 ms]
+pedersen_hash           time:   [237.49 us 237.88 us 238.71 us]
+rfc6979_generate_k      time:   [2.2266 us 2.2300 us 2.2348 us]
 ```
 
 ## Credits

--- a/starknet-crypto/src/ec_point.rs
+++ b/starknet-crypto/src/ec_point.rs
@@ -11,6 +11,14 @@ pub struct EcPoint {
     pub infinity: bool,
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct ProjectivePoint {
+    pub x: FieldElement,
+    pub y: FieldElement,
+    pub z: FieldElement,
+    pub infinity: bool,
+}
+
 impl EcPoint {
     pub fn from_x(x: FieldElement) -> Self {
         let y_squared = x * x * x + ALPHA * x + BETA;
@@ -36,10 +44,8 @@ impl EcPoint {
 
         // l = (3x^2+a)/2y with a=1 from stark curve
         let lambda = {
-            let two = FieldElement::ONE + FieldElement::ONE;
-            let three = two + FieldElement::ONE;
-            let dividend = three * (self.x * self.x) + FieldElement::ONE;
-            let divisor_inv = (two * self.y).invert().unwrap();
+            let dividend = FieldElement::THREE * (self.x * self.x) + FieldElement::ONE;
+            let divisor_inv = (FieldElement::TWO * self.y).invert().unwrap();
             dividend * divisor_inv
         };
 
@@ -54,11 +60,14 @@ impl EcPoint {
     }
 
     pub fn add(&self, other: &EcPoint) -> EcPoint {
+        if other.infinity {
+            return *self;
+        }
         if self.infinity {
             return *other;
         }
-        if other.infinity {
-            return *self;
+        if self.x == other.x {
+            return self.double();
         }
 
         // l = (y2-y1)/(x2-x1)
@@ -96,5 +105,115 @@ impl EcPoint {
         }
 
         product
+    }
+}
+
+impl From<&ProjectivePoint> for EcPoint {
+    fn from(p: &ProjectivePoint) -> Self {
+        let zinv = p.z.invert().unwrap();
+        Self {
+            x: p.x * zinv,
+            y: p.y * zinv,
+            infinity: false,
+        }
+    }
+}
+
+impl ProjectivePoint {
+    pub const fn from_ec_point(p: &EcPoint) -> Self {
+        Self {
+            x: p.x,
+            y: p.y,
+            z: FieldElement::ONE,
+            infinity: false,
+        }
+    }
+
+    fn identity() -> ProjectivePoint {
+        Self {
+            x: FieldElement::ZERO,
+            y: FieldElement::ZERO,
+            z: FieldElement::ONE,
+            infinity: true,
+        }
+    }
+
+    pub fn double(&self) -> ProjectivePoint {
+        if self.infinity {
+            return *self;
+        }
+
+        // t=3x^2+az^2 with a=1 from stark curve
+        let t = FieldElement::THREE * self.x * self.x + self.z * self.z;
+        let u = FieldElement::TWO * self.y * self.z;
+        let v = FieldElement::TWO * u * self.x * self.y;
+        let w = t * t - FieldElement::TWO * v;
+
+        let uy = u * self.y;
+
+        let x = u * w;
+        let y = t * (v - w) - FieldElement::TWO * uy * uy;
+        let z = u * u * u;
+
+        ProjectivePoint {
+            x,
+            y,
+            z,
+            infinity: false,
+        }
+    }
+
+    pub fn add(&self, other: &ProjectivePoint) -> ProjectivePoint {
+        if other.infinity {
+            return *self;
+        }
+        if self.infinity {
+            return *other;
+        }
+        let u0 = self.x * other.z;
+        let u1 = other.x * self.z;
+        if u0 == u1 {
+            return self.double();
+        }
+
+        let t0 = self.y * other.z;
+        let t1 = other.y * self.z;
+        let t = t0 - t1;
+
+        let u = u0 - u1;
+        let u2 = u * u;
+
+        let v = self.z * other.z;
+        let w = t * t * v - u2 * (u0 + u1);
+        let u3 = u * u2;
+
+        let x = u * w;
+        let y = t * (u0 * u2 - w) - t0 * u3;
+        let z = u3 * v;
+
+        ProjectivePoint {
+            x,
+            y,
+            z,
+            infinity: false,
+        }
+    }
+
+    pub fn multiply(&self, bits: &[bool]) -> ProjectivePoint {
+        let mut product = ProjectivePoint::identity();
+        for b in bits.iter().rev() {
+            product = product.double();
+            if *b {
+                product = product.add(self);
+            }
+        }
+
+        product
+    }
+}
+
+impl From<&EcPoint> for ProjectivePoint {
+    fn from(p: &EcPoint) -> Self {
+        Self::from_ec_point(p)
     }
 }

--- a/starknet-ff/src/lib.rs
+++ b/starknet-ff/src/lib.rs
@@ -57,6 +57,22 @@ impl FieldElement {
         576460752303422960,
     ]);
 
+    /// [FieldElement] constant that's equal to 2
+    pub const TWO: FieldElement = FieldElement::from_mont([
+        18446744073709551553,
+        18446744073709551615,
+        18446744073709551615,
+        576460752303422416,
+    ]);
+
+    /// [FieldElement] constant that's equal to 3
+    pub const THREE: FieldElement = FieldElement::from_mont([
+        18446744073709551521,
+        18446744073709551615,
+        18446744073709551615,
+        576460752303421872,
+    ]);
+
     /// Maximum value of [FieldElement]. Equals to 2^251 + 17 * 2^192.
     pub const MAX: FieldElement = FieldElement::from_mont([32, 0, 0, 544]);
 


### PR DESCRIPTION
Resolves #35.

This PR significantly improves the Pedersen hash performance by around 110% (2.81ms -> 0.23ms) by using projective points (with code taken from `pathfinder`, as already mentioned in the linked issue).

Class hash calculation has also been improved by around the same multiple.