### PR TITLE
chore: add wasm benchmark scripts and results

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1,0 +1,17 @@
+# Benchmark
+
+`starknet-rs` uses [`criterion`](https://github.com/bheisler/criterion.rs) for performance benchmarking.
+
+## Native
+
+For native performance benchmark, simply run:
+
+```console
+$ cargo bench --all
+```
+
+Or just `cargo bench` inside any crate with benchmark code.
+
+## WebAssembly
+
+As a portable format, WebAssembly has many runtimes, including `wasmer`, `wasmtime`, Node.js, browsers, and more. Results are only provided for `wamer`, `wasmtime`, and Node.js. For other runtimes, check out [this guide](https://github.com/bheisler/criterion.rs/blob/version-0.4/book/src/user_guide/wasi.md) from `criterion`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,7 +28,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
- "rustc_version 0.3.3",
+ "rustc_version",
  "zeroize",
 ]
 
@@ -168,18 +174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,12 +199,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cast"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
-dependencies = [
- "rustc_version 0.4.0",
-]
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -225,14 +216,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "clap"
-version = "2.34.0"
+name = "ciborium"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "bitflags",
+ "clap_lex",
+ "indexmap",
  "textwrap",
- "unicode-width",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -265,24 +293,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
 dependencies = [
+ "anes",
  "atty",
  "cast",
+ "ciborium",
  "clap",
  "criterion-plot",
- "csv",
  "itertools",
  "lazy_static",
  "num-traits",
  "oorandom",
- "plotters",
- "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -291,57 +317,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
-dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
- "lazy_static",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
-dependencies = [
- "cfg-if",
- "lazy_static",
 ]
 
 [[package]]
@@ -380,28 +361,6 @@ checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array",
  "subtle",
-]
-
-[[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa 0.4.8",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -687,7 +646,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.2",
+ "itoa",
 ]
 
 [[package]]
@@ -728,7 +687,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.2",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -832,12 +791,6 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
@@ -899,15 +852,6 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -995,6 +939,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
+
+[[package]]
 name = "parity-scale-codec"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,34 +1025,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "plotters"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
-dependencies = [
- "plotters-backend",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -1212,30 +1134,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
-dependencies = [
- "autocfg",
- "crossbeam-deque",
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
- "num_cpus",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,12 +1150,6 @@ checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "regex-syntax",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -1351,16 +1243,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver 1.0.9",
+ "semver",
 ]
 
 [[package]]
@@ -1431,12 +1314,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
-
-[[package]]
 name = "semver-parser"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,16 +1329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
 ]
 
 [[package]]
@@ -1481,7 +1348,7 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
- "itoa 1.0.2",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1493,7 +1360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.2",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1773,12 +1640,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -1975,12 +1839,6 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ This workspace contains the following crates:
 
 `starknet-rs` can be used as a WebAssembly module. Check out [this example](./examples/starknet-wasm/).
 
+## Performance
+
+Benchmark results for native and WebAssembly targets are available for these crates:
+
+- [starknet-core](./starknet-core/)
+- [starknet-crypto](./starknet-crypto/)
+
+For instructions on running the benchmark yourself, check [here](./BENCHMARK.md).
+
 ## Example
 
 Examples can be found in the [examples folder](./examples):

--- a/scripts/build_bench_wasm.sh
+++ b/scripts/build_bench_wasm.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Make sure `wasm32-wasi` target and `cargo-wasi` are installed
+
+set -e
+
+function generate_wasm() {
+  cargo wasi build --bench=$1 --release
+  cp $(ls -t $REPO_ROOT/target/wasm32-wasi/release/deps/$1*.rustc.wasm | head -n 1) $REPO_ROOT/target/bench-wasm/$1.wasm
+}
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( dirname -- $SCRIPT_DIR )
+
+rm -rf $REPO_ROOT/target/bench-wasm
+mkdir -p $REPO_ROOT/target/bench-wasm
+
+cd $REPO_ROOT/starknet-core
+benches=(
+  class_hash
+)
+
+for bench in ${benches[@]}; do
+  generate_wasm $bench
+  generate_wasm $bench
+done
+
+cd $REPO_ROOT/starknet-crypto
+benches=(
+  ecdsa_get_public_key
+  ecdsa_sign
+  ecdsa_verify
+  pedersen_hash
+  rfc6979_generate_k
+)
+
+for bench in ${benches[@]}; do
+  generate_wasm $bench
+done

--- a/scripts/run_bench_wasm.sh
+++ b/scripts/run_bench_wasm.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Build benchmark wasm artifacts with `build_bench_wasm.sh` first
+
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( dirname -- $SCRIPT_DIR )
+
+RUNTIME="$1"
+
+if [ -z "$RUNTIME" ]; then
+  echo "Runtime not specified"
+  exit 1
+fi
+
+benches=(
+  class_hash
+  ecdsa_get_public_key
+  ecdsa_sign
+  ecdsa_verify
+  pedersen_hash
+  rfc6979_generate_k
+)
+
+for bench in ${benches[@]}; do
+  $RUNTIME run --dir=. $REPO_ROOT/target/bench-wasm/$bench.wasm -- --bench
+done

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -29,7 +29,7 @@ sha3 = "0.10.0"
 thiserror = "1.0.30"
 
 [dev-dependencies]
-criterion = "0.3.5"
+criterion = { version = "0.4.0", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.29"

--- a/starknet-core/README.md
+++ b/starknet-core/README.md
@@ -4,8 +4,45 @@
 
 ## Benchmark
 
-On the author's machine with _AMD Ryzen 9 5950X 16-Core Processor_ running _Ubuntu 20.04.5 LTS_:
+These results were generated on the author's machine with _AMD Ryzen 9 5950X 16-Core Processor_ running _Ubuntu 20.04.5 LTS_.
+
+For instructions on running the benchmarks yourself, check out [this page](../BENCHMARK.md).
+
+### Native
 
 ```log
-class_hash              time:   [124.28 ms 124.34 ms 124.39 ms]
+class_hash              time:   [117.32 ms 117.55 ms 117.78 ms]
+```
+
+### WebAssembly
+
+Runtime versions:
+
+```console
+$ wasmer --version
+wasmer 2.3.0
+$ wasmtime --version
+wasmtime-cli 2.0.2
+$ node --version
+v18.12.1
+$ wasmer-js --version
+wasmer-js 0.4.1
+```
+
+`wasmer` results:
+
+```log
+class_hash              time:   [1.0280 s 1.0283 s 1.0287 s]
+```
+
+`wasmtime` results:
+
+```log
+class_hash              time:   [836.69 ms 839.33 ms 841.92 ms]
+```
+
+Node.js results:
+
+```log
+class_hash              time:   [900.73 ms 901.09 ms 901.47 ms]
 ```

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -26,7 +26,7 @@ zeroize = "1.5.0"
 hex = "0.4.3"
 
 [dev-dependencies]
-criterion = "0.3.5"
+criterion = { version = "0.4.0", default-features = false }
 hex = "0.4.3"
 hex-literal = "0.3.4"
 serde = { version = "1.0.133", features = ["derive"] }

--- a/starknet-crypto/README.md
+++ b/starknet-crypto/README.md
@@ -14,14 +14,63 @@ If you're a cryptographer, you're welcome to contribute by reviewing the impleme
 
 ## Benchmark
 
-On the author's machine with _AMD Ryzen 9 5950X 16-Core Processor_ running _Ubuntu 20.04.5 LTS_:
+These results were generated on the author's machine with _AMD Ryzen 9 5950X 16-Core Processor_ running _Ubuntu 20.04.5 LTS_.
+
+For instructions on running the benchmarks yourself, check out [this page](../BENCHMARK.md).
+
+### Native
 
 ```log
-ecdsa_get_public_key    time:   [1.4792 ms 1.4795 ms 1.4799 ms]
-ecdsa_sign              time:   [1.4861 ms 1.4865 ms 1.4870 ms]
-ecdsa_verify            time:   [3.1352 ms 3.1405 ms 3.1470 ms]
-pedersen_hash           time:   [237.49 us 237.88 us 238.71 us]
-rfc6979_generate_k      time:   [2.2266 us 2.2300 us 2.2348 us]
+ecdsa_get_public_key    time:   [1.4756 ms 1.4761 ms 1.4765 ms]
+ecdsa_sign              time:   [1.4728 ms 1.4735 ms 1.4743 ms]
+ecdsa_verify            time:   [3.1314 ms 3.1331 ms 3.1348 ms]
+pedersen_hash           time:   [223.93 µs 224.41 µs 225.04 µs]
+rfc6979_generate_k      time:   [2.2909 µs 2.2922 µs 2.2935 µs]
+```
+
+### WebAssembly
+
+Runtime versions:
+
+```console
+$ wasmer --version
+wasmer 2.3.0
+$ wasmtime --version
+wasmtime-cli 2.0.2
+$ node --version
+v18.12.1
+$ wasmer-js --version
+wasmer-js 0.4.1
+```
+
+`wasmer` results:
+
+```log
+ecdsa_get_public_key    time:   [3.0703 ms 3.0806 ms 3.0914 ms]
+ecdsa_sign              time:   [3.1632 ms 3.1665 ms 3.1717 ms]
+ecdsa_verify            time:   [6.9936 ms 7.0168 ms 7.0426 ms]
+pedersen_hash           time:   [2.0007 ms 2.0076 ms 2.0145 ms]
+rfc6979_generate_k      time:   [12.197 µs 12.203 µs 12.210 µs]
+```
+
+`wasmtime` results:
+
+```log
+ecdsa_get_public_key    time:   [2.8495 ms 2.8541 ms 2.8618 ms]
+ecdsa_sign              time:   [2.8797 ms 2.8814 ms 2.8832 ms]
+ecdsa_verify            time:   [6.7528 ms 6.7570 ms 6.7613 ms]
+pedersen_hash           time:   [1.6589 ms 1.6618 ms 1.6651 ms]
+rfc6979_generate_k      time:   [10.833 µs 10.839 µs 10.845 µs]
+```
+
+Node.js results:
+
+```log
+ecdsa_get_public_key    time:   [2.6020 ms 2.6138 ms 2.6304 ms]
+ecdsa_sign              time:   [2.5616 ms 2.5654 ms 2.5697 ms]
+ecdsa_verify            time:   [6.2385 ms 6.2399 ms 6.2412 ms]
+pedersen_hash           time:   [1.7788 ms 1.7899 ms 1.8013 ms]
+rfc6979_generate_k      time:   [9.6454 µs 9.6483 µs 9.6514 µs]
 ```
 
 ## Credits


### PR DESCRIPTION
Resolves #239.

This PR bumps `criterion` to `0.4.0` and adds benchmark results for `wasmer`, `wasmtime`, and Node.js (via `wasmer-js`).

Now that we have multiple targets, it makes more sense to present the benchmark results in a tabular form. It will be done in a future PR.