### PR TITLE
perf: pedersen hash lookup tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,11 +1524,21 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "starknet-crypto-codegen",
  "starknet-curve",
  "starknet-ff",
  "thiserror",
  "wasm-bindgen-test",
  "zeroize",
+]
+
+[[package]]
+name = "starknet-crypto-codegen"
+version = "0.1.0"
+dependencies = [
+ "starknet-curve",
+ "starknet-ff",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "starknet-ff",
     "starknet-macros",
     "starknet-curve",
+    "starknet-crypto-codegen",
     "examples/starknet-wasm",
 ]
 

--- a/starknet-core/README.md
+++ b/starknet-core/README.md
@@ -11,7 +11,7 @@ For instructions on running the benchmarks yourself, check out [this page](../BE
 ### Native
 
 ```log
-class_hash              time:   [117.32 ms 117.55 ms 117.78 ms]
+class_hash              time:   [18.931 ms 18.943 ms 18.958 ms]
 ```
 
 ### WebAssembly
@@ -32,17 +32,17 @@ wasmer-js 0.4.1
 `wasmer` results:
 
 ```log
-class_hash              time:   [1.0280 s 1.0283 s 1.0287 s]
+class_hash              time:   [126.30 ms 126.47 ms 126.65 ms]
 ```
 
 `wasmtime` results:
 
 ```log
-class_hash              time:   [836.69 ms 839.33 ms 841.92 ms]
+class_hash              time:   [108.80 ms 109.02 ms 109.24 ms]
 ```
 
 Node.js results:
 
 ```log
-class_hash              time:   [900.73 ms 901.09 ms 901.47 ms]
+class_hash              time:   [113.77 ms 114.36 ms 115.07 ms]
 ```

--- a/starknet-crypto-codegen/Cargo.toml
+++ b/starknet-crypto-codegen/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "starknet-crypto-codegen"
+version = "0.1.0"
+authors = ["Jonathan LEI <me@xjonathan.dev>"]
+license = "MIT OR Apache-2.0"
+edition = "2021"
+readme = "README.md"
+repository = "https://github.com/xJonathanLEI/starknet-rs"
+homepage = "https://starknet.rs/"
+description = """
+Codegen macros for `starknet-crypto`
+"""
+keywords = ["ethereum", "starknet", "web3"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+starknet-curve = { version = "0.1.0", path = "../starknet-curve" }
+starknet-ff = { version = "0.1.0", path = "../starknet-ff" }
+syn = "1.0.96"

--- a/starknet-crypto-codegen/README.md
+++ b/starknet-crypto-codegen/README.md
@@ -1,0 +1,1 @@
+# Codegen macros for `starknet-crypto`

--- a/starknet-crypto-codegen/src/lib.rs
+++ b/starknet-crypto-codegen/src/lib.rs
@@ -1,0 +1,91 @@
+// Code ported from the build.rs script here:
+//   https://github.com/eqlabs/pathfinder/blob/7f9a6bb0264943f93a633f61fc4e0bc9237f68a0/crates/stark_hash/build.rs
+
+use std::fmt::Write;
+
+use proc_macro::TokenStream;
+use starknet_curve::{
+    curve_params::{PEDERSEN_P0, PEDERSEN_P1, PEDERSEN_P2, PEDERSEN_P3},
+    AffinePoint,
+};
+use syn::{parse_macro_input, LitInt};
+
+#[proc_macro]
+pub fn lookup_table(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as LitInt);
+    let bits: u32 = input.base10_parse().expect("invalid bits");
+
+    let mut output = String::new();
+    writeln!(output, "pub const CURVE_CONSTS_BITS: usize = {};", bits).unwrap();
+
+    push_points(&mut output, "P0", PEDERSEN_P0, 248, bits).expect("push_points failed");
+    push_points(&mut output, "P1", PEDERSEN_P1, 4, bits).expect("push_points failed");
+    push_points(&mut output, "P2", PEDERSEN_P2, 248, bits).expect("push_points failed");
+    push_points(&mut output, "P3", PEDERSEN_P3, 4, bits).expect("push_points failed");
+
+    output.parse().unwrap()
+}
+
+fn push_points(
+    buf: &mut String,
+    name: &str,
+    base: AffinePoint,
+    max_bits: u32,
+    bits: u32,
+) -> std::fmt::Result {
+    let full_chunks = max_bits / bits;
+    let leftover_bits = max_bits % bits;
+    let table_size_full = (1 << bits) - 1;
+    let table_size_leftover = (1 << leftover_bits) - 1;
+    let len = full_chunks * table_size_full + table_size_leftover;
+
+    writeln!(
+        buf,
+        "pub const CURVE_CONSTS_{}: [::starknet_curve::AffinePoint; {}] = [",
+        name, len
+    )?;
+
+    let mut bits_left = max_bits;
+    let mut outer_point = base;
+    while bits_left > 0 {
+        let eat_bits = std::cmp::min(bits_left, bits);
+        let table_size = (1 << eat_bits) - 1;
+
+        // Loop through each possible bit combination except zero
+        let mut inner_point = outer_point;
+        for _ in 1..(table_size + 1) {
+            push_point(buf, &inner_point)?;
+            inner_point.add_assign(&outer_point);
+        }
+
+        // Shift outer point #bits times
+        bits_left -= eat_bits;
+        for _i in 0..bits {
+            outer_point.double_assign();
+        }
+    }
+
+    writeln!(buf, "];")?;
+    Ok(())
+}
+
+fn push_point(buf: &mut String, p: &AffinePoint) -> std::fmt::Result {
+    let x = p.x.into_mont();
+    let y = p.y.into_mont();
+    writeln!(buf, "::starknet_curve::AffinePoint {{")?;
+    writeln!(buf, "x: ::starknet_ff::FieldElement::from_mont([")?;
+    writeln!(buf, "{},", x[0])?;
+    writeln!(buf, "{},", x[1])?;
+    writeln!(buf, "{},", x[2])?;
+    writeln!(buf, "{},", x[3])?;
+    writeln!(buf, "]),")?;
+    writeln!(buf, "y: ::starknet_ff::FieldElement::from_mont([")?;
+    writeln!(buf, "{},", y[0])?;
+    writeln!(buf, "{},", y[1])?;
+    writeln!(buf, "{},", y[2])?;
+    writeln!(buf, "{},", y[3])?;
+    writeln!(buf, "]),")?;
+    writeln!(buf, "infinity: false,")?;
+    writeln!(buf, "}},")?;
+    Ok(())
+}

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -13,6 +13,7 @@ Low-level cryptography utilities for StarkNet
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
+starknet-crypto-codegen = { version = "0.1.0", path = "../starknet-crypto-codegen" }
 starknet-curve = { version = "0.1.0", path = "../starknet-curve" }
 starknet-ff = { version = "0.1.0", path = "../starknet-ff" }
 crypto-bigint = "0.3.2"

--- a/starknet-crypto/README.md
+++ b/starknet-crypto/README.md
@@ -21,11 +21,11 @@ For instructions on running the benchmarks yourself, check out [this page](../BE
 ### Native
 
 ```log
-ecdsa_get_public_key    time:   [1.4756 ms 1.4761 ms 1.4765 ms]
-ecdsa_sign              time:   [1.4728 ms 1.4735 ms 1.4743 ms]
-ecdsa_verify            time:   [3.1314 ms 3.1331 ms 3.1348 ms]
-pedersen_hash           time:   [223.93 µs 224.41 µs 225.04 µs]
-rfc6979_generate_k      time:   [2.2909 µs 2.2922 µs 2.2935 µs]
+ecdsa_get_public_key    time:   [1.5350 ms 1.5461 ms 1.5629 ms]
+ecdsa_sign              time:   [1.5379 ms 1.5420 ms 1.5474 ms]
+ecdsa_verify            time:   [3.2405 ms 3.2443 ms 3.2487 ms]
+pedersen_hash           time:   [31.775 µs 31.988 µs 32.273 µs]
+rfc6979_generate_k      time:   [2.3819 µs 2.3904 µs 2.4020 µs]
 ```
 
 ### WebAssembly
@@ -46,31 +46,31 @@ wasmer-js 0.4.1
 `wasmer` results:
 
 ```log
-ecdsa_get_public_key    time:   [3.0703 ms 3.0806 ms 3.0914 ms]
-ecdsa_sign              time:   [3.1632 ms 3.1665 ms 3.1717 ms]
-ecdsa_verify            time:   [6.9936 ms 7.0168 ms 7.0426 ms]
-pedersen_hash           time:   [2.0007 ms 2.0076 ms 2.0145 ms]
-rfc6979_generate_k      time:   [12.197 µs 12.203 µs 12.210 µs]
+ecdsa_get_public_key    time:   [3.1780 ms 3.2041 ms 3.2374 ms]
+ecdsa_sign              time:   [3.2371 ms 3.2554 ms 3.2785 ms]
+ecdsa_verify            time:   [7.5052 ms 7.5168 ms 7.5297 ms]
+pedersen_hash           time:   [267.19 µs 268.74 µs 270.89 µs]
+rfc6979_generate_k      time:   [12.501 µs 12.512 µs 12.525 µs]
 ```
 
 `wasmtime` results:
 
 ```log
-ecdsa_get_public_key    time:   [2.8495 ms 2.8541 ms 2.8618 ms]
-ecdsa_sign              time:   [2.8797 ms 2.8814 ms 2.8832 ms]
-ecdsa_verify            time:   [6.7528 ms 6.7570 ms 6.7613 ms]
-pedersen_hash           time:   [1.6589 ms 1.6618 ms 1.6651 ms]
-rfc6979_generate_k      time:   [10.833 µs 10.839 µs 10.845 µs]
+ecdsa_get_public_key    time:   [2.9626 ms 2.9677 ms 2.9734 ms]
+ecdsa_sign              time:   [2.9489 ms 2.9603 ms 2.9730 ms]
+ecdsa_verify            time:   [6.8464 ms 6.8792 ms 6.9221 ms]
+pedersen_hash           time:   [220.62 µs 221.77 µs 223.72 µs]
+rfc6979_generate_k      time:   [11.263 µs 11.281 µs 11.304 µs]
 ```
 
 Node.js results:
 
 ```log
-ecdsa_get_public_key    time:   [2.6020 ms 2.6138 ms 2.6304 ms]
-ecdsa_sign              time:   [2.5616 ms 2.5654 ms 2.5697 ms]
-ecdsa_verify            time:   [6.2385 ms 6.2399 ms 6.2412 ms]
-pedersen_hash           time:   [1.7788 ms 1.7899 ms 1.8013 ms]
-rfc6979_generate_k      time:   [9.6454 µs 9.6483 µs 9.6514 µs]
+ecdsa_get_public_key    time:   [2.7033 ms 2.7220 ms 2.7461 ms]
+ecdsa_sign              time:   [2.7405 ms 2.7431 ms 2.7461 ms]
+ecdsa_verify            time:   [6.5923 ms 6.6322 ms 6.6816 ms]
+pedersen_hash           time:   [230.24 µs 230.84 µs 231.74 µs]
+rfc6979_generate_k      time:   [9.9566 µs 9.9891 µs 10.032 µs]
 ```
 
 ## Credits

--- a/starknet-crypto/src/lib.rs
+++ b/starknet-crypto/src/lib.rs
@@ -4,6 +4,7 @@ mod ecdsa;
 mod error;
 mod fe_utils;
 mod pedersen_hash;
+mod pedersen_points;
 mod rfc6979;
 
 #[cfg(test)]

--- a/starknet-crypto/src/pedersen_points.rs
+++ b/starknet-crypto/src/pedersen_points.rs
@@ -1,0 +1,3 @@
+use starknet_crypto_codegen::lookup_table;
+
+lookup_table!(4);

--- a/starknet-curve/src/ec_point.rs
+++ b/starknet-curve/src/ec_point.rs
@@ -36,7 +36,7 @@ impl AffinePoint {
         }
     }
 
-    fn double_assign(&mut self) {
+    pub fn double_assign(&mut self) {
         if self.infinity {
             return;
         }
@@ -191,6 +191,48 @@ impl ProjectivePoint {
         let u2 = u * u;
 
         let v = self.z * other.z;
+        let w = t * t * v - u2 * (u0 + u1);
+        let u3 = u * u2;
+
+        let x = u * w;
+        let y = t * (u0 * u2 - w) - t0 * u3;
+        let z = u3 * v;
+
+        self.x = x;
+        self.y = y;
+        self.z = z;
+    }
+
+    pub fn add_affine_assign(&mut self, other: &AffinePoint) {
+        if other.infinity {
+            return;
+        }
+        if self.infinity {
+            self.x = other.x;
+            self.y = other.y;
+            self.z = FieldElement::ONE;
+            self.infinity = other.infinity;
+            return;
+        }
+        let u0 = self.x;
+        let u1 = other.x * self.z;
+        let t0 = self.y;
+        let t1 = other.y * self.z;
+        if u0 == u1 {
+            if t0 != t1 {
+                self.infinity = true;
+                return;
+            } else {
+                self.double_assign();
+                return;
+            }
+        }
+
+        let t = t0 - t1;
+        let u = u0 - u1;
+        let u2 = u * u;
+
+        let v = self.z;
         let w = t * t * v - u2 * (u0 + u1);
         let u3 = u * u2;
 


### PR DESCRIPTION
Resolves #236.

The Pedersen hash performance has been significantly improved. Time per hash operation changed from `224.41 µs` to `31.988 µs`.