### PR TITLE
release: bump starknet-crypto to 0.2.0 (and deps)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "crypto-bigint",

--- a/examples/starknet-wasm/Cargo.toml
+++ b/examples/starknet-wasm/Cargo.toml
@@ -20,6 +20,6 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 starknet-ff = { version = "0.1.0", path = "../../starknet-ff" }
-starknet-crypto = { version = "0.1.0", path = "../../starknet-crypto" }
+starknet-crypto = { version = "0.2.0", path = "../../starknet-crypto" }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 wasm-bindgen = "0.2.79"

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 all-features = true
 
 [dependencies]
-starknet-crypto = { version = "0.1.0", path = "../starknet-crypto" }
+starknet-crypto = { version = "0.2.0", path = "../starknet-crypto" }
 starknet-ff = { version = "0.1.0", path = "../starknet-ff", default-features = false }
 base64 = "0.13.0"
 ethereum-types = "0.12.1"

--- a/starknet-crypto-codegen/src/lib.rs
+++ b/starknet-crypto-codegen/src/lib.rs
@@ -55,7 +55,7 @@ fn push_points(
         let mut inner_point = outer_point;
         for _ in 1..(table_size + 1) {
             push_point(buf, &inner_point)?;
-            inner_point.add_assign(&outer_point);
+            inner_point += &outer_point;
         }
 
         // Shift outer point #bits times

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-crypto"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/starknet-crypto/src/ecdsa.rs
+++ b/starknet-crypto/src/ecdsa.rs
@@ -42,7 +42,7 @@ impl fmt::Display for Signature {
 ///
 /// * `private_key`: The private key
 pub fn get_public_key(private_key: &FieldElement) -> FieldElement {
-    GENERATOR.multiply(&private_key.to_bits_le()).x
+    (&GENERATOR * &private_key.to_bits_le()).x
 }
 
 /// Computes ECDSA signature given a Stark private key and message hash.
@@ -64,7 +64,7 @@ pub fn sign(
         return Err(SignError::InvalidK);
     }
 
-    let r = GENERATOR.multiply(&k.to_bits_le()).x;
+    let r = (&GENERATOR * &k.to_bits_le()).x;
     if r == FieldElement::ZERO || r >= ELEMENT_UPPER_BOUND {
         return Err(SignError::InvalidK);
     }
@@ -113,12 +113,12 @@ pub fn verify(
     }
 
     let zw = mul_mod_floor(message, &w, &EC_ORDER);
-    let zw_g = GENERATOR.multiply(&zw.to_bits_le());
+    let zw_g = &GENERATOR * &zw.to_bits_le();
 
     let rw = mul_mod_floor(r, &w, &EC_ORDER);
-    let rw_q = full_public_key.multiply(&rw.to_bits_le());
+    let rw_q = &full_public_key * &rw.to_bits_le();
 
-    Ok(zw_g.add(&rw_q).x == *r || zw_g.subtract(&rw_q).x == *r)
+    Ok((&zw_g + &rw_q).x == *r || (&zw_g - &rw_q).x == *r)
 }
 
 #[cfg(test)]

--- a/starknet-crypto/src/pedersen_hash.rs
+++ b/starknet-crypto/src/pedersen_hash.rs
@@ -24,7 +24,7 @@ pub fn pedersen_hash(x: &FieldElement, y: &FieldElement) -> FieldElement {
                 let offset = bools_to_usize_le(v);
                 if offset > 0 {
                     // Table lookup at 'offset-1' in table for chunk 'i'
-                    acc.add_affine_assign(&prep[i * table_size + offset - 1]);
+                    *acc += &prep[i * table_size + offset - 1];
                 }
             });
     };

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
 starknet-core = { version = "0.2.0", path = "../starknet-core" }
-starknet-crypto = { version = "0.1.0", path = "../starknet-crypto" }
+starknet-crypto = { version = "0.2.0", path = "../starknet-crypto" }
 async-trait = "0.1.52"
 thiserror = "1.0.30"
 


### PR DESCRIPTION
The `starknet-crypto` crate version available on crates.io right now is around 100x slower than the current `master` head. It's time to release a new version so that projects stuck with crates.io (e.g. they also want to publish on crates.io) can take advantage of the performance gains.

- `starknet-ff`: `0.1.0` -> `0.2.0` - breaking changes on an error type
- `starknet-curve`: `0.1.0` - new crate
- `starknet-crypto-codegen`: `0.1.0` - new crate
- `starknet-crypto`: `0.1.0` -> `0.2.0` - there's zero breaking change on the lib itself, but since it re-exports `starknet-ff`, its public API has technically changed