### PR TITLE
release: bump starknet-crypto to 0.2.0 (and deps)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "crypto-bigint",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-ff"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ark-ff",
  "bigdecimal",

--- a/examples/starknet-wasm/Cargo.toml
+++ b/examples/starknet-wasm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-starknet-ff = { version = "0.1.0", path = "../../starknet-ff" }
-starknet-crypto = { version = "0.1.0", path = "../../starknet-crypto" }
+starknet-ff = { version = "0.2.0", path = "../../starknet-ff" }
+starknet-crypto = { version = "0.2.0", path = "../../starknet-crypto" }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 wasm-bindgen = "0.2.79"

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -16,8 +16,8 @@ keywords = ["ethereum", "starknet", "web3"]
 all-features = true
 
 [dependencies]
-starknet-crypto = { version = "0.1.0", path = "../starknet-crypto" }
-starknet-ff = { version = "0.1.0", path = "../starknet-ff", default-features = false }
+starknet-crypto = { version = "0.2.0", path = "../starknet-crypto" }
+starknet-ff = { version = "0.2.0", path = "../starknet-ff", default-features = false }
 base64 = "0.13.0"
 ethereum-types = "0.12.1"
 flate2 = "1.0.24"

--- a/starknet-crypto-codegen/Cargo.toml
+++ b/starknet-crypto-codegen/Cargo.toml
@@ -17,5 +17,5 @@ proc-macro = true
 
 [dependencies]
 starknet-curve = { version = "0.1.0", path = "../starknet-curve" }
-starknet-ff = { version = "0.1.0", path = "../starknet-ff" }
+starknet-ff = { version = "0.2.0", path = "../starknet-ff" }
 syn = "1.0.96"

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-crypto"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -15,7 +15,7 @@ keywords = ["ethereum", "starknet", "web3"]
 [dependencies]
 starknet-crypto-codegen = { version = "0.1.0", path = "../starknet-crypto-codegen" }
 starknet-curve = { version = "0.1.0", path = "../starknet-curve" }
-starknet-ff = { version = "0.1.0", path = "../starknet-ff" }
+starknet-ff = { version = "0.2.0", path = "../starknet-ff" }
 crypto-bigint = "0.3.2"
 hmac = "0.11.0"
 num-bigint = "0.4.3"

--- a/starknet-curve/Cargo.toml
+++ b/starknet-curve/Cargo.toml
@@ -13,4 +13,4 @@ Stark curve
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-ff = { version = "0.1.0", path = "../starknet-ff" }
+starknet-ff = { version = "0.2.0", path = "../starknet-ff" }

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-ff"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
 starknet-core = { version = "0.2.0", path = "../starknet-core" }
-starknet-crypto = { version = "0.1.0", path = "../starknet-crypto" }
+starknet-crypto = { version = "0.2.0", path = "../starknet-crypto" }
 async-trait = "0.1.52"
 thiserror = "1.0.30"
 


### PR DESCRIPTION
_Supersedes #247, but actually changes the version for `starknet-ff` too. Somehow it was missing from that PR, which has been reverted on `master`._

The `starknet-crypto` crate version available on crates.io right now is around 100x slower than the current `master` head. It's time to release a new version so that projects stuck with crates.io (e.g. they also want to publish on crates.io) can take advantage of the performance gains.

- `starknet-ff`: `0.1.0` -> `0.2.0` - breaking changes on an error type
- `starknet-curve`: `0.1.0` - new crate
- `starknet-crypto-codegen`: `0.1.0` - new crate
- `starknet-crypto`: `0.1.0` -> `0.2.0` - there's zero breaking change on the lib itself, but since it re-exports `starknet-ff`, its public API has technically changed