### PR TITLE
feat(jsonrpc): update to support spec v0.2.1

### DIFF
--- a/starknet-contract/tests/contract_deployment.rs
+++ b/starknet-contract/tests/contract_deployment.rs
@@ -2,6 +2,7 @@ use starknet_contract::ContractFactory;
 use starknet_core::types::{ContractArtifact, FieldElement};
 
 #[tokio::test]
+#[ignore = "Legacy deploy transaction removed from live environments"]
 async fn can_deploy_contract_to_alpha_goerli() {
     let artifact = serde_json::from_str::<ContractArtifact>(include_str!(
         "../test-data/artifacts/oz_account.txt"

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -65,6 +65,8 @@ pub enum JsonRpcMethod {
     AddDeclareTransaction,
     #[serde(rename = "starknet_addDeployTransaction")]
     AddDeployTransaction,
+    #[serde(rename = "starknet_addDeployAccountTransaction")]
+    AddDeployAccountTransaction,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -111,8 +113,8 @@ struct FeltArray(#[serde_as(as = "Vec<UfeHex>")] pub Vec<FieldElement>);
 struct EventFilterWithPage {
     #[serde(flatten)]
     filter: EventFilter,
-    page_size: u64,
-    page_number: u64,
+    #[serde(flatten)]
+    page: ResultPageRequest,
 }
 
 impl<T> JsonRpcClient<T> {
@@ -221,14 +223,18 @@ where
         .await
     }
 
-    /// Get the contract class definition associated with the given hash
+    /// Get the contract class definition in the given block associated with the given hash
     pub async fn get_class(
         &self,
+        block_id: &BlockId,
         class_hash: FieldElement,
     ) -> Result<ContractClass, JsonRpcClientError<T::Error>> {
         self.send_request(
             JsonRpcMethod::GetClass,
-            [serde_json::to_value(Felt(class_hash))?],
+            [
+                serde_json::to_value(block_id)?,
+                serde_json::to_value(Felt(class_hash))?,
+            ],
         )
         .await
     }
@@ -307,7 +313,7 @@ where
         block_id: &BlockId,
     ) -> Result<FeeEstimate, JsonRpcClientError<T::Error>>
     where
-        R: AsRef<FunctionCall>,
+        R: AsRef<BroadcastedTransaction>,
     {
         self.send_request(
             JsonRpcMethod::EstimateFee,
@@ -357,29 +363,35 @@ where
     pub async fn get_events(
         &self,
         filter: EventFilter,
-        page_size: u64,
-        page_number: u64,
+        continuation_token: Option<String>,
+        chunk_size: u64,
     ) -> Result<EventsPage, JsonRpcClientError<T::Error>> {
         self.send_request(
             JsonRpcMethod::GetEvents,
             [serde_json::to_value(EventFilterWithPage {
                 filter,
-                page_size,
-                page_number,
+                page: ResultPageRequest {
+                    continuation_token,
+                    chunk_size,
+                },
             })?],
         )
         .await
     }
 
-    /// Get the latest nonce associated with the given address
+    /// Get the nonce associated with the given address in the given block
     pub async fn get_nonce(
         &self,
+        block_id: &BlockId,
         contract_address: FieldElement,
     ) -> Result<FieldElement, JsonRpcClientError<T::Error>> {
         Ok(self
             .send_request::<_, Felt>(
                 JsonRpcMethod::GetNonce,
-                [serde_json::to_value(Felt(contract_address))?],
+                [
+                    serde_json::to_value(block_id)?,
+                    serde_json::to_value(Felt(contract_address))?,
+                ],
             )
             .await?
             .0)
@@ -388,19 +400,11 @@ where
     /// Submit a new transaction to be added to the chain
     pub async fn add_invoke_transaction(
         &self,
-        function_invocation: &FunctionCall,
-        signature: Vec<FieldElement>,
-        max_fee: FieldElement,
-        version: FieldElement,
+        invoke_transaction: &BroadcastedInvokeTransaction,
     ) -> Result<InvokeTransactionResult, JsonRpcClientError<T::Error>> {
         self.send_request(
             JsonRpcMethod::AddInvokeTransaction,
-            [
-                serde_json::to_value(function_invocation)?,
-                serde_json::to_value(FeltArray(signature))?,
-                serde_json::to_value(Felt(max_fee))?,
-                serde_json::to_value(Felt(version))?,
-            ],
+            [serde_json::to_value(invoke_transaction)?],
         )
         .await
     }
@@ -408,15 +412,11 @@ where
     /// Submit a new transaction to be added to the chain
     pub async fn add_declare_transaction(
         &self,
-        contract_class: &ContractClass,
-        version: FieldElement,
+        declare_transaction: &BroadcastedDeclareTransaction,
     ) -> Result<DeclareTransactionResult, JsonRpcClientError<T::Error>> {
         self.send_request(
             JsonRpcMethod::AddDeclareTransaction,
-            [
-                serde_json::to_value(contract_class)?,
-                serde_json::to_value(Felt(version))?,
-            ],
+            [serde_json::to_value(declare_transaction)?],
         )
         .await
     }
@@ -424,17 +424,23 @@ where
     /// Submit a new deploy contract transaction
     pub async fn add_deploy_transaction(
         &self,
-        contract_address_salt: FieldElement,
-        constructor_calldata: Vec<FieldElement>,
-        contract_definition: &ContractClass,
+        deploy_transaction: &BroadcastedDeployTransaction,
     ) -> Result<DeployTransactionResult, JsonRpcClientError<T::Error>> {
         self.send_request(
             JsonRpcMethod::AddDeployTransaction,
-            [
-                serde_json::to_value(Felt(contract_address_salt))?,
-                serde_json::to_value(FeltArray(constructor_calldata))?,
-                serde_json::to_value(contract_definition)?,
-            ],
+            [serde_json::to_value(deploy_transaction)?],
+        )
+        .await
+    }
+
+    /// Submit a new deploy account transaction
+    pub async fn add_deploy_account_transaction(
+        &self,
+        deploy_account_transaction: &BroadcastedDeployAccountTransaction,
+    ) -> Result<DeployAccountTransactionResult, JsonRpcClientError<T::Error>> {
+        self.send_request(
+            JsonRpcMethod::AddDeployAccountTransaction,
+            [serde_json::to_value(deploy_account_transaction)?],
         )
         .await
     }

--- a/starknet-providers/src/jsonrpc/models/codegen.rs
+++ b/starknet-providers/src/jsonrpc/models/codegen.rs
@@ -1,0 +1,2294 @@
+// AUTO-GENERATED CODE. DO NOT EDIT
+// To change the code generated, modify the codegen tool instead:
+//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen
+
+// Code generated with version:
+//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen#c75e6067c10b9f1161f99657e9c9819528bc96a6
+
+// Code generation requested but not implemented for these types:
+// - `BLOCK_ID`
+// - `TXN`
+// - `BROADCASTED_TXN`
+// - `INVOKE_TXN`
+// - `BROADCASTED_INVOKE_TXN`
+// - `TXN_RECEIPT`
+// - `PENDING_TXN_RECEIPT`
+// - `CONTRACT_ABI_ENTRY`
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_with::serde_as;
+use starknet_core::{
+    serde::{byte_array::base64, unsigned_field_element::UfeHex},
+    types::FieldElement,
+};
+
+use super::{serde_impls::NumAsHex, *};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResultPageRequest {
+    /// A pointer to the last element of the delivered page, use this token in a subsequent query to
+    /// obtain the next page
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub continuation_token: Option<String>,
+    pub chunk_size: u64,
+}
+
+/// An event emitted as a result of transaction execution.
+///
+/// Event information decorated with metadata on where it was emitted.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmittedEvent {
+    #[serde_as(as = "UfeHex")]
+    pub from_address: FieldElement,
+    #[serde_as(as = "Vec<UfeHex>")]
+    pub keys: Vec<FieldElement>,
+    #[serde_as(as = "Vec<UfeHex>")]
+    pub data: Vec<FieldElement>,
+    /// The hash of the block in which the event was emitted
+    #[serde_as(as = "UfeHex")]
+    pub block_hash: FieldElement,
+    /// The number of the block in which the event was emitted
+    pub block_number: u64,
+    /// The transaction that emitted the event
+    #[serde_as(as = "UfeHex")]
+    pub transaction_hash: FieldElement,
+}
+
+/// A StarkNet event.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Event {
+    #[serde_as(as = "UfeHex")]
+    pub from_address: FieldElement,
+    #[serde_as(as = "Vec<UfeHex>")]
+    pub keys: Vec<FieldElement>,
+    #[serde_as(as = "Vec<UfeHex>")]
+    pub data: Vec<FieldElement>,
+}
+
+/// An event filter/query.
+#[serde_as]
+#[derive(Debug, Clone, Serialize)]
+pub struct EventFilter {
+    /// From block
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub from_block: Option<BlockId>,
+    /// To block
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_block: Option<BlockId>,
+    /// From contract
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<UfeHex>")]
+    pub address: Option<FieldElement>,
+    /// Filter key values
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<Vec<UfeHex>>")]
+    pub keys: Option<Vec<FieldElement>>,
+}
+
+/// A tag specifying a dynamic reference to a block.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum BlockTag {
+    #[serde(rename = "latest")]
+    Latest,
+    #[serde(rename = "pending")]
+    Pending,
+}
+
+/// An object describing the node synchronization status.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncStatus {
+    /// The hash of the block from which the sync started
+    #[serde_as(as = "UfeHex")]
+    pub starting_block_hash: FieldElement,
+    /// The number (height) of the block from which the sync started
+    #[serde_as(as = "NumAsHex")]
+    pub starting_block_num: u64,
+    /// The hash of the current block being synchronized
+    #[serde_as(as = "UfeHex")]
+    pub current_block_hash: FieldElement,
+    /// The number (height) of the current block being synchronized
+    #[serde_as(as = "NumAsHex")]
+    pub current_block_num: u64,
+    /// The hash of the estimated highest block to be synchronized
+    #[serde_as(as = "UfeHex")]
+    pub highest_block_hash: FieldElement,
+    /// The number (height) of the estimated highest block to be synchronized
+    #[serde_as(as = "NumAsHex")]
+    pub highest_block_num: u64,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateUpdate {
+    #[serde_as(as = "UfeHex")]
+    pub block_hash: FieldElement,
+    /// The new global state root
+    #[serde_as(as = "UfeHex")]
+    pub new_root: FieldElement,
+    /// The previous global state root
+    #[serde_as(as = "UfeHex")]
+    pub old_root: FieldElement,
+    /// The change in state applied in this block, given as a mapping of addresses to the new values
+    /// and/or new contracts
+    pub state_diff: StateDiff,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateDiff {
+    pub storage_diffs: Vec<ContractStorageDiffItem>,
+    #[serde_as(as = "Vec<UfeHex>")]
+    pub declared_contract_hashes: Vec<FieldElement>,
+    pub deployed_contracts: Vec<DeployedContractItem>,
+    pub nonces: Vec<NonceUpdate>,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NonceUpdate {
+    /// The address of the contract
+    #[serde_as(as = "UfeHex")]
+    pub contract_address: FieldElement,
+    /// The nonce for the given address at the end of the block
+    #[serde_as(as = "UfeHex")]
+    pub nonce: FieldElement,
+}
+
+/// The block object.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockWithTxHashes {
+    pub status: BlockStatus,
+    #[serde_as(as = "UfeHex")]
+    pub block_hash: FieldElement,
+    /// The hash of this block's parent
+    #[serde_as(as = "UfeHex")]
+    pub parent_hash: FieldElement,
+    /// The block number (its height)
+    pub block_number: u64,
+    /// The new global state root
+    #[serde_as(as = "UfeHex")]
+    pub new_root: FieldElement,
+    /// The time in which the block was created, encoded in Unix time
+    pub timestamp: u64,
+    /// The StarkNet identity of the sequencer submitting this block
+    #[serde_as(as = "UfeHex")]
+    pub sequencer_address: FieldElement,
+    /// The hashes of the transactions included in this block
+    #[serde_as(as = "Vec<UfeHex>")]
+    pub transactions: Vec<FieldElement>,
+}
+
+/// The block object.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockWithTxs {
+    pub status: BlockStatus,
+    #[serde_as(as = "UfeHex")]
+    pub block_hash: FieldElement,
+    /// The hash of this block's parent
+    #[serde_as(as = "UfeHex")]
+    pub parent_hash: FieldElement,
+    /// The block number (its height)
+    pub block_number: u64,
+    /// The new global state root
+    #[serde_as(as = "UfeHex")]
+    pub new_root: FieldElement,
+    /// The time in which the block was created, encoded in Unix time
+    pub timestamp: u64,
+    /// The StarkNet identity of the sequencer submitting this block
+    #[serde_as(as = "UfeHex")]
+    pub sequencer_address: FieldElement,
+    /// The transactions in this block
+    pub transactions: Vec<Transaction>,
+}
+
+/// The dynamic block being constructed by the sequencer. Note that this object will be deprecated
+/// upon decentralization.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingBlockWithTxHashes {
+    /// The hashes of the transactions included in this block
+    #[serde_as(as = "Vec<UfeHex>")]
+    pub transactions: Vec<FieldElement>,
+    /// The time in which the block was created, encoded in Unix time
+    pub timestamp: u64,
+    /// The StarkNet identity of the sequencer submitting this block
+    #[serde_as(as = "UfeHex")]
+    pub sequencer_address: FieldElement,
+    /// The hash of this block's parent
+    #[serde_as(as = "UfeHex")]
+    pub parent_hash: FieldElement,
+}
+
+/// The dynamic block being constructed by the sequencer. Note that this object will be deprecated
+/// upon decentralization.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingBlockWithTxs {
+    /// The transactions in this block
+    pub transactions: Vec<Transaction>,
+    /// The time in which the block was created, encoded in Unix time
+    pub timestamp: u64,
+    /// The StarkNet identity of the sequencer submitting this block
+    #[serde_as(as = "UfeHex")]
+    pub sequencer_address: FieldElement,
+    /// The hash of this block's parent
+    #[serde_as(as = "UfeHex")]
+    pub parent_hash: FieldElement,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeployedContractItem {
+    /// The address of the contract
+    #[serde_as(as = "UfeHex")]
+    pub address: FieldElement,
+    /// The hash of the contract code
+    #[serde_as(as = "UfeHex")]
+    pub class_hash: FieldElement,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContractStorageDiffItem {
+    /// The contract address for which the storage changed
+    #[serde_as(as = "UfeHex")]
+    pub address: FieldElement,
+    /// The changes in the storage of the contract
+    pub storage_entries: Vec<StorageEntry>,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageEntry {
+    /// The key of the changed value
+    #[serde_as(as = "UfeHex")]
+    pub key: FieldElement,
+    /// The new value applied to the given address
+    #[serde_as(as = "UfeHex")]
+    pub value: FieldElement,
+}
+
+/// Declare contract transaction.
+#[derive(Debug, Clone)]
+pub struct DeclareTransaction {
+    /// The hash identifying the transaction
+    pub transaction_hash: FieldElement,
+    /// The maximal fee that can be charged for including the transaction
+    pub max_fee: FieldElement,
+    /// Version of the transaction scheme
+    pub version: u64,
+    pub signature: Vec<FieldElement>,
+    pub nonce: FieldElement,
+    /// The hash of the declared class
+    pub class_hash: FieldElement,
+    /// The address of the account contract sending the declaration transaction
+    pub sender_address: FieldElement,
+}
+
+/// Mempool representation of a declare transaction.
+#[derive(Debug, Clone)]
+pub struct BroadcastedDeclareTransaction {
+    /// The maximal fee that can be charged for including the transaction
+    pub max_fee: FieldElement,
+    /// Version of the transaction scheme
+    pub version: u64,
+    pub signature: Vec<FieldElement>,
+    pub nonce: FieldElement,
+    /// The class to be declared
+    pub contract_class: ContractClass,
+    /// The address of the account contract sending the declaration transaction
+    pub sender_address: FieldElement,
+}
+
+/// Deploy account transaction.
+///
+/// Deploys an account contract, charges fee from the pre-funded account addresses.
+#[derive(Debug, Clone)]
+pub struct DeployAccountTransaction {
+    /// The hash identifying the transaction
+    pub transaction_hash: FieldElement,
+    /// The maximal fee that can be charged for including the transaction
+    pub max_fee: FieldElement,
+    /// Version of the transaction scheme
+    pub version: u64,
+    pub signature: Vec<FieldElement>,
+    pub nonce: FieldElement,
+    /// The salt for the address of the deployed contract
+    pub contract_address_salt: FieldElement,
+    /// The parameters passed to the constructor
+    pub constructor_calldata: Vec<FieldElement>,
+    /// The hash of the deployed contract's class
+    pub class_hash: FieldElement,
+}
+
+/// Mempool representation of a deploy account transaction.
+#[derive(Debug, Clone)]
+pub struct BroadcastedDeployAccountTransaction {
+    /// The maximal fee that can be charged for including the transaction
+    pub max_fee: FieldElement,
+    /// Version of the transaction scheme
+    pub version: u64,
+    pub signature: Vec<FieldElement>,
+    pub nonce: FieldElement,
+    /// The salt for the address of the deployed contract
+    pub contract_address_salt: FieldElement,
+    /// The parameters passed to the constructor
+    pub constructor_calldata: Vec<FieldElement>,
+    /// The hash of the deployed contract's class
+    pub class_hash: FieldElement,
+}
+
+/// Deploy contract transaction.
+///
+/// The structure of a deploy transaction. Note that this transaction type is deprecated and will no
+/// longer be supported in future versions.
+#[derive(Debug, Clone)]
+pub struct DeployTransaction {
+    /// The hash identifying the transaction
+    pub transaction_hash: FieldElement,
+    /// The hash of the deployed contract's class
+    pub class_hash: FieldElement,
+    /// Version of the transaction scheme
+    pub version: u64,
+    /// The salt for the address of the deployed contract
+    pub contract_address_salt: FieldElement,
+    /// The parameters passed to the constructor
+    pub constructor_calldata: Vec<FieldElement>,
+}
+
+/// Mempool representation of a deploy transaction.
+///
+/// The structure of a deploy transaction. Note that this transaction type is deprecated and will no
+/// longer be supported in future versions.
+#[derive(Debug, Clone)]
+pub struct BroadcastedDeployTransaction {
+    /// The class of the contract that will be deployed
+    pub contract_class: ContractClass,
+    /// Version of the transaction scheme
+    pub version: u64,
+    /// The salt for the address of the deployed contract
+    pub contract_address_salt: FieldElement,
+    /// The parameters passed to the constructor
+    pub constructor_calldata: Vec<FieldElement>,
+}
+
+/// Version 0 invoke transaction.
+///
+/// Invokes a specific function in the desired contract (not necessarily an account).
+#[derive(Debug, Clone)]
+pub struct InvokeTransactionV0 {
+    /// The hash identifying the transaction
+    pub transaction_hash: FieldElement,
+    /// The maximal fee that can be charged for including the transaction
+    pub max_fee: FieldElement,
+    pub signature: Vec<FieldElement>,
+    pub nonce: FieldElement,
+    pub contract_address: FieldElement,
+    pub entry_point_selector: FieldElement,
+    /// The parameters passed to the function
+    pub calldata: Vec<FieldElement>,
+}
+
+/// Version 1 invoke transaction.
+///
+/// Initiates a transaction from a given account.
+#[derive(Debug, Clone)]
+pub struct InvokeTransactionV1 {
+    /// The hash identifying the transaction
+    pub transaction_hash: FieldElement,
+    /// The maximal fee that can be charged for including the transaction
+    pub max_fee: FieldElement,
+    pub signature: Vec<FieldElement>,
+    pub nonce: FieldElement,
+    pub sender_address: FieldElement,
+    /// The data expected by the account's `execute` function (in most usecases, this includes the
+    /// called contract address and a function selector)
+    pub calldata: Vec<FieldElement>,
+}
+
+/// Version 0 invoke transaction.
+///
+/// Invokes a specific function in the desired contract (not necessarily an account).
+#[derive(Debug, Clone)]
+pub struct BroadcastedInvokeTransactionV0 {
+    /// The maximal fee that can be charged for including the transaction
+    pub max_fee: FieldElement,
+    pub signature: Vec<FieldElement>,
+    pub nonce: FieldElement,
+    pub contract_address: FieldElement,
+    pub entry_point_selector: FieldElement,
+    /// The parameters passed to the function
+    pub calldata: Vec<FieldElement>,
+}
+
+/// Version 1 invoke transaction.
+///
+/// Initiates a transaction from a given account.
+#[derive(Debug, Clone)]
+pub struct BroadcastedInvokeTransactionV1 {
+    /// The maximal fee that can be charged for including the transaction
+    pub max_fee: FieldElement,
+    pub signature: Vec<FieldElement>,
+    pub nonce: FieldElement,
+    pub sender_address: FieldElement,
+    /// The data expected by the account's `execute` function (in most usecases, this includes the
+    /// called contract address and a function selector)
+    pub calldata: Vec<FieldElement>,
+}
+
+#[derive(Debug, Clone)]
+pub struct L1HandlerTransaction {
+    /// The hash identifying the transaction
+    pub transaction_hash: FieldElement,
+    /// Version of the transaction scheme
+    pub version: u64,
+    /// The L1->L2 message nonce field of the sn core L1 contract at the time the transaction was
+    /// sent
+    pub nonce: u64,
+    pub contract_address: FieldElement,
+    pub entry_point_selector: FieldElement,
+    /// The parameters passed to the function
+    pub calldata: Vec<FieldElement>,
+}
+
+/// Invoke transaction receipt.
+#[derive(Debug, Clone)]
+pub struct InvokeTransactionReceipt {
+    /// The hash identifying the transaction
+    pub transaction_hash: FieldElement,
+    /// The fee that was charged by the sequencer
+    pub actual_fee: FieldElement,
+    pub status: TransactionStatus,
+    pub block_hash: FieldElement,
+    pub block_number: u64,
+    pub messages_sent: Vec<MsgToL1>,
+    /// The events emitted as part of this transaction
+    pub events: Vec<Event>,
+}
+
+/// Declare transaction receipt.
+#[derive(Debug, Clone)]
+pub struct DeclareTransactionReceipt {
+    /// The hash identifying the transaction
+    pub transaction_hash: FieldElement,
+    /// The fee that was charged by the sequencer
+    pub actual_fee: FieldElement,
+    pub status: TransactionStatus,
+    pub block_hash: FieldElement,
+    pub block_number: u64,
+    pub messages_sent: Vec<MsgToL1>,
+    /// The events emitted as part of this transaction
+    pub events: Vec<Event>,
+}
+
+/// Deploy account transaction receipt.
+#[derive(Debug, Clone)]
+pub struct DeployAccountTransactionReceipt {
+    /// The hash identifying the transaction
+    pub transaction_hash: FieldElement,
+    /// The fee that was charged by the sequencer
+    pub actual_fee: FieldElement,
+    pub status: TransactionStatus,
+    pub block_hash: FieldElement,
+    pub block_number: u64,
+    pub messages_sent: Vec<MsgToL1>,
+    /// The events emitted as part of this transaction
+    pub events: Vec<Event>,
+    /// The address of the deployed contract
+    pub contract_address: FieldElement,
+}
+
+/// Deploy transaction receipt.
+#[derive(Debug, Clone)]
+pub struct DeployTransactionReceipt {
+    /// The hash identifying the transaction
+    pub transaction_hash: FieldElement,
+    /// The fee that was charged by the sequencer
+    pub actual_fee: FieldElement,
+    pub status: TransactionStatus,
+    pub block_hash: FieldElement,
+    pub block_number: u64,
+    pub messages_sent: Vec<MsgToL1>,
+    /// The events emitted as part of this transaction
+    pub events: Vec<Event>,
+    /// The address of the deployed contract
+    pub contract_address: FieldElement,
+}
+
+/// Receipt for L1 handler transaction.
+#[derive(Debug, Clone)]
+pub struct L1HandlerTransactionReceipt {
+    /// The hash identifying the transaction
+    pub transaction_hash: FieldElement,
+    /// The fee that was charged by the sequencer
+    pub actual_fee: FieldElement,
+    pub status: TransactionStatus,
+    pub block_hash: FieldElement,
+    pub block_number: u64,
+    pub messages_sent: Vec<MsgToL1>,
+    /// The events emitted as part of this transaction
+    pub events: Vec<Event>,
+}
+
+/// Pending invoke transaction receipt.
+#[derive(Debug, Clone)]
+pub struct PendingInvokeTransactionReceipt {
+    /// The hash identifying the transaction
+    pub transaction_hash: FieldElement,
+    /// The fee that was charged by the sequencer
+    pub actual_fee: FieldElement,
+    pub messages_sent: Vec<MsgToL1>,
+    /// The events emitted as part of this transaction
+    pub events: Vec<Event>,
+}
+
+/// Pending declare transaction receipt.
+#[derive(Debug, Clone)]
+pub struct PendingDeclareTransactionReceipt {
+    /// The hash identifying the transaction
+    pub transaction_hash: FieldElement,
+    /// The fee that was charged by the sequencer
+    pub actual_fee: FieldElement,
+    pub messages_sent: Vec<MsgToL1>,
+    /// The events emitted as part of this transaction
+    pub events: Vec<Event>,
+}
+
+/// Pending deploy account transaction receipt.
+#[derive(Debug, Clone)]
+pub struct PendingDeployAccountTransactionReceipt {
+    /// The hash identifying the transaction
+    pub transaction_hash: FieldElement,
+    /// The fee that was charged by the sequencer
+    pub actual_fee: FieldElement,
+    pub messages_sent: Vec<MsgToL1>,
+    /// The events emitted as part of this transaction
+    pub events: Vec<Event>,
+}
+
+/// Pending deploy transaction receipt.
+#[derive(Debug, Clone)]
+pub struct PendingDeployTransactionReceipt {
+    /// The hash identifying the transaction
+    pub transaction_hash: FieldElement,
+    /// The fee that was charged by the sequencer
+    pub actual_fee: FieldElement,
+    pub messages_sent: Vec<MsgToL1>,
+    /// The events emitted as part of this transaction
+    pub events: Vec<Event>,
+    /// The address of the deployed contract
+    pub contract_address: FieldElement,
+}
+
+/// Pending receipt for L1 handler transaction.
+#[derive(Debug, Clone)]
+pub struct PendingL1HandlerTransactionReceipt {
+    /// The hash identifying the transaction
+    pub transaction_hash: FieldElement,
+    /// The fee that was charged by the sequencer
+    pub actual_fee: FieldElement,
+    pub messages_sent: Vec<MsgToL1>,
+    /// The events emitted as part of this transaction
+    pub events: Vec<Event>,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MsgToL1 {
+    /// The target L1 address the message is sent to
+    #[serde_as(as = "UfeHex")]
+    pub to_address: FieldElement,
+    /// The payload of the message
+    #[serde_as(as = "Vec<UfeHex>")]
+    pub payload: Vec<FieldElement>,
+}
+
+/// The status of the transaction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TransactionStatus {
+    #[serde(rename = "PENDING")]
+    Pending,
+    #[serde(rename = "ACCEPTED_ON_L2")]
+    AcceptedOnL2,
+    #[serde(rename = "ACCEPTED_ON_L1")]
+    AcceptedOnL1,
+    #[serde(rename = "REJECTED")]
+    Rejected,
+}
+
+/// The status of the block.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum BlockStatus {
+    #[serde(rename = "PENDING")]
+    Pending,
+    #[serde(rename = "ACCEPTED_ON_L2")]
+    AcceptedOnL2,
+    #[serde(rename = "ACCEPTED_ON_L1")]
+    AcceptedOnL1,
+    #[serde(rename = "REJECTED")]
+    Rejected,
+}
+
+/// Function call information.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionCall {
+    #[serde_as(as = "UfeHex")]
+    pub contract_address: FieldElement,
+    #[serde_as(as = "UfeHex")]
+    pub entry_point_selector: FieldElement,
+    /// The parameters passed to the function
+    #[serde_as(as = "Vec<UfeHex>")]
+    pub calldata: Vec<FieldElement>,
+}
+
+/// The definition of a StarkNet contract class.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContractClass {
+    /// A base64 representation of the compressed program code
+    #[serde(with = "base64")]
+    pub program: Vec<u8>,
+    pub entry_points_by_type: EntryPointsByType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub abi: Option<Vec<ContractAbiEntry>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntryPointsByType {
+    #[serde(rename = "CONSTRUCTOR")]
+    pub constructor: Vec<ContractEntryPoint>,
+    #[serde(rename = "EXTERNAL")]
+    pub external: Vec<ContractEntryPoint>,
+    #[serde(rename = "L1_HANDLER")]
+    pub l1_handler: Vec<ContractEntryPoint>,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContractEntryPoint {
+    /// The offset of the entry point in the program
+    #[serde_as(as = "NumAsHex")]
+    pub offset: u64,
+    /// A unique identifier of the entry point (function) in the program
+    #[serde_as(as = "UfeHex")]
+    pub selector: FieldElement,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum StructAbiType {
+    #[serde(rename = "struct")]
+    Struct,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum EventAbiType {
+    #[serde(rename = "event")]
+    Event,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FunctionAbiType {
+    #[serde(rename = "function")]
+    Function,
+    #[serde(rename = "l1_handler")]
+    L1Handler,
+    #[serde(rename = "constructor")]
+    Constructor,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StructAbiEntry {
+    pub r#type: StructAbiType,
+    /// The struct name
+    pub name: String,
+    pub size: u64,
+    pub members: Vec<StructMember>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StructMember {
+    /// The parameter's name
+    pub name: String,
+    /// The parameter's type
+    pub r#type: String,
+    /// Offset of this property within the struct
+    pub offset: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventAbiEntry {
+    pub r#type: EventAbiType,
+    /// The event name
+    pub name: String,
+    pub keys: Vec<TypedParameter>,
+    pub data: Vec<TypedParameter>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionAbiEntry {
+    pub r#type: FunctionAbiType,
+    /// The function name
+    pub name: String,
+    pub inputs: Vec<TypedParameter>,
+    pub outputs: Vec<TypedParameter>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TypedParameter {
+    /// The parameter's name
+    pub name: String,
+    /// The parameter's type
+    pub r#type: String,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeeEstimate {
+    /// The Ethereum gas cost of the transaction (see
+    /// https://docs.starknet.io/docs/fees/fee-mechanism for more info)
+    #[serde_as(as = "NumAsHex")]
+    pub gas_consumed: u64,
+    /// The gas price (in gwei) that was used in the cost estimation
+    #[serde_as(as = "NumAsHex")]
+    pub gas_price: u64,
+    /// The estimated fee for the transaction (in gwei), product of gas_consumed and gas_price
+    #[serde_as(as = "NumAsHex")]
+    pub overall_fee: u64,
+}
+
+impl Serialize for DeclareTransaction {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: &'a FieldElement,
+            pub r#type: &'a str,
+            #[serde_as(as = "UfeHex")]
+            pub max_fee: &'a FieldElement,
+            #[serde_as(as = "NumAsHex")]
+            pub version: &'a u64,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub signature: &'a Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub nonce: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub class_hash: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub sender_address: &'a FieldElement,
+        }
+
+        let tagged = Tagged {
+            transaction_hash: &self.transaction_hash,
+            r#type: "DECLARE",
+            max_fee: &self.max_fee,
+            version: &self.version,
+            signature: &self.signature,
+            nonce: &self.nonce,
+            class_hash: &self.class_hash,
+            sender_address: &self.sender_address,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for DeclareTransaction {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: FieldElement,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            #[serde_as(as = "UfeHex")]
+            pub max_fee: FieldElement,
+            #[serde_as(as = "NumAsHex")]
+            pub version: u64,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub signature: Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub nonce: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub class_hash: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub sender_address: FieldElement,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "DECLARE" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        Ok(Self {
+            transaction_hash: tagged.transaction_hash,
+            max_fee: tagged.max_fee,
+            version: tagged.version,
+            signature: tagged.signature,
+            nonce: tagged.nonce,
+            class_hash: tagged.class_hash,
+            sender_address: tagged.sender_address,
+        })
+    }
+}
+
+impl Serialize for BroadcastedDeclareTransaction {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            pub r#type: &'a str,
+            #[serde_as(as = "UfeHex")]
+            pub max_fee: &'a FieldElement,
+            #[serde_as(as = "NumAsHex")]
+            pub version: &'a u64,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub signature: &'a Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub nonce: &'a FieldElement,
+            pub contract_class: &'a ContractClass,
+            #[serde_as(as = "UfeHex")]
+            pub sender_address: &'a FieldElement,
+        }
+
+        let tagged = Tagged {
+            r#type: "DECLARE",
+            max_fee: &self.max_fee,
+            version: &self.version,
+            signature: &self.signature,
+            nonce: &self.nonce,
+            contract_class: &self.contract_class,
+            sender_address: &self.sender_address,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for BroadcastedDeclareTransaction {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            #[serde_as(as = "UfeHex")]
+            pub max_fee: FieldElement,
+            #[serde_as(as = "NumAsHex")]
+            pub version: u64,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub signature: Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub nonce: FieldElement,
+            pub contract_class: ContractClass,
+            #[serde_as(as = "UfeHex")]
+            pub sender_address: FieldElement,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "DECLARE" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        Ok(Self {
+            max_fee: tagged.max_fee,
+            version: tagged.version,
+            signature: tagged.signature,
+            nonce: tagged.nonce,
+            contract_class: tagged.contract_class,
+            sender_address: tagged.sender_address,
+        })
+    }
+}
+
+impl Serialize for DeployAccountTransaction {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: &'a FieldElement,
+            pub r#type: &'a str,
+            #[serde_as(as = "UfeHex")]
+            pub max_fee: &'a FieldElement,
+            #[serde_as(as = "NumAsHex")]
+            pub version: &'a u64,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub signature: &'a Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub nonce: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address_salt: &'a FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub constructor_calldata: &'a Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub class_hash: &'a FieldElement,
+        }
+
+        let tagged = Tagged {
+            transaction_hash: &self.transaction_hash,
+            r#type: "DEPLOY_ACCOUNT",
+            max_fee: &self.max_fee,
+            version: &self.version,
+            signature: &self.signature,
+            nonce: &self.nonce,
+            contract_address_salt: &self.contract_address_salt,
+            constructor_calldata: &self.constructor_calldata,
+            class_hash: &self.class_hash,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for DeployAccountTransaction {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: FieldElement,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            #[serde_as(as = "UfeHex")]
+            pub max_fee: FieldElement,
+            #[serde_as(as = "NumAsHex")]
+            pub version: u64,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub signature: Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub nonce: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address_salt: FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub constructor_calldata: Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub class_hash: FieldElement,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "DEPLOY_ACCOUNT" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        Ok(Self {
+            transaction_hash: tagged.transaction_hash,
+            max_fee: tagged.max_fee,
+            version: tagged.version,
+            signature: tagged.signature,
+            nonce: tagged.nonce,
+            contract_address_salt: tagged.contract_address_salt,
+            constructor_calldata: tagged.constructor_calldata,
+            class_hash: tagged.class_hash,
+        })
+    }
+}
+
+impl Serialize for BroadcastedDeployAccountTransaction {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            pub r#type: &'a str,
+            #[serde_as(as = "UfeHex")]
+            pub max_fee: &'a FieldElement,
+            #[serde_as(as = "NumAsHex")]
+            pub version: &'a u64,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub signature: &'a Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub nonce: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address_salt: &'a FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub constructor_calldata: &'a Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub class_hash: &'a FieldElement,
+        }
+
+        let tagged = Tagged {
+            r#type: "DEPLOY_ACCOUNT",
+            max_fee: &self.max_fee,
+            version: &self.version,
+            signature: &self.signature,
+            nonce: &self.nonce,
+            contract_address_salt: &self.contract_address_salt,
+            constructor_calldata: &self.constructor_calldata,
+            class_hash: &self.class_hash,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for BroadcastedDeployAccountTransaction {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            #[serde_as(as = "UfeHex")]
+            pub max_fee: FieldElement,
+            #[serde_as(as = "NumAsHex")]
+            pub version: u64,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub signature: Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub nonce: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address_salt: FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub constructor_calldata: Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub class_hash: FieldElement,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "DEPLOY_ACCOUNT" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        Ok(Self {
+            max_fee: tagged.max_fee,
+            version: tagged.version,
+            signature: tagged.signature,
+            nonce: tagged.nonce,
+            contract_address_salt: tagged.contract_address_salt,
+            constructor_calldata: tagged.constructor_calldata,
+            class_hash: tagged.class_hash,
+        })
+    }
+}
+
+impl Serialize for DeployTransaction {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub class_hash: &'a FieldElement,
+            #[serde_as(as = "NumAsHex")]
+            pub version: &'a u64,
+            pub r#type: &'a str,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address_salt: &'a FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub constructor_calldata: &'a Vec<FieldElement>,
+        }
+
+        let tagged = Tagged {
+            transaction_hash: &self.transaction_hash,
+            class_hash: &self.class_hash,
+            version: &self.version,
+            r#type: "DEPLOY",
+            contract_address_salt: &self.contract_address_salt,
+            constructor_calldata: &self.constructor_calldata,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for DeployTransaction {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub class_hash: FieldElement,
+            #[serde_as(as = "NumAsHex")]
+            pub version: u64,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address_salt: FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub constructor_calldata: Vec<FieldElement>,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "DEPLOY" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        Ok(Self {
+            transaction_hash: tagged.transaction_hash,
+            class_hash: tagged.class_hash,
+            version: tagged.version,
+            contract_address_salt: tagged.contract_address_salt,
+            constructor_calldata: tagged.constructor_calldata,
+        })
+    }
+}
+
+impl Serialize for BroadcastedDeployTransaction {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            pub contract_class: &'a ContractClass,
+            #[serde_as(as = "NumAsHex")]
+            pub version: &'a u64,
+            pub r#type: &'a str,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address_salt: &'a FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub constructor_calldata: &'a Vec<FieldElement>,
+        }
+
+        let tagged = Tagged {
+            contract_class: &self.contract_class,
+            version: &self.version,
+            r#type: "DEPLOY",
+            contract_address_salt: &self.contract_address_salt,
+            constructor_calldata: &self.constructor_calldata,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for BroadcastedDeployTransaction {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            pub contract_class: ContractClass,
+            #[serde_as(as = "NumAsHex")]
+            pub version: u64,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address_salt: FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub constructor_calldata: Vec<FieldElement>,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "DEPLOY" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        Ok(Self {
+            contract_class: tagged.contract_class,
+            version: tagged.version,
+            contract_address_salt: tagged.contract_address_salt,
+            constructor_calldata: tagged.constructor_calldata,
+        })
+    }
+}
+
+impl Serialize for InvokeTransactionV0 {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: &'a FieldElement,
+            pub r#type: &'a str,
+            #[serde_as(as = "UfeHex")]
+            pub max_fee: &'a FieldElement,
+            #[serde_as(as = "NumAsHex")]
+            pub version: &'a u64,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub signature: &'a Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub nonce: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub entry_point_selector: &'a FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub calldata: &'a Vec<FieldElement>,
+        }
+
+        let tagged = Tagged {
+            transaction_hash: &self.transaction_hash,
+            r#type: "INVOKE",
+            max_fee: &self.max_fee,
+            version: &0,
+            signature: &self.signature,
+            nonce: &self.nonce,
+            contract_address: &self.contract_address,
+            entry_point_selector: &self.entry_point_selector,
+            calldata: &self.calldata,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for InvokeTransactionV0 {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: FieldElement,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            #[serde_as(as = "UfeHex")]
+            pub max_fee: FieldElement,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            #[serde_as(as = "Option<NumAsHex>")]
+            pub version: Option<u64>,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub signature: Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub nonce: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub entry_point_selector: FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub calldata: Vec<FieldElement>,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "INVOKE" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        if let Some(tag_field) = &tagged.version {
+            if tag_field != &0 {
+                return Err(serde::de::Error::custom("Invalid `version` value"));
+            }
+        }
+
+        Ok(Self {
+            transaction_hash: tagged.transaction_hash,
+            max_fee: tagged.max_fee,
+            signature: tagged.signature,
+            nonce: tagged.nonce,
+            contract_address: tagged.contract_address,
+            entry_point_selector: tagged.entry_point_selector,
+            calldata: tagged.calldata,
+        })
+    }
+}
+
+impl Serialize for InvokeTransactionV1 {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: &'a FieldElement,
+            pub r#type: &'a str,
+            #[serde_as(as = "UfeHex")]
+            pub max_fee: &'a FieldElement,
+            #[serde_as(as = "NumAsHex")]
+            pub version: &'a u64,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub signature: &'a Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub nonce: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub sender_address: &'a FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub calldata: &'a Vec<FieldElement>,
+        }
+
+        let tagged = Tagged {
+            transaction_hash: &self.transaction_hash,
+            r#type: "INVOKE",
+            max_fee: &self.max_fee,
+            version: &1,
+            signature: &self.signature,
+            nonce: &self.nonce,
+            sender_address: &self.sender_address,
+            calldata: &self.calldata,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for InvokeTransactionV1 {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: FieldElement,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            #[serde_as(as = "UfeHex")]
+            pub max_fee: FieldElement,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            #[serde_as(as = "Option<NumAsHex>")]
+            pub version: Option<u64>,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub signature: Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub nonce: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub sender_address: FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub calldata: Vec<FieldElement>,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "INVOKE" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        if let Some(tag_field) = &tagged.version {
+            if tag_field != &1 {
+                return Err(serde::de::Error::custom("Invalid `version` value"));
+            }
+        }
+
+        Ok(Self {
+            transaction_hash: tagged.transaction_hash,
+            max_fee: tagged.max_fee,
+            signature: tagged.signature,
+            nonce: tagged.nonce,
+            sender_address: tagged.sender_address,
+            calldata: tagged.calldata,
+        })
+    }
+}
+
+impl Serialize for BroadcastedInvokeTransactionV0 {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            pub r#type: &'a str,
+            #[serde_as(as = "UfeHex")]
+            pub max_fee: &'a FieldElement,
+            #[serde_as(as = "NumAsHex")]
+            pub version: &'a u64,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub signature: &'a Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub nonce: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub entry_point_selector: &'a FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub calldata: &'a Vec<FieldElement>,
+        }
+
+        let tagged = Tagged {
+            r#type: "INVOKE",
+            max_fee: &self.max_fee,
+            version: &0,
+            signature: &self.signature,
+            nonce: &self.nonce,
+            contract_address: &self.contract_address,
+            entry_point_selector: &self.entry_point_selector,
+            calldata: &self.calldata,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for BroadcastedInvokeTransactionV0 {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            #[serde_as(as = "UfeHex")]
+            pub max_fee: FieldElement,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            #[serde_as(as = "Option<NumAsHex>")]
+            pub version: Option<u64>,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub signature: Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub nonce: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub entry_point_selector: FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub calldata: Vec<FieldElement>,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "INVOKE" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        if let Some(tag_field) = &tagged.version {
+            if tag_field != &0 {
+                return Err(serde::de::Error::custom("Invalid `version` value"));
+            }
+        }
+
+        Ok(Self {
+            max_fee: tagged.max_fee,
+            signature: tagged.signature,
+            nonce: tagged.nonce,
+            contract_address: tagged.contract_address,
+            entry_point_selector: tagged.entry_point_selector,
+            calldata: tagged.calldata,
+        })
+    }
+}
+
+impl Serialize for BroadcastedInvokeTransactionV1 {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            pub r#type: &'a str,
+            #[serde_as(as = "UfeHex")]
+            pub max_fee: &'a FieldElement,
+            #[serde_as(as = "NumAsHex")]
+            pub version: &'a u64,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub signature: &'a Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub nonce: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub sender_address: &'a FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub calldata: &'a Vec<FieldElement>,
+        }
+
+        let tagged = Tagged {
+            r#type: "INVOKE",
+            max_fee: &self.max_fee,
+            version: &1,
+            signature: &self.signature,
+            nonce: &self.nonce,
+            sender_address: &self.sender_address,
+            calldata: &self.calldata,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for BroadcastedInvokeTransactionV1 {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            #[serde_as(as = "UfeHex")]
+            pub max_fee: FieldElement,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            #[serde_as(as = "Option<NumAsHex>")]
+            pub version: Option<u64>,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub signature: Vec<FieldElement>,
+            #[serde_as(as = "UfeHex")]
+            pub nonce: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub sender_address: FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub calldata: Vec<FieldElement>,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "INVOKE" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        if let Some(tag_field) = &tagged.version {
+            if tag_field != &1 {
+                return Err(serde::de::Error::custom("Invalid `version` value"));
+            }
+        }
+
+        Ok(Self {
+            max_fee: tagged.max_fee,
+            signature: tagged.signature,
+            nonce: tagged.nonce,
+            sender_address: tagged.sender_address,
+            calldata: tagged.calldata,
+        })
+    }
+}
+
+impl Serialize for L1HandlerTransaction {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: &'a FieldElement,
+            #[serde_as(as = "NumAsHex")]
+            pub version: &'a u64,
+            pub r#type: &'a str,
+            #[serde_as(as = "NumAsHex")]
+            pub nonce: &'a u64,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub entry_point_selector: &'a FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub calldata: &'a Vec<FieldElement>,
+        }
+
+        let tagged = Tagged {
+            transaction_hash: &self.transaction_hash,
+            version: &self.version,
+            r#type: "L1_HANDLER",
+            nonce: &self.nonce,
+            contract_address: &self.contract_address,
+            entry_point_selector: &self.entry_point_selector,
+            calldata: &self.calldata,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for L1HandlerTransaction {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: FieldElement,
+            #[serde_as(as = "NumAsHex")]
+            pub version: u64,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            #[serde_as(as = "NumAsHex")]
+            pub nonce: u64,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub entry_point_selector: FieldElement,
+            #[serde_as(as = "Vec<UfeHex>")]
+            pub calldata: Vec<FieldElement>,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "L1_HANDLER" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        Ok(Self {
+            transaction_hash: tagged.transaction_hash,
+            version: tagged.version,
+            nonce: tagged.nonce,
+            contract_address: tagged.contract_address,
+            entry_point_selector: tagged.entry_point_selector,
+            calldata: tagged.calldata,
+        })
+    }
+}
+
+impl Serialize for InvokeTransactionReceipt {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: &'a FieldElement,
+            pub status: &'a TransactionStatus,
+            #[serde_as(as = "UfeHex")]
+            pub block_hash: &'a FieldElement,
+            pub block_number: &'a u64,
+            pub r#type: &'a str,
+            pub messages_sent: &'a Vec<MsgToL1>,
+            pub events: &'a Vec<Event>,
+        }
+
+        let tagged = Tagged {
+            transaction_hash: &self.transaction_hash,
+            actual_fee: &self.actual_fee,
+            status: &self.status,
+            block_hash: &self.block_hash,
+            block_number: &self.block_number,
+            r#type: "INVOKE",
+            messages_sent: &self.messages_sent,
+            events: &self.events,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for InvokeTransactionReceipt {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: FieldElement,
+            pub status: TransactionStatus,
+            #[serde_as(as = "UfeHex")]
+            pub block_hash: FieldElement,
+            pub block_number: u64,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            pub messages_sent: Vec<MsgToL1>,
+            pub events: Vec<Event>,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "INVOKE" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        Ok(Self {
+            transaction_hash: tagged.transaction_hash,
+            actual_fee: tagged.actual_fee,
+            status: tagged.status,
+            block_hash: tagged.block_hash,
+            block_number: tagged.block_number,
+            messages_sent: tagged.messages_sent,
+            events: tagged.events,
+        })
+    }
+}
+
+impl Serialize for DeclareTransactionReceipt {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: &'a FieldElement,
+            pub status: &'a TransactionStatus,
+            #[serde_as(as = "UfeHex")]
+            pub block_hash: &'a FieldElement,
+            pub block_number: &'a u64,
+            pub r#type: &'a str,
+            pub messages_sent: &'a Vec<MsgToL1>,
+            pub events: &'a Vec<Event>,
+        }
+
+        let tagged = Tagged {
+            transaction_hash: &self.transaction_hash,
+            actual_fee: &self.actual_fee,
+            status: &self.status,
+            block_hash: &self.block_hash,
+            block_number: &self.block_number,
+            r#type: "DECLARE",
+            messages_sent: &self.messages_sent,
+            events: &self.events,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for DeclareTransactionReceipt {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: FieldElement,
+            pub status: TransactionStatus,
+            #[serde_as(as = "UfeHex")]
+            pub block_hash: FieldElement,
+            pub block_number: u64,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            pub messages_sent: Vec<MsgToL1>,
+            pub events: Vec<Event>,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "DECLARE" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        Ok(Self {
+            transaction_hash: tagged.transaction_hash,
+            actual_fee: tagged.actual_fee,
+            status: tagged.status,
+            block_hash: tagged.block_hash,
+            block_number: tagged.block_number,
+            messages_sent: tagged.messages_sent,
+            events: tagged.events,
+        })
+    }
+}
+
+impl Serialize for DeployAccountTransactionReceipt {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: &'a FieldElement,
+            pub status: &'a TransactionStatus,
+            #[serde_as(as = "UfeHex")]
+            pub block_hash: &'a FieldElement,
+            pub block_number: &'a u64,
+            pub r#type: &'a str,
+            pub messages_sent: &'a Vec<MsgToL1>,
+            pub events: &'a Vec<Event>,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address: &'a FieldElement,
+        }
+
+        let tagged = Tagged {
+            transaction_hash: &self.transaction_hash,
+            actual_fee: &self.actual_fee,
+            status: &self.status,
+            block_hash: &self.block_hash,
+            block_number: &self.block_number,
+            r#type: "DEPLOY_ACCOUNT",
+            messages_sent: &self.messages_sent,
+            events: &self.events,
+            contract_address: &self.contract_address,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for DeployAccountTransactionReceipt {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: FieldElement,
+            pub status: TransactionStatus,
+            #[serde_as(as = "UfeHex")]
+            pub block_hash: FieldElement,
+            pub block_number: u64,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            pub messages_sent: Vec<MsgToL1>,
+            pub events: Vec<Event>,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address: FieldElement,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "DEPLOY_ACCOUNT" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        Ok(Self {
+            transaction_hash: tagged.transaction_hash,
+            actual_fee: tagged.actual_fee,
+            status: tagged.status,
+            block_hash: tagged.block_hash,
+            block_number: tagged.block_number,
+            messages_sent: tagged.messages_sent,
+            events: tagged.events,
+            contract_address: tagged.contract_address,
+        })
+    }
+}
+
+impl Serialize for DeployTransactionReceipt {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: &'a FieldElement,
+            pub status: &'a TransactionStatus,
+            #[serde_as(as = "UfeHex")]
+            pub block_hash: &'a FieldElement,
+            pub block_number: &'a u64,
+            pub r#type: &'a str,
+            pub messages_sent: &'a Vec<MsgToL1>,
+            pub events: &'a Vec<Event>,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address: &'a FieldElement,
+        }
+
+        let tagged = Tagged {
+            transaction_hash: &self.transaction_hash,
+            actual_fee: &self.actual_fee,
+            status: &self.status,
+            block_hash: &self.block_hash,
+            block_number: &self.block_number,
+            r#type: "DEPLOY",
+            messages_sent: &self.messages_sent,
+            events: &self.events,
+            contract_address: &self.contract_address,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for DeployTransactionReceipt {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: FieldElement,
+            pub status: TransactionStatus,
+            #[serde_as(as = "UfeHex")]
+            pub block_hash: FieldElement,
+            pub block_number: u64,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            pub messages_sent: Vec<MsgToL1>,
+            pub events: Vec<Event>,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address: FieldElement,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "DEPLOY" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        Ok(Self {
+            transaction_hash: tagged.transaction_hash,
+            actual_fee: tagged.actual_fee,
+            status: tagged.status,
+            block_hash: tagged.block_hash,
+            block_number: tagged.block_number,
+            messages_sent: tagged.messages_sent,
+            events: tagged.events,
+            contract_address: tagged.contract_address,
+        })
+    }
+}
+
+impl Serialize for L1HandlerTransactionReceipt {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: &'a FieldElement,
+            pub status: &'a TransactionStatus,
+            #[serde_as(as = "UfeHex")]
+            pub block_hash: &'a FieldElement,
+            pub block_number: &'a u64,
+            pub r#type: &'a str,
+            pub messages_sent: &'a Vec<MsgToL1>,
+            pub events: &'a Vec<Event>,
+        }
+
+        let tagged = Tagged {
+            transaction_hash: &self.transaction_hash,
+            actual_fee: &self.actual_fee,
+            status: &self.status,
+            block_hash: &self.block_hash,
+            block_number: &self.block_number,
+            r#type: "L1_HANDLER",
+            messages_sent: &self.messages_sent,
+            events: &self.events,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for L1HandlerTransactionReceipt {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: FieldElement,
+            pub status: TransactionStatus,
+            #[serde_as(as = "UfeHex")]
+            pub block_hash: FieldElement,
+            pub block_number: u64,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            pub messages_sent: Vec<MsgToL1>,
+            pub events: Vec<Event>,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "L1_HANDLER" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        Ok(Self {
+            transaction_hash: tagged.transaction_hash,
+            actual_fee: tagged.actual_fee,
+            status: tagged.status,
+            block_hash: tagged.block_hash,
+            block_number: tagged.block_number,
+            messages_sent: tagged.messages_sent,
+            events: tagged.events,
+        })
+    }
+}
+
+impl Serialize for PendingInvokeTransactionReceipt {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: &'a FieldElement,
+            pub r#type: &'a str,
+            pub messages_sent: &'a Vec<MsgToL1>,
+            pub events: &'a Vec<Event>,
+        }
+
+        let tagged = Tagged {
+            transaction_hash: &self.transaction_hash,
+            actual_fee: &self.actual_fee,
+            r#type: "INVOKE",
+            messages_sent: &self.messages_sent,
+            events: &self.events,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for PendingInvokeTransactionReceipt {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: FieldElement,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            pub messages_sent: Vec<MsgToL1>,
+            pub events: Vec<Event>,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "INVOKE" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        Ok(Self {
+            transaction_hash: tagged.transaction_hash,
+            actual_fee: tagged.actual_fee,
+            messages_sent: tagged.messages_sent,
+            events: tagged.events,
+        })
+    }
+}
+
+impl Serialize for PendingDeclareTransactionReceipt {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: &'a FieldElement,
+            pub r#type: &'a str,
+            pub messages_sent: &'a Vec<MsgToL1>,
+            pub events: &'a Vec<Event>,
+        }
+
+        let tagged = Tagged {
+            transaction_hash: &self.transaction_hash,
+            actual_fee: &self.actual_fee,
+            r#type: "DECLARE",
+            messages_sent: &self.messages_sent,
+            events: &self.events,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for PendingDeclareTransactionReceipt {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: FieldElement,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            pub messages_sent: Vec<MsgToL1>,
+            pub events: Vec<Event>,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "DECLARE" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        Ok(Self {
+            transaction_hash: tagged.transaction_hash,
+            actual_fee: tagged.actual_fee,
+            messages_sent: tagged.messages_sent,
+            events: tagged.events,
+        })
+    }
+}
+
+impl Serialize for PendingDeployAccountTransactionReceipt {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: &'a FieldElement,
+            pub r#type: &'a str,
+            pub messages_sent: &'a Vec<MsgToL1>,
+            pub events: &'a Vec<Event>,
+        }
+
+        let tagged = Tagged {
+            transaction_hash: &self.transaction_hash,
+            actual_fee: &self.actual_fee,
+            r#type: "DEPLOY_ACCOUNT",
+            messages_sent: &self.messages_sent,
+            events: &self.events,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for PendingDeployAccountTransactionReceipt {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: FieldElement,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            pub messages_sent: Vec<MsgToL1>,
+            pub events: Vec<Event>,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "DEPLOY_ACCOUNT" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        Ok(Self {
+            transaction_hash: tagged.transaction_hash,
+            actual_fee: tagged.actual_fee,
+            messages_sent: tagged.messages_sent,
+            events: tagged.events,
+        })
+    }
+}
+
+impl Serialize for PendingDeployTransactionReceipt {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: &'a FieldElement,
+            pub r#type: &'a str,
+            pub messages_sent: &'a Vec<MsgToL1>,
+            pub events: &'a Vec<Event>,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address: &'a FieldElement,
+        }
+
+        let tagged = Tagged {
+            transaction_hash: &self.transaction_hash,
+            actual_fee: &self.actual_fee,
+            r#type: "DEPLOY",
+            messages_sent: &self.messages_sent,
+            events: &self.events,
+            contract_address: &self.contract_address,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for PendingDeployTransactionReceipt {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: FieldElement,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            pub messages_sent: Vec<MsgToL1>,
+            pub events: Vec<Event>,
+            #[serde_as(as = "UfeHex")]
+            pub contract_address: FieldElement,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "DEPLOY" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        Ok(Self {
+            transaction_hash: tagged.transaction_hash,
+            actual_fee: tagged.actual_fee,
+            messages_sent: tagged.messages_sent,
+            events: tagged.events,
+            contract_address: tagged.contract_address,
+        })
+    }
+}
+
+impl Serialize for PendingL1HandlerTransactionReceipt {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct Tagged<'a> {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: &'a FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: &'a FieldElement,
+            pub r#type: &'a str,
+            pub messages_sent: &'a Vec<MsgToL1>,
+            pub events: &'a Vec<Event>,
+        }
+
+        let tagged = Tagged {
+            transaction_hash: &self.transaction_hash,
+            actual_fee: &self.actual_fee,
+            r#type: "L1_HANDLER",
+            messages_sent: &self.messages_sent,
+            events: &self.events,
+        };
+
+        Tagged::serialize(&tagged, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for PendingL1HandlerTransactionReceipt {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Tagged {
+            #[serde_as(as = "UfeHex")]
+            pub transaction_hash: FieldElement,
+            #[serde_as(as = "UfeHex")]
+            pub actual_fee: FieldElement,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub r#type: Option<String>,
+            pub messages_sent: Vec<MsgToL1>,
+            pub events: Vec<Event>,
+        }
+
+        let tagged = Tagged::deserialize(deserializer)?;
+
+        if let Some(tag_field) = &tagged.r#type {
+            if tag_field != "L1_HANDLER" {
+                return Err(serde::de::Error::custom("Invalid `type` value"));
+            }
+        }
+
+        Ok(Self {
+            transaction_hash: tagged.transaction_hash,
+            actual_fee: tagged.actual_fee,
+            messages_sent: tagged.messages_sent,
+            events: tagged.events,
+        })
+    }
+}

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -1,15 +1,13 @@
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use starknet_core::{
-    serde::{byte_array::base64, unsigned_field_element::UfeHex},
-    types::FieldElement,
-};
+use starknet_core::{serde::unsigned_field_element::UfeHex, types::FieldElement};
 
 pub use starknet_core::types::L1Address as EthAddress;
 
-// Not exposed by design
 mod serde_impls;
-use serde_impls::NumAsHex;
+
+mod codegen;
+pub use codegen::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -32,78 +30,12 @@ pub enum MaybePendingTransactionReceipt {
     PendingReceipt(PendingTransactionReceipt),
 }
 
-/// An event emitted as a result of transaction execution
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EmittedEvent {
-    /// The hash of the block in which the event was emitted
+pub struct BlockHashAndNumber {
     #[serde_as(as = "UfeHex")]
     pub block_hash: FieldElement,
-    /// The number of the block in which the event was emitted
     pub block_number: u64,
-    /// The transaction that emitted the event
-    #[serde_as(as = "UfeHex")]
-    pub transaction_hash: FieldElement,
-    /// The event information
-    #[serde(flatten)]
-    pub event: Event,
-}
-
-/// A StarkNet event
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Event {
-    #[serde_as(as = "UfeHex")]
-    pub from_address: FieldElement,
-    #[serde(flatten)]
-    pub content: EventContent,
-}
-
-/// The content of an event
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EventContent {
-    #[serde_as(as = "Vec<UfeHex>")]
-    pub keys: Vec<FieldElement>,
-    #[serde_as(as = "Vec<UfeHex>")]
-    pub data: Vec<FieldElement>,
-}
-
-/// An event filter/query
-#[serde_as]
-#[derive(Debug, Clone, Default, Serialize)]
-pub struct EventFilter {
-    // Using `fromBlock` instead of `from_block` for now due to pathfinder bug:
-    //   https://github.com/eqlabs/pathfinder/issues/536
-    #[serde(rename = "fromBlock", skip_serializing_if = "Option::is_none")]
-    pub from_block: Option<BlockId>,
-    // Using `toBlock` instead of `to_block` for now due to pathfinder bug:
-    //   https://github.com/eqlabs/pathfinder/issues/536
-    #[serde(rename = "toBlock", skip_serializing_if = "Option::is_none")]
-    pub to_block: Option<BlockId>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[serde_as(as = "Option<UfeHex>")]
-    pub address: Option<FieldElement>,
-    /// The values used to filter the events
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[serde_as(as = "Option<Vec<UfeHex>>")]
-    pub keys: Option<Vec<FieldElement>>,
-}
-
-/// Block hash, number or tag
-#[derive(Debug, Clone)]
-pub enum BlockId {
-    Hash(FieldElement),
-    Number(u64),
-    Tag(BlockTag),
-}
-
-/// A tag specifying a dynamic reference to a block
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum BlockTag {
-    Latest,
-    Pending,
 }
 
 #[derive(Debug, Clone)]
@@ -112,483 +44,13 @@ pub enum SyncStatusType {
     NotSyncing,
 }
 
-/// An object describing the node synchronization status
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SyncStatus {
-    /// The hash of the block from which the sync started
-    #[serde_as(as = "UfeHex")]
-    pub starting_block_hash: FieldElement,
-    /// The number (height) of the block from which the sync started
-    #[serde_as(as = "NumAsHex")]
-    pub starting_block_num: u64,
-    /// The hash of the current block being synchronized
-    #[serde_as(as = "UfeHex")]
-    pub current_block_hash: FieldElement,
-    /// The number (height) of the current block being synchronized
-    #[serde_as(as = "NumAsHex")]
-    pub current_block_num: u64,
-    /// The hash of the estimated highest block to be synchronized
-    #[serde_as(as = "UfeHex")]
-    pub highest_block_hash: FieldElement,
-    /// The number (height) of the estimated highest block to be synchronized
-    #[serde_as(as = "NumAsHex")]
-    pub highest_block_num: u64,
-}
-
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StateUpdate {
-    #[serde_as(as = "UfeHex")]
-    pub block_hash: FieldElement,
-    /// The new global state root
-    #[serde_as(as = "UfeHex")]
-    pub new_root: FieldElement,
-    /// The previous global state root
-    #[serde_as(as = "UfeHex")]
-    pub old_root: FieldElement,
-    /// The change in state applied in this block, given as a mapping of addresses to the new values
-    /// and/or new contracts
-    pub state_diff: StateDiff,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StateDiff {
-    pub storage_diffs: Vec<StorageDiffItem>,
-    pub declared_contracts: Vec<DeclaredContractItem>,
-    pub deployed_contracts: Vec<DeployedContractItem>,
-    pub nonces: Vec<NonceUpdate>,
-}
-
-/// The updated nonce per contract address
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NonceUpdate {
-    /// The address of the contract
-    #[serde_as(as = "UfeHex")]
-    pub contract_address: FieldElement,
-    /// The nonce for the given address at the end of the block
-    #[serde_as(as = "UfeHex")]
-    pub nonce: FieldElement,
-}
-
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlockHeader {
-    #[serde_as(as = "UfeHex")]
-    pub block_hash: FieldElement,
-    /// The hash of this block's parent
-    #[serde_as(as = "UfeHex")]
-    pub parent_hash: FieldElement,
-    /// The block number (its height)
-    pub block_number: u64,
-    /// The new global state root
-    #[serde_as(as = "UfeHex")]
-    pub new_root: FieldElement,
-    /// The time in which the block was created, encoded in Unix time
-    pub timestamp: u64,
-    /// The StarkNet identity of the sequencer submitting this block
-    #[serde_as(as = "UfeHex")]
-    pub sequencer_address: FieldElement,
-}
-
-/// The block object
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlockWithTxHashes {
-    pub status: BlockStatus,
-    #[serde(flatten)]
-    pub header: BlockHeader,
-    /// The hashes of the transactions included in this block
-    #[serde_as(as = "Vec<UfeHex>")]
-    pub transactions: Vec<FieldElement>,
-}
-
-/// The block object
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlockWithTxs {
-    pub status: BlockStatus,
-    #[serde(flatten)]
-    pub header: BlockHeader,
-    /// The transactions in this block
-    pub transactions: Vec<Transaction>,
-}
-
-/// The dynamic block being constructed by the sequencer. Note that this object will be deprecated
-/// upon decentralization.
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PendingBlockWithTxHashes {
-    /// The hashes of the transactions included in this block
-    #[serde_as(as = "Vec<UfeHex>")]
-    pub transactions: Vec<FieldElement>,
-    /// The time in which the block was created, encoded in Unix time
-    pub timestamp: u64,
-    /// The StarkNet identity of the sequencer submitting this block
-    #[serde_as(as = "UfeHex")]
-    pub sequencer_address: FieldElement,
-    /// The hash of this block's parent
-    #[serde_as(as = "UfeHex")]
-    pub parent_hash: FieldElement,
-}
-
-/// The dynamic block being constructed by the sequencer. Note that this object will be deprecated
-/// upon decentralization.
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PendingBlockWithTxs {
-    /// The transactions in this block
-    pub transactions: Vec<Transaction>,
-    /// The time in which the block was created, encoded in Unix time
-    pub timestamp: u64,
-    /// The StarkNet identity of the sequencer submitting this block
-    #[serde_as(as = "UfeHex")]
-    pub sequencer_address: FieldElement,
-    /// The hash of this block's parent
-    #[serde_as(as = "UfeHex")]
-    pub parent_hash: FieldElement,
-}
-
-/// A new contract declared as part of the new state
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DeclaredContractItem {
-    /// The hash of the contract code
-    #[serde_as(as = "UfeHex")]
-    pub class_hash: FieldElement,
-}
-
-/// A new contract deployed as part of the new state
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DeployedContractItem {
-    /// The address of the contract
-    #[serde_as(as = "UfeHex")]
-    pub address: FieldElement,
-    /// The hash of the contract code
-    #[serde_as(as = "UfeHex")]
-    pub class_hash: FieldElement,
-}
-
-/// A change in a single storage item
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StorageDiffItem {
-    /// The contract address for which the state changed
-    #[serde_as(as = "UfeHex")]
-    pub address: FieldElement,
-    /// The key of the changed value
-    #[serde_as(as = "UfeHex")]
-    pub key: FieldElement,
-    /// The new value applied to the given address
-    #[serde_as(as = "UfeHex")]
-    pub value: FieldElement,
-}
-
-/// Transaction (`TXN`)
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum Transaction {
-    Invoke(InvokeTransaction),
-    Declare(DeclareTransaction),
-    Deploy(DeployTransaction),
-    L1Handler(L1HandlerTransaction),
-}
-
-/// The `COMMON_TXN_PROPERTIES` type in the specification
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TransactionMeta {
-    /// The hash identifying the transaction
-    #[serde_as(as = "UfeHex")]
-    pub transaction_hash: FieldElement,
-    /// The maximal fee that can be charged for including the transaction
-    #[serde_as(as = "UfeHex")]
-    pub max_fee: FieldElement,
-    /// Version of the transaction scheme
-    #[serde_as(as = "NumAsHex")]
-    pub version: u64,
-    #[serde_as(as = "Vec<UfeHex>")]
-    pub signature: Vec<FieldElement>,
-    #[serde_as(as = "UfeHex")]
-    pub nonce: FieldElement,
-}
-
-/// A call to an l1_handler on an L2 contract induced by a message from L1
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct L1HandlerTransaction {
-    /// The hash identifying the transaction
-    #[serde_as(as = "UfeHex")]
-    pub transaction_hash: FieldElement,
-    /// Version of the transaction scheme
-    #[serde_as(as = "NumAsHex")]
-    pub version: u64,
-    /// The L1->L2 message nonce field of the SN Core L1 contract at the time the transaction was
-    /// sent
-    #[serde_as(as = "NumAsHex")]
-    pub nonce: u64,
-    #[serde(flatten)]
-    pub function_call: FunctionCall,
-}
-
-/// Declare Contract Transaction (`DECLARE_TXN`)
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DeclareTransaction {
-    #[serde(flatten)]
-    pub meta: TransactionMeta,
-    /// The hash of the declared class
-    #[serde_as(as = "UfeHex")]
-    pub class_hash: FieldElement,
-    /// The address of the account contract sending the declaration transaction
-    #[serde_as(as = "UfeHex")]
-    pub sender_address: FieldElement,
-}
-
-/// Deploy Contract Transaction (`DEPLOY_TXN`)
-///
-/// The structure of a deploy transaction. Note that this transaction type is deprecated and will no
-/// longer be supported in future versions.
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DeployTransaction {
-    /// The hash identifying the transaction
-    #[serde_as(as = "UfeHex")]
-    pub transaction_hash: FieldElement,
-    /// The hash of the deployed contract's class
-    #[serde_as(as = "UfeHex")]
-    pub class_hash: FieldElement,
-    /// Version of the transaction scheme
-    #[serde_as(as = "NumAsHex")]
-    pub version: u64,
-    /// The address of the deployed contract
-    #[serde_as(as = "UfeHex")]
-    pub contract_address: FieldElement,
-    /// The salt for the address of the deployed contract
-    #[serde_as(as = "UfeHex")]
-    pub contract_address_salt: FieldElement,
-    /// The parameters passed to the constructor
-    #[serde_as(as = "Vec<UfeHex>")]
-    pub constructor_calldata: Vec<FieldElement>,
-}
-
-/// Invoke Contract Transaction (`INVOKE_TXN`)
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct InvokeTransaction {
-    #[serde(flatten)]
-    pub meta: TransactionMeta,
-    /// The function the transaction invokes
-    #[serde(flatten)]
-    pub function_call: FunctionCall,
-}
-
-/// Common properties for a transaction receipt (`COMMON_TXN_PROPERTIES`)
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TransactionReceiptMeta {
-    /// The hash identifying the transaction
-    #[serde_as(as = "UfeHex")]
-    pub transaction_hash: FieldElement,
-    /// The fee that was charged by the sequencer
-    #[serde_as(as = "UfeHex")]
-    pub actual_fee: FieldElement,
-    pub status: TransactionStatus,
-    /// Extra information pertaining to the status
-    pub status_data: Option<String>,
-    #[serde_as(as = "UfeHex")]
-    pub block_hash: FieldElement,
-    pub block_number: u64,
-}
-
-/// Properties specific to invoke transaction (`INVOKE_TXN_RECEIPT_PROPERTIES`)
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct InvokeTransactionReceiptData {
-    pub messages_sent: Vec<MsgToL1>,
-    /// In case this transaction was an L1 handler, this is the original message that invoked it
-    pub l1_origin_message: Option<MsgToL2>,
-    /// The events emitted as part of this transaction
-    pub events: Vec<Event>,
-}
-
-/// Invoke transaction receipt
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct InvokeTransactionReceipt {
-    #[serde(flatten)]
-    pub meta: TransactionReceiptMeta,
-    #[serde(flatten)]
-    pub data: InvokeTransactionReceiptData,
-}
-
-/// A special type that covers both `DECLARE_TXN_RECEIPT` and `DEPLOY_TXN_RECEIPT` in the spec.
-/// This type exists because there's no way to distinguish between the 2 underlying types over the
-/// wire. The issue will be fixed in spec v0.2.0, upon which this type shall be removed.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DeclareOrDeployTransactionReceipt {
-    #[serde(flatten)]
-    pub meta: TransactionReceiptMeta,
-}
-
-/// The `TXN_RECEIPT` type in the specification, except without the `PENDING_TXN_RECEIPT` variant.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum TransactionReceipt {
-    Invoke(InvokeTransactionReceipt),
-    DeclareOrDeploy(DeclareOrDeployTransactionReceipt),
-}
-
-/// Common properties for a pending transaction receipt (`PENDING_COMMON_RECEIPT_PROPERTIES`)
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PendingTransactionReceiptMeta {
-    /// The hash identifying the transaction
-    #[serde_as(as = "UfeHex")]
-    pub transaction_hash: FieldElement,
-    /// The fee that was charged by the sequencer
-    #[serde_as(as = "UfeHex")]
-    pub actual_fee: FieldElement,
-}
-
-/// Pending invoke transaction receipt
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PendingInvokeTransactionReceipt {
-    #[serde(flatten)]
-    pub meta: PendingTransactionReceiptMeta,
-    #[serde(flatten)]
-    pub data: InvokeTransactionReceiptData,
-}
-
-/// Used for deploy and declare transaction receipts
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PendingDeclareOrDeployTransactionReceipt {
-    #[serde(flatten)]
-    pub meta: PendingTransactionReceiptMeta,
-}
-
-/// The `PENDING_TXN_RECEIPT` type in the specification
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum PendingTransactionReceipt {
-    Invoke(PendingInvokeTransactionReceipt),
-    DeclareOrDeploy(PendingDeclareOrDeployTransactionReceipt),
-}
-
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MsgToL1 {
-    /// The target L1 address the message is sent to
-    #[serde_as(as = "UfeHex")]
-    pub to_address: FieldElement,
-    /// The payload of the message
-    #[serde_as(as = "Vec<UfeHex>")]
-    pub payload: Vec<FieldElement>,
-}
-
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MsgToL2 {
-    /// The originating L1 contract that sent the message
-    pub from_address: EthAddress,
-    /// The payload of the meesage. The call data to the L1 handler
-    #[serde_as(as = "Vec<UfeHex>")]
-    pub payload: Vec<FieldElement>,
-}
-
-/// The status of the transaction. May be unknown in case node is not aware of it
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum TransactionStatus {
-    Pending,
-    AcceptedOnL2,
-    AcceptedOnL1,
-    Rejected,
-}
-
-/// The status of the block
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum BlockStatus {
-    Pending,
-    AcceptedOnL2,
-    AcceptedOnL1,
-    Rejected,
-}
-
-/// Function call information
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FunctionCall {
-    #[serde_as(as = "UfeHex")]
-    pub contract_address: FieldElement,
-    #[serde_as(as = "UfeHex")]
-    pub entry_point_selector: FieldElement,
-    /// The parameters passed to the function
-    #[serde_as(as = "Vec<UfeHex>")]
-    pub calldata: Vec<FieldElement>,
-}
-
-/// The definition of a StarkNet contract class
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ContractClass {
-    /// A base64 representation of the compressed program code
-    #[serde(with = "base64")]
-    pub program: Vec<u8>,
-    pub entry_points_by_type: EntryPointsByType,
-}
-
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub struct EntryPointsByType {
-    pub constructor: Vec<ContractEntryPoint>,
-    pub external: Vec<ContractEntryPoint>,
-    pub l1_handler: Vec<ContractEntryPoint>,
-}
-
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ContractEntryPoint {
-    /// The offset of the entry point in the program
-    #[serde_as(as = "NumAsHex")]
-    pub offset: u64,
-    /// A unique identifier of the entry point (function) in the program
-    #[serde_as(as = "UfeHex")]
-    pub selector: FieldElement,
-}
-
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FeeEstimate {
-    /// The Ethereum gas cost of the transaction
-    /// (see https://docs.starknet.io/docs/Fees/fee-mechanism for more info)
-    #[serde_as(as = "UfeHex")]
-    pub gas_consumed: FieldElement,
-    /// The gas price (in gwei) that was used in the cost estimation
-    #[serde_as(as = "UfeHex")]
-    pub gas_price: FieldElement,
-    /// The estimated fee for the transaction (in gwei), product of gas_consumed and gas_price
-    #[serde_as(as = "UfeHex")]
-    pub overall_fee: FieldElement,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EventsPage {
     /// Matching events
     pub events: Vec<EmittedEvent>,
-    /// The returned page number
-    pub page_number: u64,
-    /// A flag indicating whether this is the end of the stream of events
-    pub is_last_page: bool,
-}
-
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlockHashAndNumber {
-    #[serde_as(as = "UfeHex")]
-    pub block_hash: FieldElement,
-    pub block_number: u64,
+    /// A pointer to the last element of the delivered page, use this token in a subsequent query to
+    /// obtain the next page
+    pub continuation_token: Option<String>,
 }
 
 #[serde_as]
@@ -621,6 +83,109 @@ pub struct DeployTransactionResult {
     pub contract_address: FieldElement,
 }
 
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeployAccountTransactionResult {
+    /// The hash of the deploy transaction
+    #[serde_as(as = "UfeHex")]
+    pub transaction_hash: FieldElement,
+    /// The address of the new contract
+    #[serde_as(as = "UfeHex")]
+    pub contract_address: FieldElement,
+}
+
+/// Block hash, number or tag
+#[derive(Debug, Clone)]
+pub enum BlockId {
+    Hash(FieldElement),
+    Number(u64),
+    Tag(BlockTag),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum Transaction {
+    #[serde(rename = "INVOKE")]
+    Invoke(InvokeTransaction),
+    #[serde(rename = "L1_HANDLER")]
+    L1Handler(L1HandlerTransaction),
+    #[serde(rename = "DECLARE")]
+    Declare(DeclareTransaction),
+    #[serde(rename = "DEPLOY")]
+    Deploy(DeployTransaction),
+    #[serde(rename = "DEPLOY_ACCOUNT")]
+    DeployAccount(DeployAccountTransaction),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum BroadcastedTransaction {
+    #[serde(rename = "INVOKE")]
+    Invoke(BroadcastedInvokeTransaction),
+    #[serde(rename = "DECLARE")]
+    Declare(BroadcastedDeclareTransaction),
+    #[serde(rename = "DEPLOY")]
+    Deploy(BroadcastedDeployTransaction),
+    #[serde(rename = "DEPLOY_ACCOUNT")]
+    DeployAccount(BroadcastedDeployAccountTransaction),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "version")]
+pub enum InvokeTransaction {
+    #[serde(rename = "0x0")]
+    V0(InvokeTransactionV0),
+    #[serde(rename = "0x1")]
+    V1(InvokeTransactionV1),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "version")]
+pub enum BroadcastedInvokeTransaction {
+    #[serde(rename = "0x0")]
+    V0(BroadcastedInvokeTransactionV0),
+    #[serde(rename = "0x1")]
+    V1(BroadcastedInvokeTransactionV1),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum TransactionReceipt {
+    #[serde(rename = "INVOKE")]
+    Invoke(InvokeTransactionReceipt),
+    #[serde(rename = "L1_HANDLER")]
+    L1Handler(L1HandlerTransactionReceipt),
+    #[serde(rename = "DECLARE")]
+    Declare(DeclareTransactionReceipt),
+    #[serde(rename = "DEPLOY")]
+    Deploy(DeployTransactionReceipt),
+    #[serde(rename = "DEPLOY_ACCOUNT")]
+    DeployAccount(DeployAccountTransactionReceipt),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum PendingTransactionReceipt {
+    #[serde(rename = "INVOKE")]
+    Invoke(PendingInvokeTransactionReceipt),
+    #[serde(rename = "L1_HANDLER")]
+    L1Handler(PendingL1HandlerTransactionReceipt),
+    #[serde(rename = "DECLARE")]
+    Declare(PendingDeclareTransactionReceipt),
+    #[serde(rename = "DEPLOY")]
+    Deploy(PendingDeployTransactionReceipt),
+    #[serde(rename = "DEPLOY_ACCOUNT")]
+    DeployAccount(PendingDeployAccountTransactionReceipt),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ContractAbiEntry {
+    Function(FunctionAbiEntry),
+    Event(EventAbiEntry),
+    Struct(StructAbiEntry),
+}
+
 impl Serialize for BlockId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -650,9 +215,14 @@ impl Serialize for BlockId {
         }
     }
 }
-
 impl AsRef<FunctionCall> for FunctionCall {
     fn as_ref(&self) -> &FunctionCall {
+        self
+    }
+}
+
+impl AsRef<BroadcastedTransaction> for BroadcastedTransaction {
+    fn as_ref(&self) -> &BroadcastedTransaction {
         self
     }
 }


### PR DESCRIPTION
Resolves #244.

Supersedes #251.

While the work in #251 by @Matthew-Herman was quite complete, I decided to build on it with a new approach and implement codegen from the specs instead:

- it helps reduce future maintenance effort;
- it helps make sure we're not accidentally deviating from the specs.

The codegen tool is available [here](https://github.com/xJonathanLEI/starknet-jsonrpc-codegen).

Technically we're not directly deriving everything from the specs though, for some reasons:

- the specs itself isn't completely correct: https://github.com/starkware-libs/starknet-specs/pull/64;
- some semantics are not captured by the specs (e.g. the `type` field value is directly linked to the variant, but the specs doesn't declare the relationship);
- some types are too complicated to be automatically generated for them to be idiomatic.

Alternative approaches have been considered:

- proc macros: not exactly a good fit for value objects like this as it makes exploring the source rather difficult;
- `build.rs`: better than proc macros but users still need to dig into the `target` folder for the generated source.

This PR also makes the contract deployment test ignored by default since it's no longer possible to send deploy transactions to live environments.