### PR TITLE
docs: bump supported StarkNet version to 0.10.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Complete StarkNet library in Rust**
 
-![starknet-version-v0.10.2](https://img.shields.io/badge/StarkNet_Version-v0.10.2-2ea44f?logo=ethereum)
+![starknet-version-v0.10.3](https://img.shields.io/badge/StarkNet_Version-v0.10.3-2ea44f?logo=ethereum)
 [![jsonrpc-spec-v0.2.1](https://img.shields.io/badge/JSON--RPC-v0.2.1-2ea44f?logo=ethereum)](https://github.com/starkware-libs/starknet-specs/tree/v0.2.1)
 [![linting-badge](https://github.com/xJonathanLEI/starknet-rs/actions/workflows/lint.yaml/badge.svg?branch=master)](https://github.com/xJonathanLEI/starknet-rs/actions/workflows/lint.yaml)
 [![crates-badge](https://img.shields.io/crates/v/starknet.svg)](https://crates.io/crates/starknet)


### PR DESCRIPTION
A simple version bump following the test data update in #258.