### PR TITLE
feat: chain id for testnet 2

### DIFF
--- a/starknet-core/src/chain_id.rs
+++ b/starknet-core/src/chain_id.rs
@@ -14,6 +14,13 @@ pub const TESTNET: FieldElement = FieldElement::from_mont([
     398700013197595345,
 ]);
 
+pub const TESTNET2: FieldElement = FieldElement::from_mont([
+    1663542769632127759,
+    18446744073708869172,
+    18446744073709551615,
+    33650220878420990,
+]);
+
 #[cfg(test)]
 mod test {
     use crate::utils::cairo_short_string_to_felt;
@@ -23,7 +30,13 @@ mod test {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_chain_ids() {
-        for (text, felt) in [("SN_MAIN", MAINNET), ("SN_GOERLI", TESTNET)].into_iter() {
+        for (text, felt) in [
+            ("SN_MAIN", MAINNET),
+            ("SN_GOERLI", TESTNET),
+            ("SN_GOERLI2", TESTNET2),
+        ]
+        .into_iter()
+        {
             assert_eq!(cairo_short_string_to_felt(text).unwrap(), felt);
         }
     }


### PR DESCRIPTION
This PR adds the chain ID constant for testnet 2 following the chain ID change. This is the same diff that got dropped as part of #233.