### PR TITLE
feat: remove token for add_transaction method

### DIFF
--- a/examples/deploy_contract.rs
+++ b/examples/deploy_contract.rs
@@ -13,7 +13,7 @@ async fn main() {
 
     let contract_factory = ContractFactory::new(&contract_artifact, provider).unwrap();
     contract_factory
-        .deploy(vec![FieldElement::from_dec_str("123456").unwrap()], None)
+        .deploy(vec![FieldElement::from_dec_str("123456").unwrap()])
         .await
         .expect("Unable to deploy contract");
 }

--- a/starknet-accounts/src/single_owner.rs
+++ b/starknet-accounts/src/single_owner.rs
@@ -311,10 +311,7 @@ where
             .await
             .map_err(Self::SendTransactionError::SignerError)?;
         self.provider
-            .add_transaction(
-                TransactionRequest::InvokeFunction(add_transaction_request),
-                None,
-            )
+            .add_transaction(TransactionRequest::InvokeFunction(add_transaction_request))
             .await
             .map_err(Self::SendTransactionError::ProviderError)
     }
@@ -360,7 +357,7 @@ where
             .await
             .map_err(Self::SendTransactionError::SignerError)?;
         self.provider
-            .add_transaction(TransactionRequest::Declare(add_transaction_request), None)
+            .add_transaction(TransactionRequest::Declare(add_transaction_request))
             .await
             .map_err(Self::SendTransactionError::ProviderError)
     }

--- a/starknet-contract/src/factory.rs
+++ b/starknet-contract/src/factory.rs
@@ -31,7 +31,6 @@ impl<P: Provider> Factory<P> {
     pub async fn deploy(
         &self,
         constructor_calldata: Vec<FieldElement>,
-        token: Option<String>,
     ) -> Result<AddTransactionResult, P::Error> {
         let mut salt_buffer = [0u8; 32];
 
@@ -41,18 +40,15 @@ impl<P: Provider> Factory<P> {
         rng.fill_bytes(&mut salt_buffer[1..]);
 
         self.provider
-            .add_transaction(
-                TransactionRequest::Deploy(DeployTransactionRequest {
-                    contract_address_salt: FieldElement::from_bytes_be(&salt_buffer).unwrap(),
-                    contract_definition: ContractDefinition {
-                        program: self.compressed_program.clone(),
-                        entry_points_by_type: self.entry_points_by_type.clone(),
-                        abi: Some(self.abi.clone()),
-                    },
-                    constructor_calldata,
-                }),
-                token,
-            )
+            .add_transaction(TransactionRequest::Deploy(DeployTransactionRequest {
+                contract_address_salt: FieldElement::from_bytes_be(&salt_buffer).unwrap(),
+                contract_definition: ContractDefinition {
+                    program: self.compressed_program.clone(),
+                    entry_points_by_type: self.entry_points_by_type.clone(),
+                    abi: Some(self.abi.clone()),
+                },
+                constructor_calldata,
+            }))
             .await
     }
 }

--- a/starknet-contract/tests/contract_deployment.rs
+++ b/starknet-contract/tests/contract_deployment.rs
@@ -13,7 +13,7 @@ async fn can_deploy_contract_to_alpha_goerli() {
     let factory = ContractFactory::new(&artifact, provider).unwrap();
 
     let result = factory
-        .deploy(vec![FieldElement::from_dec_str("1").unwrap()], None)
+        .deploy(vec![FieldElement::from_dec_str("1").unwrap()])
         .await;
 
     match result {

--- a/starknet-providers/src/provider.rs
+++ b/starknet-providers/src/provider.rs
@@ -17,7 +17,6 @@ pub trait Provider {
     async fn add_transaction(
         &self,
         tx: TransactionRequest,
-        token: Option<String>,
     ) -> Result<AddTransactionResult, Self::Error>;
 
     async fn get_contract_addresses(&self) -> Result<ContractAddresses, Self::Error>;

--- a/starknet-providers/src/sequencer_gateway.rs
+++ b/starknet-providers/src/sequencer_gateway.rs
@@ -157,12 +157,8 @@ impl Provider for SequencerGatewayProvider {
     async fn add_transaction(
         &self,
         tx: TransactionRequest,
-        token: Option<String>,
     ) -> Result<AddTransactionResult, Self::Error> {
-        let mut request_url = self.extend_gateway_url("add_transaction");
-        if let Some(token) = token {
-            request_url.query_pairs_mut().append_pair("token", &token);
-        }
+        let request_url = self.extend_gateway_url("add_transaction");
 
         match self.send_post_request(request_url, &tx).await? {
             GatewayResponse::Data(data) => Ok(data),


### PR DESCRIPTION
A `token` param was used for the `add_transaction` method as `mainnet-alpha` required a whitelist for deploy/declare transactions.

This restriction has been lifted as `mainnet-alpha` upgraded to v0.10.3. This PR removes the use of the optional token for good since there's no more use case for it.