### PR TITLE
fix(jsonrpc): duplicate fields in tagged enum serialization

### DIFF
--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -102,7 +102,7 @@ pub enum BlockId {
     Tag(BlockTag),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type")]
 pub enum Transaction {
     #[serde(rename = "INVOKE")]
@@ -117,7 +117,7 @@ pub enum Transaction {
     DeployAccount(DeployAccountTransaction),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type")]
 pub enum BroadcastedTransaction {
     #[serde(rename = "INVOKE")]
@@ -130,7 +130,7 @@ pub enum BroadcastedTransaction {
     DeployAccount(BroadcastedDeployAccountTransaction),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "version")]
 pub enum InvokeTransaction {
     #[serde(rename = "0x0")]
@@ -139,7 +139,7 @@ pub enum InvokeTransaction {
     V1(InvokeTransactionV1),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "version")]
 pub enum BroadcastedInvokeTransaction {
     #[serde(rename = "0x0")]
@@ -148,7 +148,7 @@ pub enum BroadcastedInvokeTransaction {
     V1(BroadcastedInvokeTransactionV1),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type")]
 pub enum TransactionReceipt {
     #[serde(rename = "INVOKE")]
@@ -163,7 +163,7 @@ pub enum TransactionReceipt {
     DeployAccount(DeployAccountTransactionReceipt),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type")]
 pub enum PendingTransactionReceipt {
     #[serde(rename = "INVOKE")]

--- a/starknet-providers/src/jsonrpc/models/serde_impls.rs
+++ b/starknet-providers/src/jsonrpc/models/serde_impls.rs
@@ -64,3 +64,74 @@ impl<'de> Deserialize<'de> for SyncStatusType {
         }
     }
 }
+
+// Deriving the Serialize trait directly results in duplicate fields since the variants also write
+// the tag fields when individually serialized.
+mod enum_ser_impls {
+    use super::super::*;
+
+    impl Serialize for Transaction {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            match self {
+                Self::Invoke(variant) => variant.serialize(serializer),
+                Self::L1Handler(variant) => variant.serialize(serializer),
+                Self::Declare(variant) => variant.serialize(serializer),
+                Self::Deploy(variant) => variant.serialize(serializer),
+                Self::DeployAccount(variant) => variant.serialize(serializer),
+            }
+        }
+    }
+
+    impl Serialize for BroadcastedTransaction {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            match self {
+                Self::Invoke(variant) => variant.serialize(serializer),
+                Self::Declare(variant) => variant.serialize(serializer),
+                Self::Deploy(variant) => variant.serialize(serializer),
+                Self::DeployAccount(variant) => variant.serialize(serializer),
+            }
+        }
+    }
+
+    impl Serialize for InvokeTransaction {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            match self {
+                Self::V0(variant) => variant.serialize(serializer),
+                Self::V1(variant) => variant.serialize(serializer),
+            }
+        }
+    }
+
+    impl Serialize for BroadcastedInvokeTransaction {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            match self {
+                Self::V0(variant) => variant.serialize(serializer),
+                Self::V1(variant) => variant.serialize(serializer),
+            }
+        }
+    }
+
+    impl Serialize for TransactionReceipt {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            match self {
+                Self::Invoke(variant) => variant.serialize(serializer),
+                Self::L1Handler(variant) => variant.serialize(serializer),
+                Self::Declare(variant) => variant.serialize(serializer),
+                Self::Deploy(variant) => variant.serialize(serializer),
+                Self::DeployAccount(variant) => variant.serialize(serializer),
+            }
+        }
+    }
+
+    impl Serialize for PendingTransactionReceipt {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            match self {
+                Self::Invoke(variant) => variant.serialize(serializer),
+                Self::L1Handler(variant) => variant.serialize(serializer),
+                Self::Declare(variant) => variant.serialize(serializer),
+                Self::Deploy(variant) => variant.serialize(serializer),
+                Self::DeployAccount(variant) => variant.serialize(serializer),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Enum variants in JSON-RPC models are tagged even when individually serialized, which is an intentional behavior since I don't want to force users to wrap variant values inside their higher level enum type just to get the tag fields (e.g. `type`, `version`) serialized. That's why you can see a lot of custom serde impl blocks in model code.

However, there's currently a bug on the enum level causing the tag fields to be serialized twice when serializing from the enum level. This PR fixes it by manually implementing the `Serialize` traits for these types.