### PR TITLE
refactor: use from_str when deserializing FieldElement

### DIFF
--- a/starknet-ff/src/lib.rs
+++ b/starknet-ff/src/lib.rs
@@ -451,7 +451,7 @@ impl<'de> Deserialize<'de> for FieldElement {
         D: serde::Deserializer<'de>,
     {
         let value = String::deserialize(deserializer)?;
-        Self::from_str(&value).map_err(|err| serde::de::Error::custom(err))
+        Self::from_str(&value).map_err(serde::de::Error::custom)
     }
 }
 

--- a/starknet-ff/src/lib.rs
+++ b/starknet-ff/src/lib.rs
@@ -451,8 +451,7 @@ impl<'de> Deserialize<'de> for FieldElement {
         D: serde::Deserializer<'de>,
     {
         let value = String::deserialize(deserializer)?;
-        Self::from_dec_str(&value)
-            .map_err(|err| serde::de::Error::custom(format!("invalid decimal string: {}", err)))
+        Self::from_str(&value).map_err(|err| serde::de::Error::custom(err))
     }
 }
 


### PR DESCRIPTION
This PR refactors `Deserialize` trait of `FieldElement` using `from_str` so that can deserialize both hex and decimal string.