### PR TITLE
feat: change default localhost port to 5050 to meet current conventio…

### DIFF
--- a/starknet-providers/src/sequencer_gateway.rs
+++ b/starknet-providers/src/sequencer_gateway.rs
@@ -68,8 +68,8 @@ impl SequencerGatewayProvider {
 
     pub fn starknet_nile_localhost() -> Self {
         Self::new(
-            Url::parse("http://127.0.0.1:5000/gateway").unwrap(),
-            Url::parse("http://127.0.0.1:5000/feeder_gateway").unwrap(),
+            Url::parse("http://127.0.0.1:5050/gateway").unwrap(),
+            Url::parse("http://127.0.0.1:5050/feeder_gateway").unwrap(),
         )
     }
 }


### PR DESCRIPTION
Updates port value to `5050` to conform with the rest of the ecosystem standards (nile, devnet etc)

Only a minor change - but will stop users from having to have custom ports for the other services.