### PR TITLE
feat: simulate account execution

### DIFF
--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -76,6 +76,56 @@ async fn can_estimate_fee() {
 }
 
 #[tokio::test]
+async fn can_simulate_execution() {
+    // Simulates the tx in `can_execute_tst_mint()` without actually sending
+
+    let provider = SequencerGatewayProvider::starknet_alpha_goerli();
+    let signer = LocalWallet::from(SigningKey::from_secret_scalar(
+        FieldElement::from_hex_be(
+            "00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        )
+        .unwrap(),
+    ));
+    let address = FieldElement::from_hex_be(
+        "02da37a17affbd2df4ede7120dae305ec36dfe94ec96a8c3f49bbf59f4e9a9fa",
+    )
+    .unwrap();
+    let tst_token_address = FieldElement::from_hex_be(
+        "07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10",
+    )
+    .unwrap();
+
+    let account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+
+    let result = account
+        .execute(vec![
+            Call {
+                to: tst_token_address,
+                selector: get_selector_from_name("mint").unwrap(),
+                calldata: vec![
+                    address,
+                    FieldElement::from_dec_str("1000000000000000000000").unwrap(),
+                    FieldElement::ZERO,
+                ],
+            },
+            Call {
+                to: tst_token_address,
+                selector: get_selector_from_name("mint").unwrap(),
+                calldata: vec![
+                    address,
+                    FieldElement::from_dec_str("2000000000000000000000").unwrap(),
+                    FieldElement::ZERO,
+                ],
+            },
+        ])
+        .simulate()
+        .await
+        .unwrap();
+
+    assert!(!result.trace.function_invocation.internal_calls.is_empty());
+}
+
+#[tokio::test]
 async fn can_execute_tst_mint() {
     // This test case is not very useful as the sequencer will always respond with
     // `TransactionReceived` even if the transaction will eventually fail, just like how


### PR DESCRIPTION
Resolves #252.

You can now do something like:

```rust
account
    .execute(vec![...])
    .simulate()
    .await
```

To get the trace of the execution without actually sending it out.