### PR TITLE
feat: bring your own http client

### DIFF
--- a/starknet-providers/src/jsonrpc/transports/http.rs
+++ b/starknet-providers/src/jsonrpc/transports/http.rs
@@ -14,8 +14,12 @@ pub struct HttpTransport {
 
 impl HttpTransport {
     pub fn new(url: impl Into<Url>) -> Self {
+        Self::new_with_client(url, Client::new())
+    }
+
+    pub fn new_with_client(url: impl Into<Url>, client: Client) -> Self {
         Self {
-            client: Client::new(),
+            client,
             url: url.into(),
         }
     }

--- a/starknet-providers/src/sequencer_gateway.rs
+++ b/starknet-providers/src/sequencer_gateway.rs
@@ -40,8 +40,16 @@ pub enum ProviderError {
 
 impl SequencerGatewayProvider {
     pub fn new(gateway_url: impl Into<Url>, feeder_gateway_url: impl Into<Url>) -> Self {
+        Self::new_with_client(gateway_url, feeder_gateway_url, Client::new())
+    }
+
+    pub fn new_with_client(
+        gateway_url: impl Into<Url>,
+        feeder_gateway_url: impl Into<Url>,
+        client: Client,
+    ) -> Self {
         Self {
-            client: Client::new(),
+            client,
             gateway_url: gateway_url.into(),
             feeder_gateway_url: feeder_gateway_url.into(),
         }


### PR DESCRIPTION
This PR adds a new `new_with_client` constructor to types `SequencerGatewayProvider` and `HttpTransport`, making it possible to customize the HTTP client.

One example use case is to set HTTP timeout, which wasn't possible before this PR.