### PR TITLE
feat: error code `INVALID_TRANSACTION_NONCE`

### DIFF
--- a/starknet-core/src/types/starknet_error.rs
+++ b/starknet-core/src/types/starknet_error.rs
@@ -34,4 +34,6 @@ pub enum ErrorCode {
     MalformedRequest,
     #[serde(rename = "StarknetErrorCode.UNDECLARED_CLASS")]
     UndeclaredClass,
+    #[serde(rename = "StarknetErrorCode.INVALID_TRANSACTION_NONCE")]
+    InvalidTransactionNonce,
 }


### PR DESCRIPTION
This PR adds support for deserializing the `INVALID_TRANSACTION_NONCE` error code.