### PR TITLE
feat: account contract deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Examples can be found in the [examples folder](./examples):
 
 6. [Call a contract view function via sequencer gateway](./examples/sequencer_erc20_balance.rs)
 
+7. [Deploy an Argent X account to a pre-funded address](./examples/deploy_argent_account.rs)
+
 ## License
 
 Licensed under either of

--- a/examples/deploy_argent_account.rs
+++ b/examples/deploy_argent_account.rs
@@ -1,0 +1,56 @@
+use starknet::{
+    accounts::{AccountFactory, ArgentAccountFactory},
+    core::{chain_id, types::FieldElement},
+    macros::felt,
+    providers::SequencerGatewayProvider,
+    signers::{LocalWallet, SigningKey},
+};
+
+#[tokio::main]
+async fn main() {
+    // Latest hashes as of 2023-01-21. For demo only.
+    let proxy_hash = felt!("0x025ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918");
+    let impl_hash = felt!("0x033434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2");
+
+    // Anything you like here as salt
+    let salt = felt!("12345678");
+
+    let provider = SequencerGatewayProvider::starknet_alpha_goerli();
+    let signer = LocalWallet::from(SigningKey::from_secret_scalar(
+        FieldElement::from_hex_be("YOUR_PRIVATE_KEY_IN_HEX_HERE").unwrap(),
+    ));
+
+    let factory = ArgentAccountFactory::new(
+        proxy_hash,
+        impl_hash,
+        chain_id::TESTNET,
+        FieldElement::ZERO,
+        signer,
+        provider,
+    )
+    .await
+    .unwrap();
+
+    let deployment = factory.deploy(salt);
+
+    let est_fee = deployment.estimate_fee().await.unwrap();
+
+    // In an actual application you might want to add a buffer to the amount
+    println!(
+        "Fund at least {} wei to {:#064x}",
+        est_fee.overall_fee,
+        deployment.address()
+    );
+    println!("Press ENTER after account is funded to continue deployment...");
+    std::io::stdin().read_line(&mut String::new()).unwrap();
+
+    let result = deployment.send().await;
+    match result {
+        Ok(tx) => {
+            dbg!(tx);
+        }
+        Err(err) => {
+            eprintln!("Error: {err}");
+        }
+    }
+}

--- a/starknet-accounts/src/account/declaration.rs
+++ b/starknet-accounts/src/account/declaration.rs
@@ -1,6 +1,6 @@
 use super::{
-    Account, AccountError, ConnectedAccount, Declaration, NotPreparedError, PreparedDeclaration,
-    RawDeclaration,
+    super::NotPreparedError, Account, AccountError, ConnectedAccount, Declaration,
+    PreparedDeclaration, RawDeclaration,
 };
 
 use starknet_core::{

--- a/starknet-accounts/src/account/execution.rs
+++ b/starknet-accounts/src/account/execution.rs
@@ -1,5 +1,5 @@
 use super::{
-    Account, AccountError, ConnectedAccount, Execution, NotPreparedError, PreparedExecution,
+    super::NotPreparedError, Account, AccountError, ConnectedAccount, Execution, PreparedExecution,
     RawExecution,
 };
 use crate::Call;

--- a/starknet-accounts/src/account/mod.rs
+++ b/starknet-accounts/src/account/mod.rs
@@ -116,10 +116,6 @@ pub struct PreparedDeclaration<'a, A> {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("Not all fields are prepared")]
-pub struct NotPreparedError;
-
-#[derive(Debug, thiserror::Error)]
 pub enum AccountError<S, P> {
     #[error(transparent)]
     Signing(S),

--- a/starknet-accounts/src/factory/argent.rs
+++ b/starknet-accounts/src/factory/argent.rs
@@ -1,0 +1,93 @@
+use crate::{AccountFactory, PreparedAccountDeployment, RawAccountDeployment};
+
+use async_trait::async_trait;
+use starknet_core::types::FieldElement;
+use starknet_providers::Provider;
+use starknet_signers::Signer;
+
+/// Selector for "initialize"
+const SELECTOR_INITIALIZE: FieldElement = FieldElement::from_mont([
+    14382173896205878522,
+    7380089477680411368,
+    4404362358337226556,
+    132905214994424316,
+]);
+
+pub struct ArgentAccountFactory<S, P> {
+    proxy_class_hash: FieldElement,
+    impl_class_hash: FieldElement,
+    chain_id: FieldElement,
+    signer_public_key: FieldElement,
+    guardian_public_key: FieldElement,
+    signer: S,
+    provider: P,
+}
+
+impl<S, P> ArgentAccountFactory<S, P>
+where
+    S: Signer,
+{
+    pub async fn new(
+        proxy_class_hash: FieldElement,
+        impl_class_hash: FieldElement,
+        chain_id: FieldElement,
+        guardian_public_key: FieldElement,
+        signer: S,
+        provider: P,
+    ) -> Result<Self, S::GetPublicKeyError> {
+        let signer_public_key = signer.get_public_key().await?;
+        Ok(Self {
+            proxy_class_hash,
+            impl_class_hash,
+            chain_id,
+            signer_public_key: signer_public_key.scalar(),
+            guardian_public_key,
+            signer,
+            provider,
+        })
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<S, P> AccountFactory for ArgentAccountFactory<S, P>
+where
+    S: Signer + Sync + Send,
+    P: Provider + Sync + Send,
+{
+    type Provider = P;
+    type SignError = S::SignError;
+
+    fn class_hash(&self) -> FieldElement {
+        self.proxy_class_hash
+    }
+
+    fn calldata(&self) -> Vec<FieldElement> {
+        vec![
+            self.impl_class_hash,
+            SELECTOR_INITIALIZE,
+            FieldElement::TWO,
+            self.signer_public_key,
+            self.guardian_public_key,
+        ]
+    }
+
+    fn chain_id(&self) -> FieldElement {
+        self.chain_id
+    }
+
+    fn provider(&self) -> &Self::Provider {
+        &self.provider
+    }
+
+    async fn sign_deployment(
+        &self,
+        deployment: &RawAccountDeployment,
+    ) -> Result<Vec<FieldElement>, Self::SignError> {
+        let tx_hash =
+            PreparedAccountDeployment::from_raw(deployment.clone(), self).transaction_hash();
+        let signature = self.signer.sign_hash(&tx_hash).await?;
+
+        Ok(vec![signature.r, signature.s])
+    }
+}

--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -11,6 +11,9 @@ use starknet_core::{
 use starknet_providers::Provider;
 use std::error::Error;
 
+pub mod argent;
+pub mod open_zeppelin;
+
 /// Cairo string for "deploy_account"
 const PREFIX_DEPLOY_ACCOUNT: FieldElement = FieldElement::from_mont([
     3350261884043292318,

--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -1,0 +1,335 @@
+use super::NotPreparedError;
+
+use async_trait::async_trait;
+use starknet_core::{
+    crypto::compute_hash_on_elements,
+    types::{
+        AccountTransaction, AddTransactionResult, BlockId, DeployAccountTransactionRequest,
+        FeeEstimate, FieldElement, TransactionRequest,
+    },
+};
+use starknet_providers::Provider;
+use std::error::Error;
+
+/// Cairo string for "deploy_account"
+const PREFIX_DEPLOY_ACCOUNT: FieldElement = FieldElement::from_mont([
+    3350261884043292318,
+    18443211694809419988,
+    18446744073709551615,
+    461298303000467581,
+]);
+
+/// Cairo string for "STARKNET_CONTRACT_ADDRESS"
+const PREFIX_CONTRACT_ADDRESS: FieldElement = FieldElement::from_mont([
+    3829237882463328880,
+    17289941567720117366,
+    8635008616843941496,
+    533439743893157637,
+]);
+
+// 2 ** 251 - 256
+const ADDR_BOUND: FieldElement = FieldElement::from_mont([
+    18446743986131443745,
+    160989183,
+    18446744073709255680,
+    576459263475590224,
+]);
+
+/// This trait enables deploying account contracts using the `DeployAccount` transaction type.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait AccountFactory: Sized {
+    type Provider: Provider;
+    type SignError: Error;
+
+    fn class_hash(&self) -> FieldElement;
+
+    fn calldata(&self) -> Vec<FieldElement>;
+
+    fn chain_id(&self) -> FieldElement;
+
+    fn provider(&self) -> &Self::Provider;
+
+    /// Block ID to use when estimating fees.
+    fn block_id(&self) -> BlockId {
+        BlockId::Latest
+    }
+
+    async fn sign_deployment(
+        &self,
+        deployment: &RawAccountDeployment,
+    ) -> Result<Vec<FieldElement>, Self::SignError>;
+
+    fn deploy(&self, salt: FieldElement) -> AccountDeployment<Self> {
+        AccountDeployment::new(salt, self)
+    }
+}
+
+/// An intermediate type allowing users to optionally specify `nonce` and/or `max_fee`.
+#[derive(Debug)]
+pub struct AccountDeployment<'f, F> {
+    factory: &'f F,
+    salt: FieldElement,
+    // We need to allow setting nonce here as `DeployAccount` transactions may have non-zero nonces
+    /// after failed transactions can be included in blocks.
+    nonce: Option<FieldElement>,
+    max_fee: Option<FieldElement>,
+    fee_estimate_multiplier: f64,
+}
+
+/// [AccountDeployment] but with `nonce` and `max_fee` already determined.
+#[derive(Debug, Clone)]
+pub struct RawAccountDeployment {
+    salt: FieldElement,
+    nonce: FieldElement,
+    max_fee: FieldElement,
+}
+
+/// [RawAccountDeployment] but with a factory associated.
+#[derive(Debug)]
+pub struct PreparedAccountDeployment<'f, F> {
+    factory: &'f F,
+    inner: RawAccountDeployment,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AccountFactoryError<S, P> {
+    #[error(transparent)]
+    Signing(S),
+    #[error(transparent)]
+    Provider(P),
+}
+
+impl<'f, F> AccountDeployment<'f, F> {
+    pub fn new(salt: FieldElement, factory: &'f F) -> Self {
+        Self {
+            factory,
+            salt,
+            nonce: None,
+            max_fee: None,
+            fee_estimate_multiplier: 1.1,
+        }
+    }
+
+    pub fn nonce(self, nonce: FieldElement) -> Self {
+        Self {
+            nonce: Some(nonce),
+            ..self
+        }
+    }
+
+    pub fn max_fee(self, max_fee: FieldElement) -> Self {
+        Self {
+            max_fee: Some(max_fee),
+            ..self
+        }
+    }
+
+    /// Calling this function after manually specifying `nonce` and `max_fee` turns
+    /// [AccountDeployment] into [PreparedAccountDeployment]. Returns `Err` if either field is
+    /// `None`.
+    pub fn prepared(self) -> Result<PreparedAccountDeployment<'f, F>, NotPreparedError> {
+        let nonce = self.nonce.ok_or(NotPreparedError)?;
+        let max_fee = self.max_fee.ok_or(NotPreparedError)?;
+
+        Ok(PreparedAccountDeployment {
+            factory: self.factory,
+            inner: RawAccountDeployment {
+                salt: self.salt,
+                nonce,
+                max_fee,
+            },
+        })
+    }
+}
+
+impl<'f, F> AccountDeployment<'f, F>
+where
+    F: AccountFactory + Sync,
+{
+    /// Locally calculates the target deployment address.
+    pub fn address(&self) -> FieldElement {
+        calculate_contract_address(
+            self.salt,
+            self.factory.class_hash(),
+            &self.factory.calldata(),
+        )
+    }
+
+    pub async fn fetch_nonce(&self) -> Result<FieldElement, <F::Provider as Provider>::Error> {
+        self.factory
+            .provider()
+            .get_nonce(self.address(), self.factory.block_id())
+            .await
+    }
+
+    pub async fn estimate_fee(
+        &self,
+    ) -> Result<FeeEstimate, AccountFactoryError<F::SignError, <F::Provider as Provider>::Error>>
+    {
+        // Resolves nonce
+        let nonce = match self.nonce {
+            Some(value) => value,
+            None => self
+                .fetch_nonce()
+                .await
+                .map_err(AccountFactoryError::Provider)?,
+        };
+
+        self.estimate_fee_with_nonce(nonce).await
+    }
+
+    pub async fn send(
+        &self,
+    ) -> Result<
+        AddTransactionResult,
+        AccountFactoryError<F::SignError, <F::Provider as Provider>::Error>,
+    > {
+        self.prepare().await?.send().await
+    }
+
+    async fn prepare(
+        &self,
+    ) -> Result<
+        PreparedAccountDeployment<'f, F>,
+        AccountFactoryError<F::SignError, <F::Provider as Provider>::Error>,
+    > {
+        // Resolves nonce
+        let nonce = match self.nonce {
+            Some(value) => value,
+            None => self
+                .fetch_nonce()
+                .await
+                .map_err(AccountFactoryError::Provider)?,
+        };
+
+        // Resolves max_fee
+        let max_fee = match self.max_fee {
+            Some(value) => value,
+            None => {
+                let fee_estimate = self.estimate_fee_with_nonce(nonce).await?;
+                ((fee_estimate.overall_fee as f64 * self.fee_estimate_multiplier) as u64).into()
+            }
+        };
+
+        Ok(PreparedAccountDeployment {
+            factory: self.factory,
+            inner: RawAccountDeployment {
+                salt: self.salt,
+                nonce,
+                max_fee,
+            },
+        })
+    }
+
+    async fn estimate_fee_with_nonce(
+        &self,
+        nonce: FieldElement,
+    ) -> Result<FeeEstimate, AccountFactoryError<F::SignError, <F::Provider as Provider>::Error>>
+    {
+        let prepared = PreparedAccountDeployment {
+            factory: self.factory,
+            inner: RawAccountDeployment {
+                salt: self.salt,
+                nonce,
+                max_fee: FieldElement::ZERO,
+            },
+        };
+        let deploy = prepared
+            .get_deploy_request()
+            .await
+            .map_err(AccountFactoryError::Signing)?;
+
+        self.factory
+            .provider()
+            .estimate_fee(
+                AccountTransaction::DeployAccount(deploy),
+                self.factory.block_id(),
+            )
+            .await
+            .map_err(AccountFactoryError::Provider)
+    }
+}
+
+impl<'f, F> PreparedAccountDeployment<'f, F> {
+    pub fn from_raw(raw_deployment: RawAccountDeployment, factory: &'f F) -> Self {
+        Self {
+            factory,
+            inner: raw_deployment,
+        }
+    }
+}
+
+impl<'f, F> PreparedAccountDeployment<'f, F>
+where
+    F: AccountFactory,
+{
+    /// Locally calculates the target deployment address.
+    pub fn address(&self) -> FieldElement {
+        calculate_contract_address(
+            self.inner.salt,
+            self.factory.class_hash(),
+            &self.factory.calldata(),
+        )
+    }
+
+    pub fn transaction_hash(&self) -> FieldElement {
+        let mut calldata_to_hash = vec![self.factory.class_hash(), self.inner.salt];
+        calldata_to_hash.append(&mut self.factory.calldata());
+
+        compute_hash_on_elements(&[
+            PREFIX_DEPLOY_ACCOUNT,
+            FieldElement::ONE, // version
+            self.address(),
+            FieldElement::ZERO, // entry_point_selector
+            compute_hash_on_elements(&calldata_to_hash),
+            self.inner.max_fee,
+            self.factory.chain_id(),
+            self.inner.nonce,
+        ])
+    }
+
+    pub async fn send(
+        &self,
+    ) -> Result<
+        AddTransactionResult,
+        AccountFactoryError<F::SignError, <F::Provider as Provider>::Error>,
+    > {
+        let tx_request = self
+            .get_deploy_request()
+            .await
+            .map_err(AccountFactoryError::Signing)?;
+        self.factory
+            .provider()
+            .add_transaction(TransactionRequest::DeployAccount(tx_request))
+            .await
+            .map_err(AccountFactoryError::Provider)
+    }
+
+    async fn get_deploy_request(&self) -> Result<DeployAccountTransactionRequest, F::SignError> {
+        let signature = self.factory.sign_deployment(&self.inner).await?;
+
+        Ok(DeployAccountTransactionRequest {
+            class_hash: self.factory.class_hash(),
+            contract_address_salt: self.inner.salt,
+            constructor_calldata: self.factory.calldata(),
+            max_fee: self.inner.max_fee,
+            signature,
+            nonce: self.inner.nonce,
+        })
+    }
+}
+
+fn calculate_contract_address(
+    salt: FieldElement,
+    class_hash: FieldElement,
+    constructor_calldata: &[FieldElement],
+) -> FieldElement {
+    compute_hash_on_elements(&[
+        PREFIX_CONTRACT_ADDRESS,
+        FieldElement::ZERO,
+        salt,
+        class_hash,
+        compute_hash_on_elements(constructor_calldata),
+    ]) % ADDR_BOUND
+}

--- a/starknet-accounts/src/factory/open_zeppelin.rs
+++ b/starknet-accounts/src/factory/open_zeppelin.rs
@@ -1,0 +1,73 @@
+use crate::{AccountFactory, PreparedAccountDeployment, RawAccountDeployment};
+
+use async_trait::async_trait;
+use starknet_core::types::FieldElement;
+use starknet_providers::Provider;
+use starknet_signers::Signer;
+
+pub struct OpenZeppelinAccountFactory<S, P> {
+    class_hash: FieldElement,
+    chain_id: FieldElement,
+    public_key: FieldElement,
+    signer: S,
+    provider: P,
+}
+
+impl<S, P> OpenZeppelinAccountFactory<S, P>
+where
+    S: Signer,
+{
+    pub async fn new(
+        class_hash: FieldElement,
+        chain_id: FieldElement,
+        signer: S,
+        provider: P,
+    ) -> Result<Self, S::GetPublicKeyError> {
+        let public_key = signer.get_public_key().await?;
+        Ok(Self {
+            class_hash,
+            chain_id,
+            public_key: public_key.scalar(),
+            signer,
+            provider,
+        })
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<S, P> AccountFactory for OpenZeppelinAccountFactory<S, P>
+where
+    S: Signer + Sync + Send,
+    P: Provider + Sync + Send,
+{
+    type Provider = P;
+    type SignError = S::SignError;
+
+    fn class_hash(&self) -> FieldElement {
+        self.class_hash
+    }
+
+    fn calldata(&self) -> Vec<FieldElement> {
+        vec![self.public_key]
+    }
+
+    fn chain_id(&self) -> FieldElement {
+        self.chain_id
+    }
+
+    fn provider(&self) -> &Self::Provider {
+        &self.provider
+    }
+
+    async fn sign_deployment(
+        &self,
+        deployment: &RawAccountDeployment,
+    ) -> Result<Vec<FieldElement>, Self::SignError> {
+        let tx_hash =
+            PreparedAccountDeployment::from_raw(deployment.clone(), self).transaction_hash();
+        let signature = self.signer.sign_hash(&tx_hash).await?;
+
+        Ok(vec![signature.r, signature.s])
+    }
+}

--- a/starknet-accounts/src/lib.rs
+++ b/starknet-accounts/src/lib.rs
@@ -1,11 +1,21 @@
 mod account;
 pub use account::{
-    Account, AccountError, ConnectedAccount, Declaration, Execution, NotPreparedError,
-    PreparedDeclaration, PreparedExecution, RawDeclaration, RawExecution,
+    Account, AccountError, ConnectedAccount, Declaration, Execution, PreparedDeclaration,
+    PreparedExecution, RawDeclaration, RawExecution,
 };
 
 mod call;
 pub use call::Call;
 
+mod factory;
+pub use factory::{
+    AccountDeployment, AccountFactory, AccountFactoryError, PreparedAccountDeployment,
+    RawAccountDeployment,
+};
+
 pub mod single_owner;
 pub use single_owner::SingleOwnerAccount;
+
+#[derive(Debug, thiserror::Error)]
+#[error("Not all fields are prepared")]
+pub struct NotPreparedError;

--- a/starknet-accounts/src/lib.rs
+++ b/starknet-accounts/src/lib.rs
@@ -9,8 +9,8 @@ pub use call::Call;
 
 mod factory;
 pub use factory::{
-    AccountDeployment, AccountFactory, AccountFactoryError, PreparedAccountDeployment,
-    RawAccountDeployment,
+    argent::ArgentAccountFactory, open_zeppelin::OpenZeppelinAccountFactory, AccountDeployment,
+    AccountFactory, AccountFactoryError, PreparedAccountDeployment, RawAccountDeployment,
 };
 
 pub mod single_owner;


### PR DESCRIPTION
Implements the second half of #232. Closes #232.

This PR:

- adds a new trait `AccountFactory` which enables deploying pre-funded account through the `DeployAccount` transaction type; and
- implements the trait for Argent X and OpenZeppelin account contracts; and
- adds a new example of deploying an Argent X account with this new construct.

With this new feature, users can calculate the target address with a deployment, somehow fund the account, and proceed with the actual deployment transaction, as demonstrated in the example added.

No integration test case has been added as we only test against live environments (no local dev net) and testing this feature requires pre-funding addresses. It has been tested with the example code though.