### PR TITLE
feat: `short_string!()` macro for compile-time Cairo short strings

### DIFF
--- a/starknet-macros/src/lib.rs
+++ b/starknet-macros/src/lib.rs
@@ -1,5 +1,8 @@
 use proc_macro::TokenStream;
-use starknet_core::{types::FieldElement, utils::get_selector_from_name};
+use starknet_core::{
+    types::FieldElement,
+    utils::{cairo_short_string_to_felt, get_selector_from_name},
+};
 use syn::{parse_macro_input, LitStr};
 
 #[proc_macro]
@@ -14,6 +17,23 @@ pub fn selector(input: TokenStream) -> TokenStream {
     format!(
         "::starknet::core::types::FieldElement::from_mont([{}, {}, {}, {}])",
         selector_raw[0], selector_raw[1], selector_raw[2], selector_raw[3],
+    )
+    .parse()
+    .unwrap()
+}
+
+#[proc_macro]
+pub fn short_string(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as LitStr);
+
+    let str_value = input.value();
+
+    let felt_value = cairo_short_string_to_felt(&str_value).expect("invalid Cairo short string");
+    let felt_raw = felt_value.into_mont();
+
+    format!(
+        "::starknet::core::types::FieldElement::from_mont([{}, {}, {}, {}])",
+        felt_raw[0], felt_raw[1], felt_raw[2], felt_raw[3],
     )
     .parse()
     .unwrap()


### PR DESCRIPTION
This PR adds yet another macro `short_string` for building Cairo short strings at compile time.