### PR TITLE
feat: allow imported `FieldElement` type in macros

### DIFF
--- a/starknet-macros/Cargo.toml
+++ b/starknet-macros/Cargo.toml
@@ -18,3 +18,7 @@ proc-macro = true
 [dependencies]
 starknet-core = { version = "0.2.0", path = "../starknet-core" }
 syn = "1.0.96"
+
+[features]
+default = []
+use_imported_type = []

--- a/starknet-macros/src/lib.rs
+++ b/starknet-macros/src/lib.rs
@@ -15,8 +15,12 @@ pub fn selector(input: TokenStream) -> TokenStream {
     let selector_raw = selector_value.into_mont();
 
     format!(
-        "::starknet::core::types::FieldElement::from_mont([{}, {}, {}, {}])",
-        selector_raw[0], selector_raw[1], selector_raw[2], selector_raw[3],
+        "{}::from_mont([{}, {}, {}, {}])",
+        field_element_path(),
+        selector_raw[0],
+        selector_raw[1],
+        selector_raw[2],
+        selector_raw[3],
     )
     .parse()
     .unwrap()
@@ -32,8 +36,12 @@ pub fn short_string(input: TokenStream) -> TokenStream {
     let felt_raw = felt_value.into_mont();
 
     format!(
-        "::starknet::core::types::FieldElement::from_mont([{}, {}, {}, {}])",
-        felt_raw[0], felt_raw[1], felt_raw[2], felt_raw[3],
+        "{}::from_mont([{}, {}, {}, {}])",
+        field_element_path(),
+        felt_raw[0],
+        felt_raw[1],
+        felt_raw[2],
+        felt_raw[3],
     )
     .parse()
     .unwrap()
@@ -54,8 +62,12 @@ pub fn felt(input: TokenStream) -> TokenStream {
     let felt_raw = felt_value.into_mont();
 
     format!(
-        "::starknet::core::types::FieldElement::from_mont([{}, {}, {}, {}])",
-        felt_raw[0], felt_raw[1], felt_raw[2], felt_raw[3],
+        "{}::from_mont([{}, {}, {}, {}])",
+        field_element_path(),
+        felt_raw[0],
+        felt_raw[1],
+        felt_raw[2],
+        felt_raw[3],
     )
     .parse()
     .unwrap()
@@ -71,8 +83,12 @@ pub fn felt_dec(input: TokenStream) -> TokenStream {
     let felt_raw = felt_value.into_mont();
 
     format!(
-        "::starknet::core::types::FieldElement::from_mont([{}, {}, {}, {}])",
-        felt_raw[0], felt_raw[1], felt_raw[2], felt_raw[3],
+        "{}::from_mont([{}, {}, {}, {}])",
+        field_element_path(),
+        felt_raw[0],
+        felt_raw[1],
+        felt_raw[2],
+        felt_raw[3],
     )
     .parse()
     .unwrap()
@@ -88,9 +104,23 @@ pub fn felt_hex(input: TokenStream) -> TokenStream {
     let felt_raw = felt_value.into_mont();
 
     format!(
-        "::starknet::core::types::FieldElement::from_mont([{}, {}, {}, {}])",
-        felt_raw[0], felt_raw[1], felt_raw[2], felt_raw[3],
+        "{}::from_mont([{}, {}, {}, {}])",
+        field_element_path(),
+        felt_raw[0],
+        felt_raw[1],
+        felt_raw[2],
+        felt_raw[3],
     )
     .parse()
     .unwrap()
+}
+
+#[cfg(feature = "use_imported_type")]
+fn field_element_path() -> &'static str {
+    "FieldElement"
+}
+
+#[cfg(not(feature = "use_imported_type"))]
+fn field_element_path() -> &'static str {
+    "::starknet::core::types::FieldElement"
 }


### PR DESCRIPTION
Currently macros in `starknet-macros` are hard-coded to use the full path for the `FieldElement` type from the `starknet` crate so that users won't have to bring `FieldElement` into scope for the macros to work. However, this is an issue for our subcrates themselves: they don't have access to the parent `starknet` crate.

This PR adds an optional feature `use_imported_type` to the `starknet-macros` crate which requires users to bring `FieldElement` into scope, and in turn, doesn't require `starknet` to be on the crate import list.

This is so that we can replace all our const `FieldElement` definitions with macros (no more magic mont reprs).