### PR TITLE
chore: fix issues with contract types

### DIFF
--- a/starknet-core/src/serde/mod.rs
+++ b/starknet-core/src/serde/mod.rs
@@ -2,4 +2,6 @@ pub mod byte_array;
 
 pub mod unsigned_field_element;
 
+pub mod num_hex;
+
 pub(crate) mod json;

--- a/starknet-core/src/serde/num_hex.rs
+++ b/starknet-core/src/serde/num_hex.rs
@@ -1,0 +1,24 @@
+pub mod u64 {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{value:#x}"))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        match u64::from_str_radix(value.trim_start_matches("0x"), 16) {
+            Ok(value) => Ok(value),
+            Err(err) => Err(serde::de::Error::custom(format!(
+                "invalid u64 hex string: {}",
+                err
+            ))),
+        }
+    }
+}

--- a/starknet-core/src/types/contract_artifact.rs
+++ b/starknet-core/src/types/contract_artifact.rs
@@ -209,7 +209,7 @@ impl ContractArtifact {
             let mut buffer = vec![];
             for entrypoint in self.entry_points_by_type.external.iter() {
                 buffer.push(entrypoint.selector);
-                buffer.push(entrypoint.offset);
+                buffer.push(entrypoint.offset.into());
             }
             compute_hash_on_elements(&buffer)
         });
@@ -219,7 +219,7 @@ impl ContractArtifact {
             let mut buffer = vec![];
             for entrypoint in self.entry_points_by_type.l1_handler.iter() {
                 buffer.push(entrypoint.selector);
-                buffer.push(entrypoint.offset);
+                buffer.push(entrypoint.offset.into());
             }
             compute_hash_on_elements(&buffer)
         });
@@ -229,7 +229,7 @@ impl ContractArtifact {
             let mut buffer = vec![];
             for entrypoint in self.entry_points_by_type.constructor.iter() {
                 buffer.push(entrypoint.selector);
-                buffer.push(entrypoint.offset);
+                buffer.push(entrypoint.offset.into());
             }
             compute_hash_on_elements(&buffer)
         });

--- a/starknet-core/src/types/contract_code.rs
+++ b/starknet-core/src/types/contract_code.rs
@@ -55,7 +55,7 @@ pub struct L1Handler {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Event {
     pub data: Vec<EventData>,
-    pub keys: Vec<()>, // Can't figure out what's in `keys`
+    pub keys: Vec<EventData>,
     pub name: String,
 }
 

--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -23,8 +23,10 @@ pub use starknet_error::{Error as StarknetError, ErrorCode as StarknetErrorCode}
 
 mod contract_code;
 pub use contract_code::{
-    AbiEntry, Constructor as AbiConstructorEntry, ContractCode, Function as AbiFunctionEntry,
-    L1Handler as AbiL1HandlerEntry, Struct as AbiStructEntry,
+    AbiEntry, Constructor as AbiConstructorEntry, ContractCode, Event as AbiEventEntry,
+    EventData as AbiEventData, Function as AbiFunctionEntry, Input as AbiInput,
+    L1Handler as AbiL1HandlerEntry, Member as AbiStructMember, Output as AbiOutput,
+    Struct as AbiStructEntry,
 };
 
 mod contract_addresses;

--- a/starknet-core/src/types/transaction_request.rs
+++ b/starknet-core/src/types/transaction_request.rs
@@ -1,6 +1,7 @@
 use super::{
     super::serde::{
         byte_array::base64::serialize as base64_ser,
+        num_hex::u64 as u64_hex,
         unsigned_field_element::{UfeHex, UfeHexOption},
     },
     AbiEntry, FieldElement, L1Address,
@@ -111,7 +112,7 @@ pub struct DeployAccountTransaction {
     pub nonce: FieldElement,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct ContractDefinition {
     #[serde(serialize_with = "base64_ser")]
     pub program: Vec<u8>,
@@ -133,8 +134,8 @@ pub struct EntryPointsByType {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct EntryPoint {
-    #[serde_as(as = "UfeHex")]
-    pub offset: FieldElement,
+    #[serde(with = "u64_hex")]
+    pub offset: u64,
     #[serde_as(as = "UfeHex")]
     pub selector: FieldElement,
 }

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -33,7 +33,7 @@ fn create_contract_class() -> ContractClass {
                 .constructor
                 .into_iter()
                 .map(|item| ContractEntryPoint {
-                    offset: item.offset.try_into().unwrap(),
+                    offset: item.offset,
                     selector: item.selector,
                 })
                 .collect(),
@@ -42,7 +42,7 @@ fn create_contract_class() -> ContractClass {
                 .external
                 .into_iter()
                 .map(|item| ContractEntryPoint {
-                    offset: item.offset.try_into().unwrap(),
+                    offset: item.offset,
                     selector: item.selector,
                 })
                 .collect(),
@@ -51,7 +51,7 @@ fn create_contract_class() -> ContractClass {
                 .l1_handler
                 .into_iter()
                 .map(|item| ContractEntryPoint {
-                    offset: item.offset.try_into().unwrap(),
+                    offset: item.offset,
                     selector: item.selector,
                 })
                 .collect(),


### PR DESCRIPTION
This PR makes a few minor changes regarding contract related types in `starknet-core`:

- `ContractDefinition` now implements `Clone`;
- `EntryPoint::offset` is now `u64` instead of `FieldElement` to match with JSON-RPC;
- a few missing type exports have bee fixed.