### PR TITLE
feat(jsonrpc): partially implement `Provider` for jsonrpc client

### DIFF
--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -12,6 +12,12 @@ pub use transports::{HttpTransport, JsonRpcTransport};
 /// https://github.com/xJonathanLEI/starknet-rs/issues/77#issuecomment-1150184364
 pub mod models;
 
+/// Temporary module for bridging the client and the `Provider` trait until:
+///
+/// https://github.com/xJonathanLEI/starknet-rs/issues/77#issuecomment-1150184364
+mod provider;
+pub use provider::JsonRpcProviderError;
+
 #[derive(Debug)]
 pub struct JsonRpcClient<T> {
     transport: T,

--- a/starknet-providers/src/jsonrpc/models/conversions.rs
+++ b/starknet-providers/src/jsonrpc/models/conversions.rs
@@ -1,0 +1,277 @@
+use super::*;
+
+use starknet_core as core;
+
+impl From<core::types::BlockId> for BlockId {
+    fn from(value: core::types::BlockId) -> Self {
+        match value {
+            core::types::BlockId::Hash(hash) => Self::Hash(hash),
+            core::types::BlockId::Number(num) => Self::Number(num),
+            core::types::BlockId::Pending => Self::Tag(BlockTag::Pending),
+            core::types::BlockId::Latest => Self::Tag(BlockTag::Latest),
+        }
+    }
+}
+
+impl From<FeeEstimate> for core::types::FeeEstimate {
+    fn from(value: FeeEstimate) -> Self {
+        Self {
+            overall_fee: value.overall_fee,
+            unit: core::types::FeeUnit::Wei,
+            gas_price: value.gas_price,
+            gas_usage: value.gas_consumed,
+        }
+    }
+}
+
+impl From<core::types::DeclareTransactionRequest> for BroadcastedDeclareTransaction {
+    fn from(value: core::types::DeclareTransactionRequest) -> Self {
+        Self {
+            max_fee: value.max_fee,
+            version: 1,
+            signature: value.signature,
+            nonce: value.nonce,
+            contract_class: value.contract_class.as_ref().clone().into(),
+            sender_address: value.sender_address,
+        }
+    }
+}
+
+impl From<core::types::DeclareTransactionRequest> for BroadcastedTransaction {
+    fn from(value: core::types::DeclareTransactionRequest) -> Self {
+        Self::Declare(value.into())
+    }
+}
+
+impl From<core::types::InvokeFunctionTransactionRequest> for BroadcastedInvokeTransactionV1 {
+    fn from(value: core::types::InvokeFunctionTransactionRequest) -> Self {
+        Self {
+            max_fee: value.max_fee,
+            signature: value.signature,
+            nonce: value.nonce,
+            sender_address: value.contract_address,
+            calldata: value.calldata,
+        }
+    }
+}
+
+impl From<core::types::InvokeFunctionTransactionRequest> for BroadcastedInvokeTransaction {
+    fn from(value: core::types::InvokeFunctionTransactionRequest) -> Self {
+        Self::V1(value.into())
+    }
+}
+
+impl From<core::types::InvokeFunctionTransactionRequest> for BroadcastedTransaction {
+    fn from(value: core::types::InvokeFunctionTransactionRequest) -> Self {
+        Self::Invoke(value.into())
+    }
+}
+
+impl From<core::types::DeployAccountTransactionRequest> for BroadcastedDeployAccountTransaction {
+    fn from(value: core::types::DeployAccountTransactionRequest) -> Self {
+        Self {
+            max_fee: value.max_fee,
+            version: 1,
+            signature: value.signature,
+            nonce: value.nonce,
+            contract_address_salt: value.contract_address_salt,
+            constructor_calldata: value.constructor_calldata,
+            class_hash: value.class_hash,
+        }
+    }
+}
+
+impl From<core::types::DeployAccountTransactionRequest> for BroadcastedTransaction {
+    fn from(value: core::types::DeployAccountTransactionRequest) -> Self {
+        Self::DeployAccount(value.into())
+    }
+}
+
+impl From<core::types::AccountTransaction> for BroadcastedTransaction {
+    fn from(value: core::types::AccountTransaction) -> Self {
+        match value {
+            core::types::AccountTransaction::Declare(tx) => tx.into(),
+            core::types::AccountTransaction::InvokeFunction(tx) => tx.into(),
+            core::types::AccountTransaction::DeployAccount(tx) => tx.into(),
+        }
+    }
+}
+
+impl From<DeclareTransactionResult> for core::types::AddTransactionResult {
+    fn from(value: DeclareTransactionResult) -> Self {
+        Self {
+            code: core::types::AddTransactionResultCode::TransactionReceived,
+            transaction_hash: value.transaction_hash,
+            address: None,
+            class_hash: Some(value.class_hash),
+        }
+    }
+}
+
+impl From<InvokeTransactionResult> for core::types::AddTransactionResult {
+    fn from(value: InvokeTransactionResult) -> Self {
+        Self {
+            code: core::types::AddTransactionResultCode::TransactionReceived,
+            transaction_hash: value.transaction_hash,
+            address: None,
+            class_hash: None,
+        }
+    }
+}
+
+impl From<DeployAccountTransactionResult> for core::types::AddTransactionResult {
+    fn from(value: DeployAccountTransactionResult) -> Self {
+        Self {
+            code: core::types::AddTransactionResultCode::TransactionReceived,
+            transaction_hash: value.transaction_hash,
+            address: Some(value.contract_address),
+            class_hash: None,
+        }
+    }
+}
+
+impl From<core::types::ContractDefinition> for ContractClass {
+    fn from(value: core::types::ContractDefinition) -> Self {
+        Self {
+            program: value.program,
+            entry_points_by_type: value.entry_points_by_type.into(),
+            abi: value
+                .abi
+                .map(|abi| abi.into_iter().map(|item| item.into()).collect()),
+        }
+    }
+}
+
+impl From<core::types::EntryPointsByType> for EntryPointsByType {
+    fn from(value: core::types::EntryPointsByType) -> Self {
+        Self {
+            constructor: value
+                .constructor
+                .into_iter()
+                .map(|item| item.into())
+                .collect(),
+            external: value.external.into_iter().map(|item| item.into()).collect(),
+            l1_handler: value
+                .l1_handler
+                .into_iter()
+                .map(|item| item.into())
+                .collect(),
+        }
+    }
+}
+
+impl From<core::types::EntryPoint> for ContractEntryPoint {
+    fn from(value: core::types::EntryPoint) -> Self {
+        Self {
+            offset: value.offset,
+            selector: value.selector,
+        }
+    }
+}
+
+impl From<core::types::AbiEntry> for ContractAbiEntry {
+    fn from(value: core::types::AbiEntry) -> Self {
+        match value {
+            core::types::AbiEntry::Constructor(entry) => Self::Function(entry.into()),
+            core::types::AbiEntry::Function(entry) => Self::Function(entry.into()),
+            core::types::AbiEntry::Struct(entry) => Self::Struct(entry.into()),
+            core::types::AbiEntry::L1Handler(entry) => Self::Function(entry.into()),
+            core::types::AbiEntry::Event(entry) => Self::Event(entry.into()),
+        }
+    }
+}
+
+impl From<core::types::AbiConstructorEntry> for FunctionAbiEntry {
+    fn from(value: core::types::AbiConstructorEntry) -> Self {
+        Self {
+            r#type: FunctionAbiType::Constructor,
+            name: value.name,
+            inputs: value.inputs.into_iter().map(|item| item.into()).collect(),
+            outputs: value.outputs.into_iter().map(|item| item.into()).collect(),
+            state_mutability: None,
+        }
+    }
+}
+
+impl From<core::types::AbiFunctionEntry> for FunctionAbiEntry {
+    fn from(value: core::types::AbiFunctionEntry) -> Self {
+        Self {
+            r#type: FunctionAbiType::Function,
+            name: value.name,
+            inputs: value.inputs.into_iter().map(|item| item.into()).collect(),
+            outputs: value.outputs.into_iter().map(|item| item.into()).collect(),
+            state_mutability: value.state_mutability,
+        }
+    }
+}
+
+impl From<core::types::AbiStructEntry> for StructAbiEntry {
+    fn from(value: core::types::AbiStructEntry) -> Self {
+        Self {
+            r#type: StructAbiType::Struct,
+            name: value.name,
+            size: value.size,
+            members: value.members.into_iter().map(|item| item.into()).collect(),
+        }
+    }
+}
+
+impl From<core::types::AbiL1HandlerEntry> for FunctionAbiEntry {
+    fn from(value: core::types::AbiL1HandlerEntry) -> Self {
+        Self {
+            r#type: FunctionAbiType::L1Handler,
+            name: value.name,
+            inputs: value.inputs.into_iter().map(|item| item.into()).collect(),
+            outputs: value.outputs.into_iter().map(|item| item.into()).collect(),
+            state_mutability: None,
+        }
+    }
+}
+
+impl From<core::types::AbiEventEntry> for EventAbiEntry {
+    fn from(value: core::types::AbiEventEntry) -> Self {
+        Self {
+            r#type: EventAbiType::Event,
+            name: value.name,
+            keys: value.keys.into_iter().map(|item| item.into()).collect(),
+            data: value.data.into_iter().map(|item| item.into()).collect(),
+        }
+    }
+}
+
+impl From<core::types::AbiStructMember> for StructMember {
+    fn from(value: core::types::AbiStructMember) -> Self {
+        Self {
+            name: value.name,
+            r#type: value.r#type,
+            offset: value.offset,
+        }
+    }
+}
+
+impl From<core::types::AbiInput> for TypedParameter {
+    fn from(value: core::types::AbiInput) -> Self {
+        Self {
+            name: value.name,
+            r#type: value.r#type,
+        }
+    }
+}
+
+impl From<core::types::AbiOutput> for TypedParameter {
+    fn from(value: core::types::AbiOutput) -> Self {
+        Self {
+            name: value.name,
+            r#type: value.r#type,
+        }
+    }
+}
+
+impl From<core::types::AbiEventData> for TypedParameter {
+    fn from(value: core::types::AbiEventData) -> Self {
+        Self {
+            name: value.name,
+            r#type: value.r#type,
+        }
+    }
+}

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -1,10 +1,18 @@
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use starknet_core::{serde::unsigned_field_element::UfeHex, types::FieldElement};
+use starknet_core::{
+    serde::unsigned_field_element::UfeHex,
+    types::{FieldElement, StarknetError},
+};
 
 pub use starknet_core::types::L1Address as EthAddress;
 
 mod serde_impls;
+
+/// Temporary module before JSON-RPC becomes the de-facto provider:
+///
+/// https://github.com/xJonathanLEI/starknet-rs/issues/77#issuecomment-1150184364
+mod conversions;
 
 mod codegen;
 pub use codegen::*;
@@ -215,6 +223,7 @@ impl Serialize for BlockId {
         }
     }
 }
+
 impl AsRef<FunctionCall> for FunctionCall {
     fn as_ref(&self) -> &FunctionCall {
         self
@@ -224,5 +233,24 @@ impl AsRef<FunctionCall> for FunctionCall {
 impl AsRef<BroadcastedTransaction> for BroadcastedTransaction {
     fn as_ref(&self) -> &BroadcastedTransaction {
         self
+    }
+}
+
+impl From<ErrorCode> for StarknetError {
+    fn from(value: ErrorCode) -> Self {
+        match value {
+            ErrorCode::FailedToReceiveTransaction => Self::FailedToReceiveTxn,
+            ErrorCode::ContractNotFound => Self::ContractNotFound,
+            ErrorCode::InvalidMessageSelector => Self::InvalidMessageSelector,
+            ErrorCode::InvalidCallData => Self::InvalidCallData,
+            ErrorCode::BlockNotFound => Self::BlockNotFound,
+            ErrorCode::TransactionHashNotFound => Self::TxnHashNotFound,
+            ErrorCode::InvalidTransactionIndex => Self::InvalidTxnIndex,
+            ErrorCode::ClassHashNotFound => Self::ClassHashNotFound,
+            ErrorCode::PageSizeTooBig => Self::PageSizeTooBig,
+            ErrorCode::NoBlocks => Self::NoBlocks,
+            ErrorCode::InvalidContinuationToken => Self::InvalidContinuationToken,
+            ErrorCode::ContractError => Self::ContractError,
+        }
     }
 }

--- a/starknet-providers/src/jsonrpc/provider.rs
+++ b/starknet-providers/src/jsonrpc/provider.rs
@@ -1,0 +1,260 @@
+use crate::{
+    jsonrpc::{models::*, JsonRpcClient, JsonRpcClientError, JsonRpcError, JsonRpcTransport},
+    Provider, ProviderError,
+};
+
+use async_trait::async_trait;
+use starknet_core::types::{
+    AccountTransaction, AddTransactionResult, Block, BlockId, BlockTraces, CallContractResult,
+    CallFunction, CallL1Handler, ContractAddresses, ContractArtifact, ContractCode, FeeEstimate,
+    FieldElement, StateUpdate, TransactionInfo, TransactionReceipt, TransactionRequest,
+    TransactionSimulationInfo, TransactionStatusInfo, TransactionTrace,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum JsonRpcProviderError<T> {
+    #[error("Method not supported")]
+    NotSupported,
+    #[error(transparent)]
+    JsonError(serde_json::Error),
+    #[error(transparent)]
+    TransportError(T),
+    #[error(transparent)]
+    UnknownRpcError(JsonRpcError),
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<T> Provider for JsonRpcClient<T>
+where
+    T: JsonRpcTransport + Sync + Send,
+{
+    type Error = JsonRpcProviderError<T::Error>;
+
+    async fn add_transaction(
+        &self,
+        tx: TransactionRequest,
+    ) -> Result<AddTransactionResult, ProviderError<Self::Error>> {
+        match tx {
+            TransactionRequest::Declare(tx) => self
+                .add_declare_transaction(&tx.into())
+                .await
+                .map(|result| result.into())
+                .map_err(|err| err.into()),
+            TransactionRequest::InvokeFunction(tx) => self
+                .add_invoke_transaction(&tx.into())
+                .await
+                .map(|result| result.into())
+                .map_err(|err| err.into()),
+            TransactionRequest::DeployAccount(tx) => self
+                .add_deploy_account_transaction(&tx.into())
+                .await
+                .map(|result| result.into())
+                .map_err(|err| err.into()),
+        }
+    }
+
+    async fn get_contract_addresses(
+        &self,
+    ) -> Result<ContractAddresses, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn call_contract(
+        &self,
+        _call_function: CallFunction,
+        _block_identifier: BlockId,
+    ) -> Result<CallContractResult, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn estimate_fee(
+        &self,
+        tx: AccountTransaction,
+        block_identifier: BlockId,
+    ) -> Result<FeeEstimate, ProviderError<Self::Error>> {
+        let tx: BroadcastedTransaction = tx.into();
+        self.estimate_fee(tx, &block_identifier.into())
+            .await
+            .map(|est| est.into())
+            .map_err(|err| err.into())
+    }
+
+    async fn estimate_fee_bulk(
+        &self,
+        _txs: &[AccountTransaction],
+        _block_identifier: BlockId,
+    ) -> Result<Vec<FeeEstimate>, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn estimate_message_fee(
+        &self,
+        _call_l1_handler: CallL1Handler,
+        _block_identifier: BlockId,
+    ) -> Result<FeeEstimate, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn simulate_transaction(
+        &self,
+        _tx: AccountTransaction,
+        _block_identifier: BlockId,
+    ) -> Result<TransactionSimulationInfo, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_block(
+        &self,
+        _block_identifier: BlockId,
+    ) -> Result<Block, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_block_traces(
+        &self,
+        _block_identifier: BlockId,
+    ) -> Result<BlockTraces, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_state_update(
+        &self,
+        _block_identifier: BlockId,
+    ) -> Result<StateUpdate, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_code(
+        &self,
+        _contract_address: FieldElement,
+        _block_identifier: BlockId,
+    ) -> Result<ContractCode, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_full_contract(
+        &self,
+        _contract_address: FieldElement,
+        _block_identifier: BlockId,
+    ) -> Result<ContractArtifact, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_class_hash_at(
+        &self,
+        _contract_address: FieldElement,
+        _block_identifier: BlockId,
+    ) -> Result<FieldElement, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_class_by_hash(
+        &self,
+        _class_hash: FieldElement,
+    ) -> Result<ContractArtifact, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_storage_at(
+        &self,
+        _contract_address: FieldElement,
+        _key: FieldElement,
+        _block_identifier: BlockId,
+    ) -> Result<FieldElement, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_nonce(
+        &self,
+        contract_address: FieldElement,
+        block_identifier: BlockId,
+    ) -> Result<FieldElement, ProviderError<Self::Error>> {
+        self.get_nonce(&block_identifier.into(), contract_address)
+            .await
+            .map_err(|err| err.into())
+    }
+
+    async fn get_transaction_status(
+        &self,
+        _transaction_hash: FieldElement,
+    ) -> Result<TransactionStatusInfo, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_transaction(
+        &self,
+        _transaction_hash: FieldElement,
+    ) -> Result<TransactionInfo, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_transaction_receipt(
+        &self,
+        _transaction_hash: FieldElement,
+    ) -> Result<TransactionReceipt, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_transaction_trace(
+        &self,
+        _transaction_hash: FieldElement,
+    ) -> Result<TransactionTrace, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_block_hash_by_id(
+        &self,
+        _block_number: u64,
+    ) -> Result<FieldElement, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_block_id_by_hash(
+        &self,
+        _block_hash: FieldElement,
+    ) -> Result<u64, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_transaction_hash_by_id(
+        &self,
+        _transaction_number: u64,
+    ) -> Result<FieldElement, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_transaction_id_by_hash(
+        &self,
+        _transaction_hash: FieldElement,
+    ) -> Result<u64, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_last_batch_id(&self) -> Result<u64, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+
+    async fn get_l1_blockchain_id(&self) -> Result<u64, ProviderError<Self::Error>> {
+        Err(ProviderError::Other(Self::Error::NotSupported))
+    }
+}
+
+impl<T> From<JsonRpcClientError<T>> for ProviderError<JsonRpcProviderError<T>> {
+    fn from(value: JsonRpcClientError<T>) -> Self {
+        match value {
+            JsonRpcClientError::JsonError(err) => {
+                ProviderError::Other(JsonRpcProviderError::JsonError(err))
+            }
+            JsonRpcClientError::TransportError(err) => {
+                ProviderError::Other(JsonRpcProviderError::TransportError(err))
+            }
+            JsonRpcClientError::RpcError(err) => match err {
+                super::RpcError::Code(code) => ProviderError::StarknetError(code.into()),
+                super::RpcError::Unknown(err) => {
+                    ProviderError::Other(JsonRpcProviderError::UnknownRpcError(err))
+                }
+            },
+        }
+    }
+}

--- a/starknet-providers/src/jsonrpc/transports/mod.rs
+++ b/starknet-providers/src/jsonrpc/transports/mod.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 use serde::{de::DeserializeOwned, Serialize};
+use std::error::Error;
 
 use crate::jsonrpc::{JsonRpcMethod, JsonRpcResponse};
 
@@ -11,7 +12,7 @@ pub use http::HttpTransport;
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[auto_impl(&, Box, Arc)]
 pub trait JsonRpcTransport {
-    type Error;
+    type Error: Error + Send;
 
     async fn send_request<P, R>(
         &self,


### PR DESCRIPTION
This PR implements `Provider` for `JsonRpcClient`.

Note that this is just a partial implementation. Only 3 methods necessary for using it as an `Account` or `AccountFactory` backend have been implemented:

- `add_transaction`
- `estimate_fee`
- `get_nonce`

Calling any other method returns an unsupported error.