### PR TITLE
test: use infura for jsonrpc testing

### DIFF
--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -12,7 +12,8 @@ use url::Url;
 
 fn create_jsonrpc_client() -> JsonRpcClient<HttpTransport> {
     JsonRpcClient::new(HttpTransport::new(
-        Url::parse("https://starknet-goerli.rpc.zklend.com/").unwrap(),
+        Url::parse("https://starknet-goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161")
+            .unwrap(),
     ))
 }
 


### PR DESCRIPTION
Changes to use Infura for running the JSONRPC tests. The key is from Metamask and obviously it works for StarkNet RPC too :)