### PR TITLE
feat: add `must_use` on intermediate types

### DIFF
--- a/starknet-accounts/src/account/mod.rs
+++ b/starknet-accounts/src/account/mod.rs
@@ -68,6 +68,7 @@ pub trait ConnectedAccount: Account {
 }
 
 /// An intermediate type allowing users to optionally specify `nonce` and/or `max_fee`.
+#[must_use]
 #[derive(Debug)]
 pub struct Execution<'a, A> {
     account: &'a A,
@@ -78,6 +79,7 @@ pub struct Execution<'a, A> {
 }
 
 /// An intermediate type allowing users to optionally specify `nonce` and/or `max_fee`.
+#[must_use]
 #[derive(Debug)]
 pub struct Declaration<'a, A> {
     account: &'a A,

--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -69,6 +69,7 @@ pub trait AccountFactory: Sized {
 }
 
 /// An intermediate type allowing users to optionally specify `nonce` and/or `max_fee`.
+#[must_use]
 #[derive(Debug)]
 pub struct AccountDeployment<'f, F> {
     factory: &'f F,


### PR DESCRIPTION
This PR helps make sure developers don't forget to call `send()` on the intermediate types resulting from `execute()`, `declare()`, and `deploy()`. It's now a compiler warning to not use them.