### PR TITLE
chore: change "StarkNet" to "Starknet"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/starknet"
 repository = "https://github.com/xJonathanLEI/starknet-rs"
 homepage = "https://starknet.rs/"
 description = """
-Complete StarkNet library in Rust
+Complete Starknet library in Rust
 """
 keywords = ["ethereum", "starknet", "web3"]
 exclude = [".github/**", "images/**"]

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
   <h1 align="center">starknet-rs</h1>
 </p>
 
-**Complete StarkNet library in Rust**
+**Complete Starknet library in Rust**
 
-![starknet-version-v0.10.3](https://img.shields.io/badge/StarkNet_Version-v0.10.3-2ea44f?logo=ethereum)
+![starknet-version-v0.10.3](https://img.shields.io/badge/Starknet_Version-v0.10.3-2ea44f?logo=ethereum)
 [![jsonrpc-spec-v0.2.1](https://img.shields.io/badge/JSON--RPC-v0.2.1-2ea44f?logo=ethereum)](https://github.com/starkware-libs/starknet-specs/tree/v0.2.1)
 [![linting-badge](https://github.com/xJonathanLEI/starknet-rs/actions/workflows/lint.yaml/badge.svg?branch=master)](https://github.com/xJonathanLEI/starknet-rs/actions/workflows/lint.yaml)
 [![crates-badge](https://img.shields.io/crates/v/starknet.svg)](https://crates.io/crates/starknet)
@@ -43,14 +43,14 @@ starknet = { git = "https://github.com/xJonathanLEI/starknet-rs" }
 This workspace contains the following crates:
 
 - `starknet`: Re-export of other sub-crates (recommended)
-- `starknet-core`: Core data structures for interacting with StarkNet
-- `starknet-providers`: Abstraction and implementation of clients for interacting with StarkNet nodes and sequencers
-- `starknet-contract`: Types for deploying and interacting with StarkNet smart contracts
-- `starknet-crypto`: **Low-level** cryptography utilities for StarkNet
-- `starknet-signers`: StarkNet signer implementations
-- `starknet-accounts`: Types for handling StarkNet account abstraction
-- `starknet-ff`: StarkNet field element type
-- `starknet-curve`: StarkNet curve operations
+- `starknet-core`: Core data structures for interacting with Starknet
+- `starknet-providers`: Abstraction and implementation of clients for interacting with Starknet nodes and sequencers
+- `starknet-contract`: Types for deploying and interacting with Starknet smart contracts
+- `starknet-crypto`: **Low-level** cryptography utilities for Starknet
+- `starknet-signers`: Starknet signer implementations
+- `starknet-accounts`: Types for handling Starknet account abstraction
+- `starknet-ff`: Starknet field element type
+- `starknet-curve`: Starknet curve operations
 - `starknet-macros`: Useful macros for using the `starknet` crates
 
 ## WebAssembly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! # Complete StarkNet library in Rust
+//! # Complete Starknet library in Rust
 //!
 //! > _Note that `starknet-rs` is still experimental. Breaking changes will be made before the first
 //! stable release. Use at your own risk._
@@ -6,11 +6,11 @@
 //! > _The underlying cryptography library `starknet-crypto` does NOT provide constant-time
 //! guarantees._
 //!
-//! `starknet-rs` is a Rust client library for StarkNet. The current version offers full API
+//! `starknet-rs` is a Rust client library for Starknet. The current version offers full API
 //! coverage of the sequencer gateway and feeder gateway.
 //!
 //! Future versions of `starknet-rs` will support all common features required for buildling client
-//! software for StarkNet:
+//! software for Starknet:
 //!
 //! - full JSON-RPC API coverage as full node implementations become available
 //! - contract deployment
@@ -19,16 +19,16 @@
 //!
 //! ## `core`
 //!
-//! Contains all the [necessary data structures](core::types) for interacting with StarkNet.
+//! Contains all the [necessary data structures](core::types) for interacting with Starknet.
 //!
 //! ## `providers`
 //!
-//! The [`Provider`](providers::Provider) trait provides abstraction over StarkNet data providers.
+//! The [`Provider`](providers::Provider) trait provides abstraction over Starknet data providers.
 //! Currently the only implementation is [`SequencerGatewayProvider`](providers::SequencerGatewayProvider).
 //!
 //! ## `contract`
 //!
-//! Contains all the types for deploying and interacting with StarkNet smart contracts.
+//! Contains all the types for deploying and interacting with Starknet smart contracts.
 //!
 //! ## `signers`
 //!
@@ -36,7 +36,7 @@
 //!
 //! ## `accounts`
 //!
-//! Contains types for using account abstraction on StarkNet.
+//! Contains types for using account abstraction on Starknet.
 //!
 //! ## `macros`
 //!

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/xJonathanLEI/starknet-rs"
 homepage = "https://starknet.rs/"
 description = """
-Types for handling StarkNet account abstraction
+Types for handling Starknet account abstraction
 """
 keywords = ["ethereum", "starknet", "web3"]
 

--- a/starknet-accounts/README.md
+++ b/starknet-accounts/README.md
@@ -1,1 +1,1 @@
-# Types for handling StarkNet account abstraction
+# Types for handling Starknet account abstraction

--- a/starknet-accounts/src/account/mod.rs
+++ b/starknet-accounts/src/account/mod.rs
@@ -11,7 +11,7 @@ use std::{error::Error, sync::Arc};
 mod declaration;
 mod execution;
 
-/// The standard StarkNet account contract interface. It makes no assumption about the underlying
+/// The standard Starknet account contract interface. It makes no assumption about the underlying
 /// signer or provider. Account implementations that come with an active connection to the network
 /// should also implement [ConnectedAccount] for useful functionalities like estimating fees and
 /// sending transactions.

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/xJonathanLEI/starknet-rs"
 homepage = "https://starknet.rs/"
 description = """
-Types and utilities for StarkNet smart contract deployment and interaction
+Types and utilities for Starknet smart contract deployment and interaction
 """
 keywords = ["ethereum", "starknet", "web3"]
 

--- a/starknet-core/README.md
+++ b/starknet-core/README.md
@@ -1,4 +1,4 @@
-# StarkNet data types
+# Starknet data types
 
 // TODO: add `starknet-core` documentation
 

--- a/starknet-core/src/types/block.rs
+++ b/starknet-core/src/types/block.rs
@@ -133,7 +133,7 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_block_deser_with_events() {
-        // has events introduced with StarkNet v0.7.0
+        // has events introduced with Starknet v0.7.0
         let raw = include_str!("../../test-data/raw_gateway_responses/get_block/3_with_events.txt");
 
         let block: Block = serde_json::from_str(raw).unwrap();
@@ -162,7 +162,7 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_block_deser_new_attributes_0_8_2() {
-        // This block contains new fields introduced in StarkNet v0.8.2
+        // This block contains new fields introduced in Starknet v0.8.2
         let new_block: Block = serde_json::from_str(include_str!(
             "../../test-data/raw_gateway_responses/get_block/6_with_sequencer_address.txt"
         ))
@@ -179,7 +179,7 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_block_deser_new_attributes_0_9_1() {
-        // This block contains new fields introduced in StarkNet v0.9.1
+        // This block contains new fields introduced in Starknet v0.9.1
         let new_block: Block = serde_json::from_str(include_str!(
             "../../test-data/raw_gateway_responses/get_block/8_with_starknet_version.txt"
         ))

--- a/starknet-core/src/types/fee.rs
+++ b/starknet-core/src/types/fee.rs
@@ -11,7 +11,7 @@ pub struct FeeEstimate {
     pub gas_usage: u64,
 }
 
-/// Represents the information regarding a StarkNet transaction's simulation.
+/// Represents the information regarding a Starknet transaction's simulation.
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct TransactionSimulationInfo {

--- a/starknet-core/src/types/trace.rs
+++ b/starknet-core/src/types/trace.rs
@@ -12,7 +12,7 @@ pub struct BlockTraces {
     pub traces: Vec<TransactionTraceWithHash>,
 }
 
-/// Represents the trace of a StarkNet transaction execution, including internal calls.
+/// Represents the trace of a Starknet transaction execution, including internal calls.
 #[serde_as]
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_trace_deser_new_attributes_0_9_0() {
-        // This tx contains new fields introduced in StarkNet v0.9.0
+        // This tx contains new fields introduced in Starknet v0.9.0
         let new_tx: TransactionTrace = serde_json::from_str(include_str!(
             "../../test-data/raw_gateway_responses/get_transaction_trace/3_with_call_type.txt"
         ))

--- a/starknet-core/src/types/transaction_request.rs
+++ b/starknet-core/src/types/transaction_request.rs
@@ -41,7 +41,7 @@ pub enum TransactionRequest {
     DeployAccount(DeployAccountTransaction),
 }
 
-/// Represents a transaction in the StarkNet network that is originated from an action of an
+/// Represents a transaction in the Starknet network that is originated from an action of an
 /// account.
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
@@ -51,7 +51,7 @@ pub enum AccountTransaction {
     DeployAccount(DeployAccountTransaction),
 }
 
-/// Represents a contract function call in the StarkNet network.
+/// Represents a contract function call in the Starknet network.
 #[serde_as]
 #[derive(Debug, Serialize)]
 pub struct CallFunction {
@@ -62,7 +62,7 @@ pub struct CallFunction {
     pub calldata: Vec<FieldElement>,
 }
 
-/// Represents an L1 handler call in the StarkNet network.
+/// Represents an L1 handler call in the Starknet network.
 #[serde_as]
 #[derive(Debug, Serialize)]
 pub struct CallL1Handler {

--- a/starknet-core/src/utils.rs
+++ b/starknet-core/src/utils.rs
@@ -43,7 +43,7 @@ pub enum ParseCairoShortStringError {
     UnexpectedNullTerminator,
 }
 
-/// A variant of eth-keccak that computes a value that fits in a StarkNet field element.
+/// A variant of eth-keccak that computes a value that fits in a Starknet field element.
 pub fn starknet_keccak(data: &[u8]) -> FieldElement {
     let mut hasher = Keccak256::new();
     hasher.update(data);

--- a/starknet-core/test-data/raw_gateway_responses/generate_responses.sh
+++ b/starknet-core/test-data/raw_gateway_responses/generate_responses.sh
@@ -4,7 +4,7 @@
 curl -o ./get_block/1_with_transactions.txt "https://alpha4.starknet.io/feeder_gateway/get_block?blockNumber=39232"
 
 # ./get_block/2_with_messages.txt
-# (Changed from 39227 to 122387 due to a bug in StarkNet)
+# (Changed from 39227 to 122387 due to a bug in Starknet)
 curl -o ./get_block/2_with_messages.txt "https://alpha4.starknet.io/feeder_gateway/get_block?blockNumber=122387"
 
 # ./get_block/3_with_events.txt

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/xJonathanLEI/starknet-rs"
 homepage = "https://starknet.rs/"
 description = """
-Low-level cryptography utilities for StarkNet
+Low-level cryptography utilities for Starknet
 """
 keywords = ["ethereum", "starknet", "web3"]
 

--- a/starknet-crypto/README.md
+++ b/starknet-crypto/README.md
@@ -1,6 +1,6 @@
-# Low-level cryptography utilities for StarkNet
+# Low-level cryptography utilities for Starknet
 
-`starknet-crypto` contains utilities for performing **low-level** cryptographic operations in StarkNet.
+`starknet-crypto` contains utilities for performing **low-level** cryptographic operations in Starknet.
 
 > _You're advised to use high-level crypto utilities implemented by the `starknet-core` crate (or use it through the `starknet::core` re-export) if you're not familiar with cryptographic primitives. Using these low-level functions incorrectly could result in leaking your private key, for example._
 

--- a/starknet-curve/README.md
+++ b/starknet-curve/README.md
@@ -1,1 +1,1 @@
-# StarkNet Curve
+# Starknet Curve

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/xJonathanLEI/starknet-rs"
 homepage = "https://starknet.rs/"
 description = """
-StarkNet field element type
+Starknet field element type
 """
 keywords = ["ethereum", "starknet", "web3"]
 

--- a/starknet-ff/README.md
+++ b/starknet-ff/README.md
@@ -1,1 +1,1 @@
-# StarkNet field element type
+# Starknet field element type

--- a/starknet-providers/README.md
+++ b/starknet-providers/README.md
@@ -1,3 +1,3 @@
-# Clients for interacting with StarkNet nodes and sequencers
+# Clients for interacting with Starknet nodes and sequencers
 
 // TODO: add `starknet-providers` documentation

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -299,7 +299,7 @@ where
         .await
     }
 
-    /// Call a starknet function without creating a StarkNet transaction
+    /// Call a starknet function without creating a Starknet transaction
     pub async fn call<R>(
         &self,
         request: R,
@@ -320,7 +320,7 @@ where
             .0)
     }
 
-    /// Estimate the fee for a given StarkNet transaction
+    /// Estimate the fee for a given Starknet transaction
     pub async fn estimate_fee<R>(
         &self,
         request: R,
@@ -352,7 +352,7 @@ where
             .await
     }
 
-    /// Return the currently configured StarkNet chain id
+    /// Return the currently configured Starknet chain id
     pub async fn chain_id(&self) -> Result<FieldElement, JsonRpcClientError<T::Error>> {
         Ok(self
             .send_request::<_, Felt>(JsonRpcMethod::ChainId, ())

--- a/starknet-providers/src/jsonrpc/models/codegen.rs
+++ b/starknet-providers/src/jsonrpc/models/codegen.rs
@@ -3,7 +3,7 @@
 //     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen
 
 // Code generated with version:
-//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen#57a9bd34cd4541fa8e2b2ae7aeb100140800c723
+//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen#a2761a3406c257736b6306b96e38696e1b670d17
 
 // Code generation requested but not implemented for these types:
 // - `BLOCK_ID`
@@ -57,7 +57,7 @@ pub struct EmittedEvent {
     pub transaction_hash: FieldElement,
 }
 
-/// A StarkNet event.
+/// A Starknet event.
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
@@ -182,7 +182,7 @@ pub struct BlockWithTxHashes {
     pub new_root: FieldElement,
     /// The time in which the block was created, encoded in Unix time
     pub timestamp: u64,
-    /// The StarkNet identity of the sequencer submitting this block
+    /// The Starknet identity of the sequencer submitting this block
     #[serde_as(as = "UfeHex")]
     pub sequencer_address: FieldElement,
     /// The hashes of the transactions included in this block
@@ -208,7 +208,7 @@ pub struct BlockWithTxs {
     pub new_root: FieldElement,
     /// The time in which the block was created, encoded in Unix time
     pub timestamp: u64,
-    /// The StarkNet identity of the sequencer submitting this block
+    /// The Starknet identity of the sequencer submitting this block
     #[serde_as(as = "UfeHex")]
     pub sequencer_address: FieldElement,
     /// The transactions in this block
@@ -226,7 +226,7 @@ pub struct PendingBlockWithTxHashes {
     pub transactions: Vec<FieldElement>,
     /// The time in which the block was created, encoded in Unix time
     pub timestamp: u64,
-    /// The StarkNet identity of the sequencer submitting this block
+    /// The Starknet identity of the sequencer submitting this block
     #[serde_as(as = "UfeHex")]
     pub sequencer_address: FieldElement,
     /// The hash of this block's parent
@@ -244,7 +244,7 @@ pub struct PendingBlockWithTxs {
     pub transactions: Vec<Transaction>,
     /// The time in which the block was created, encoded in Unix time
     pub timestamp: u64,
-    /// The StarkNet identity of the sequencer submitting this block
+    /// The Starknet identity of the sequencer submitting this block
     #[serde_as(as = "UfeHex")]
     pub sequencer_address: FieldElement,
     /// The hash of this block's parent
@@ -663,7 +663,7 @@ pub struct FunctionCall {
     pub calldata: Vec<FieldElement>,
 }
 
-/// The definition of a StarkNet contract class.
+/// The definition of a Starknet contract class.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct ContractClass {

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/xJonathanLEI/starknet-rs"
 homepage = "https://starknet.rs/"
 description = """
-StarkNet signer implementations
+Starknet signer implementations
 """
 keywords = ["ethereum", "starknet", "web3"]
 

--- a/starknet-signers/README.md
+++ b/starknet-signers/README.md
@@ -1,1 +1,1 @@
-# StarkNet signer implementations
+# Starknet signer implementations


### PR DESCRIPTION
Changes the spelling of "StarkNet" from "StarkNet" to "Starknet" everywhere in the codebase following the recommendations in [this SNIP](https://community.starknet.io/t/snip-naming-convention-starknet-not-starknet).