### PR TITLE
chore: bump some crypto-related deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,15 +166,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
@@ -371,9 +362,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.2"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -389,16 +380,6 @@ checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
-dependencies = [
- "generic-array",
- "subtle",
 ]
 
 [[package]]
@@ -502,12 +483,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.2",
+ "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -712,12 +694,11 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac",
- "digest 0.9.0",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1049,12 +1030,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "os_str_bytes"
 version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint",
  "hmac",
@@ -1517,15 +1492,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1534,7 +1507,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.6",
  "keccak",
 ]
 

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -16,13 +16,13 @@ keywords = ["ethereum", "starknet", "web3"]
 starknet-crypto-codegen = { version = "0.1.0", path = "../starknet-crypto-codegen" }
 starknet-curve = { version = "0.1.0", path = "../starknet-curve" }
 starknet-ff = { version = "0.2.0", path = "../starknet-ff" }
-crypto-bigint = "0.3.2"
-hmac = "0.11.0"
+crypto-bigint = "0.4.9"
+hmac = "0.12.1"
 num-bigint = "0.4.3"
 num-integer = "0.1.44"
 num-traits = "0.2.14"
-rfc6979 = "0.1.0"
-sha2 = "0.9.9"
+rfc6979 = "0.3.1"
+sha2 = "0.10.6"
 thiserror = "1.0.30"
 zeroize = "1.5.0"
 hex = "0.4.3"

--- a/starknet-crypto/src/rfc6979.rs
+++ b/starknet-crypto/src/rfc6979.rs
@@ -1,5 +1,6 @@
 use crypto_bigint::{ArrayEncoding, ByteArray, Integer, U256};
-use hmac::digest::{BlockInput, FixedOutput, Reset, Update};
+use hmac::digest::Digest;
+use sha2::digest::{crypto_common::BlockSizeUser, FixedOutputReset, HashMarker};
 use zeroize::{Zeroize, Zeroizing};
 
 use crate::FieldElement;
@@ -58,7 +59,7 @@ pub fn generate_k(
 #[inline]
 fn generate_k_shifted<D, I>(x: &I, n: &I, h: &ByteArray<I>, data: &[u8]) -> Zeroizing<I>
 where
-    D: FixedOutput<OutputSize = I::ByteSize> + BlockInput + Clone + Default + Reset + Update,
+    D: Default + Digest + BlockSizeUser + FixedOutputReset + HashMarker,
     I: ArrayEncoding + Integer + Zeroize,
 {
     let mut x = x.to_be_byte_array();

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 [dependencies]
 ark-ff = "0.3.0"
 bigdecimal = { version = "0.3.0", optional = true }
-crypto-bigint = "0.3.2"
+crypto-bigint = "0.4.9"
 hex = "0.4.3"
 num-bigint = { version = "0.4.3", optional = true }
 serde = "1.0.152"

--- a/starknet-ff/src/lib.rs
+++ b/starknet-ff/src/lib.rs
@@ -369,9 +369,9 @@ impl Display for FieldElement {
 
         loop {
             let digit = if current < ten {
-                current.to_uint_array()[0] as u8
+                current.to_words()[0] as u8
             } else {
-                (current.checked_rem(&ten)).unwrap().to_uint_array()[0] as u8
+                (current.checked_rem(&ten)).unwrap().to_words()[0] as u8
             };
             buf[i] = digit + b'0';
             current = current.checked_div(&ten).unwrap();
@@ -577,12 +577,12 @@ impl TryFrom<FieldElement> for u64 {
 impl From<&FieldElement> for U256 {
     #[cfg(target_pointer_width = "64")]
     fn from(value: &FieldElement) -> Self {
-        U256::from_uint_array(value.inner.into_repr().0)
+        U256::from_words(value.inner.into_repr().0)
     }
 
     #[cfg(target_pointer_width = "32")]
     fn from(value: &FieldElement) -> Self {
-        U256::from_uint_array(unsafe {
+        U256::from_words(unsafe {
             std::mem::transmute::<[u64; 4], [u32; 8]>(value.inner.into_repr().0)
         })
     }
@@ -602,13 +602,13 @@ fn u256_to_biginteger256(num: &U256) -> BigInteger256 {
 #[cfg(target_pointer_width = "64")]
 #[inline]
 fn u256_to_u64_array(num: &U256) -> [u64; 4] {
-    num.to_uint_array()
+    num.to_words()
 }
 
 #[cfg(target_pointer_width = "32")]
 #[inline]
 fn u256_to_u64_array(num: &U256) -> [u64; 4] {
-    unsafe { std::mem::transmute::<[u32; 8], [u64; 4]>(num.to_uint_array()) }
+    unsafe { std::mem::transmute::<[u32; 8], [u64; 4]>(num.to_words()) }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Keeps our crypto dependencies up to date (`ark-ff` 0.4.0 will be handled in a separate PR).