### PR TITLE
chore: bump `ark-ff` to 0.4.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -101,23 +101,23 @@ jobs:
 
       - name: Run starknet-ff tests
         run: |
-          (cd ./starknet-ff && wasm-pack test --node)
+          (cd ./starknet-ff && wasm-pack test --release --node)
 
       - name: Run starknet-crypto tests
         run: |
-          (cd ./starknet-crypto && wasm-pack test --node)
+          (cd ./starknet-crypto && wasm-pack test --release --node)
 
       - name: Run starknet-core tests
         run: |
-          (cd ./starknet-core && wasm-pack test --node)
+          (cd ./starknet-core && wasm-pack test --release --node)
 
       - name: Run starknet-signers tests
         run: |
-          (cd ./starknet-signers && wasm-pack test --node)
+          (cd ./starknet-signers && wasm-pack test --release --node)
 
       - name: Run starknet-macros tests
         run: |
-          (cd ./starknet-macros && wasm-pack test --node)
+          (cd ./starknet-macros && wasm-pack test --release --node)
 
   no-std-build:
     name: no-std build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,15 +25,17 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "ark-ff"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
  "ark-std",
  "derivative",
+ "digest",
+ "itertools",
  "num-bigint",
  "num-traits",
  "paste",
@@ -43,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
  "quote",
  "syn",
@@ -53,31 +55,33 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-macros"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint",
  "num-traits",
+ "proc-macro2",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "ark-serialize"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std",
- "digest 0.9.0",
+ "digest",
+ "num-bigint",
 ]
 
 [[package]]
 name = "ark-std"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
  "rand",
@@ -474,15 +478,6 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
@@ -698,7 +693,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.6",
+ "digest",
 ]
 
 [[package]]
@@ -1097,15 +1092,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,9 +1316,9 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
@@ -1403,21 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
@@ -1498,7 +1472,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest",
 ]
 
 [[package]]
@@ -1507,7 +1481,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
 dependencies = [
- "digest 0.10.6",
+ "digest",
  "keccak",
 ]
 
@@ -1968,12 +1942,6 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uint"

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["ethereum", "starknet", "web3", "no_std"]
 all-features = true
 
 [dependencies]
-ark-ff = { version = "0.3.0", default-features = false }
+ark-ff = { version = "0.4.2", default-features = false }
 crypto-bigint = { version = "0.4.9", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 serde = { version = "1.0.152", optional = true, default-features = false }

--- a/starknet-ff/src/fr.rs
+++ b/starknet-ff/src/fr.rs
@@ -1,62 +1,8 @@
-use ark_ff::{
-    biginteger::BigInteger256,
-    fields::{FftParameters, Fp256Parameters, FpParameters},
-};
+use ark_ff::fields::{Fp256, MontBackend, MontConfig};
 
-pub struct FrParameters;
+pub type Fr = Fp256<MontBackend<FrConfig, 4>>;
 
-impl Fp256Parameters for FrParameters {}
-
-impl FftParameters for FrParameters {
-    type BigInt = BigInteger256;
-
-    const TWO_ADICITY: u32 = 192;
-
-    const TWO_ADIC_ROOT_OF_UNITY: BigInteger256 = BigInteger256::new([
-        0x4106bccd64a2bdd8,
-        0xaaada25731fe3be9,
-        0xa35c5be60505574,
-        0x7222e32c47afc26,
-    ]);
-}
-
-impl FpParameters for FrParameters {
-    const MODULUS: BigInteger256 = BigInteger256::new([0x1, 0x0, 0x0, 0x800000000000011]);
-
-    const MODULUS_BITS: u32 = 252;
-
-    const CAPACITY: u32 = Self::MODULUS_BITS - 1;
-
-    const REPR_SHAVE_BITS: u32 = 4;
-
-    const R: BigInteger256 = BigInteger256::new([
-        0xffffffffffffffe1,
-        0xffffffffffffffff,
-        0xffffffffffffffff,
-        0x7fffffffffffdf0,
-    ]);
-
-    const R2: BigInteger256 = BigInteger256::new([
-        0xfffffd737e000401,
-        0x1330fffff,
-        0xffffffffff6f8000,
-        0x7ffd4ab5e008810,
-    ]);
-
-    const INV: u64 = 0xffffffffffffffff;
-
-    const GENERATOR: BigInteger256 = BigInteger256::new([
-        0xffffffffffffffa1,
-        0xffffffffffffffff,
-        0xffffffffffffffff,
-        0x7fffffffffff9b0,
-    ]);
-
-    const MODULUS_MINUS_ONE_DIV_TWO: BigInteger256 =
-        BigInteger256::new([0x0, 0x0, 0x8000000000000000, 0x400000000000008]);
-
-    const T: BigInteger256 = BigInteger256::new([0x800000000000011, 0x0, 0x0, 0x0]);
-
-    const T_MINUS_ONE_DIV_TWO: BigInteger256 =
-        BigInteger256::new([0x400000000000008, 0x0, 0x0, 0x0]);
-}
+#[derive(MontConfig)]
+#[modulus = "3618502788666131213697322783095070105623107215331596699973092056135872020481"]
+#[generator = "3"]
+pub struct FrConfig;


### PR DESCRIPTION
This PR bumps `ark-ff` to 0.4.0 and resolves all the breaking changes.