### PR TITLE
Add no_std compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,6 +1668,8 @@ name = "starknet-ff"
 version = "0.2.0"
 dependencies = [
  "ark-ff",
+ "ark-serialize",
+ "ark-std",
  "bigdecimal",
  "crypto-bigint",
  "getrandom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,7 +1668,6 @@ name = "starknet-ff"
 version = "0.2.0"
 dependencies = [
  "ark-ff",
- "ark-serialize",
  "ark-std",
  "bigdecimal",
  "crypto-bigint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
- "rand_core",
  "subtle",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,6 +1574,7 @@ name = "starknet-accounts"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "no-std-compat",
  "serde_json",
  "starknet-core",
  "starknet-providers",
@@ -1580,6 +1587,7 @@ dependencies = [
 name = "starknet-contract"
 version = "0.1.0"
 dependencies = [
+ "no-std-compat",
  "rand",
  "serde",
  "serde_json",
@@ -1601,6 +1609,7 @@ dependencies = [
  "ethereum-types",
  "flate2",
  "hex",
+ "no-std-compat",
  "serde",
  "serde_json",
  "serde_with",
@@ -1621,6 +1630,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "hmac",
+ "no-std-compat",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1640,6 +1650,7 @@ dependencies = [
 name = "starknet-crypto-codegen"
 version = "0.1.0"
 dependencies = [
+ "no-std-compat",
  "starknet-curve",
  "starknet-ff",
  "syn",
@@ -1649,6 +1660,7 @@ dependencies = [
 name = "starknet-curve"
 version = "0.1.0"
 dependencies = [
+ "no-std-compat",
  "starknet-ff",
 ]
 
@@ -1661,6 +1673,7 @@ dependencies = [
  "crypto-bigint",
  "getrandom",
  "hex",
+ "no-std-compat",
  "num-bigint",
  "serde",
  "thiserror",
@@ -1671,6 +1684,7 @@ dependencies = [
 name = "starknet-macros"
 version = "0.1.0"
 dependencies = [
+ "no-std-compat",
  "starknet-core",
  "syn",
 ]
@@ -1682,6 +1696,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "flate2",
+ "no-std-compat",
  "reqwest",
  "serde",
  "serde_json",
@@ -1698,6 +1713,7 @@ name = "starknet-signers"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "no-std-compat",
  "starknet-core",
  "starknet-crypto",
  "thiserror",

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -18,6 +18,14 @@ starknet-providers = { version = "0.2.0", path = "../starknet-providers" }
 starknet-signers = { version = "0.1.0", path = "../starknet-signers" }
 async-trait = "0.1.52"
 thiserror = "1.0.30"
+no-std-compat = { version = "0.4.1", features = [
+    "alloc",
+    "compat_macros",
+    "std",
+] }
+[features]
+default = [ "std" ] # Default to using the std
+std = [ "no-std-compat/std" ]
 
 [dev-dependencies]
 serde_json = "1.0.74"

--- a/starknet-accounts/src/account/execution.rs
+++ b/starknet-accounts/src/account/execution.rs
@@ -3,7 +3,6 @@ use super::{
     RawExecution,
 };
 use crate::Call;
-
 use starknet_core::{
     crypto::compute_hash_on_elements,
     types::{
@@ -12,6 +11,7 @@ use starknet_core::{
     },
 };
 use starknet_providers::Provider;
+use std::prelude::v1::*;
 
 /// Cairo string for "invoke"
 const PREFIX_INVOKE: FieldElement = FieldElement::from_mont([

--- a/starknet-accounts/src/account/mod.rs
+++ b/starknet-accounts/src/account/mod.rs
@@ -6,8 +6,8 @@ use starknet_core::types::{
     BlockId, ContractArtifact, FieldElement,
 };
 use starknet_providers::{Provider, ProviderError};
+use std::prelude::v1::*;
 use std::{error::Error, sync::Arc};
-
 mod declaration;
 mod execution;
 

--- a/starknet-accounts/src/call.rs
+++ b/starknet-accounts/src/call.rs
@@ -1,5 +1,5 @@
 use starknet_core::types::FieldElement;
-
+use std::prelude::v1::*;
 #[derive(Debug, Clone)]
 pub struct Call {
     pub to: FieldElement,

--- a/starknet-accounts/src/factory/argent.rs
+++ b/starknet-accounts/src/factory/argent.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use starknet_core::types::FieldElement;
 use starknet_providers::Provider;
 use starknet_signers::Signer;
-
+use std::prelude::v1::*;
 /// Selector for "initialize"
 const SELECTOR_INITIALIZE: FieldElement = FieldElement::from_mont([
     14382173896205878522,

--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -10,6 +10,7 @@ use starknet_core::{
 };
 use starknet_providers::{Provider, ProviderError};
 use std::error::Error;
+use std::prelude::v1::*;
 
 pub mod argent;
 pub mod open_zeppelin;

--- a/starknet-accounts/src/factory/open_zeppelin.rs
+++ b/starknet-accounts/src/factory/open_zeppelin.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use starknet_core::types::FieldElement;
 use starknet_providers::Provider;
 use starknet_signers::Signer;
-
+use std::prelude::v1::*;
 pub struct OpenZeppelinAccountFactory<S, P> {
     class_hash: FieldElement,
     chain_id: FieldElement,

--- a/starknet-accounts/src/lib.rs
+++ b/starknet-accounts/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+extern crate no_std_compat as std;
+
 mod account;
 pub use account::{
     Account, AccountError, ConnectedAccount, Declaration, Execution, PreparedDeclaration,

--- a/starknet-accounts/src/single_owner.rs
+++ b/starknet-accounts/src/single_owner.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use starknet_core::types::{contract_artifact::ComputeClassHashError, FieldElement};
 use starknet_providers::Provider;
 use starknet_signers::Signer;
-
+use std::prelude::v1::*;
 #[derive(Debug, Clone)]
 pub struct SingleOwnerAccount<P, S>
 where

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -20,6 +20,14 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.74"
 serde_with = "2.2.0"
 thiserror = "1.0.30"
+no-std-compat = { version = "0.4.1", features = [
+    "alloc",
+    "compat_macros",
+    "std",
+] }
+[features]
+default = [ "std" ] # Default to using the std
+std = [ "no-std-compat/std" ]
 
 [dev-dependencies]
 rand = { version = "0.8.5", features=["std_rng"] }

--- a/starknet-contract/src/factory.rs
+++ b/starknet-contract/src/factory.rs
@@ -1,6 +1,6 @@
 use starknet_accounts::{Account, Call, Execution};
 use starknet_core::types::FieldElement;
-
+use std::prelude::v1::*;
 /// The default UDC address: 0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf.
 const UDC_ADDRESS: FieldElement = FieldElement::from_mont([
     15144800532519055890,

--- a/starknet-contract/src/lib.rs
+++ b/starknet-contract/src/lib.rs
@@ -1,2 +1,6 @@
+#![no_std]
+
+extern crate no_std_compat as std;
+
 mod factory;
 pub use factory::ContractFactory;

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -21,7 +21,7 @@ starknet-ff = { version = "0.2.0", path = "../starknet-ff", default-features = f
 base64 = "0.13.0"
 ethereum-types = "0.12.1"
 flate2 = "1.0.24"
-hex = "0.4.3"
+hex = {version = "0.4.3", default-features = false}
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.74", features = ["arbitrary_precision"] }
 serde_with = "2.2.0"

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -27,6 +27,11 @@ serde_json = { version = "1.0.74", features = ["arbitrary_precision"] }
 serde_with = "2.2.0"
 sha3 = "0.10.0"
 thiserror = "1.0.30"
+no-std-compat = { version = "0.4.1", features = [
+    "alloc",
+    "compat_macros",
+    "std",
+] }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", default-features = false }
@@ -39,6 +44,7 @@ wasm-bindgen-test = "0.3.29"
 default = ["bigdecimal"]
 bigdecimal = ["starknet-ff/bigdecimal"]
 no_unknown_fields = []
+std = [ "no-std-compat/std" ]
 
 [[bench]]
 name = "class_hash"

--- a/starknet-core/src/lib.rs
+++ b/starknet-core/src/lib.rs
@@ -1,5 +1,8 @@
 #![allow(clippy::comparison_chain)]
 #![doc = include_str!("../README.md")]
+#![no_std]
+
+extern crate no_std_compat as std;
 
 pub mod serde;
 

--- a/starknet-core/src/serde/byte_array.rs
+++ b/starknet-core/src/serde/byte_array.rs
@@ -1,6 +1,6 @@
 pub mod base64 {
     use serde::{Deserialize, Deserializer, Serializer};
-
+    use std::prelude::v1::*;
     pub fn serialize<S, T>(value: T, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/starknet-core/src/serde/json/mod.rs
+++ b/starknet-core/src/serde/json/mod.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use serde_json::{ser::Formatter, Serializer};
 use std::io;
-
+use std::prelude::v1::*;
 /// A `serde_json` formatter that mimicks the output of `json.dumps()` in Python. This is primarily
 /// used in `hinted_class_hash` calculation to obtain the exact same hash as in `cairo-lang`.
 #[derive(Debug)]

--- a/starknet-core/src/serde/num_hex.rs
+++ b/starknet-core/src/serde/num_hex.rs
@@ -1,6 +1,6 @@
 pub mod u64 {
     use serde::{Deserialize, Deserializer, Serializer};
-
+    use std::prelude::v1::*;
     pub fn serialize<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/starknet-core/src/serde/unsigned_field_element.rs
+++ b/starknet-core/src/serde/unsigned_field_element.rs
@@ -1,7 +1,7 @@
+use crate::types::FieldElement;
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serializer};
 use serde_with::{DeserializeAs, SerializeAs};
-
-use crate::types::FieldElement;
+use std::prelude::v1::*;
 
 pub struct UfeHex;
 

--- a/starknet-core/src/types/block.rs
+++ b/starknet-core/src/types/block.rs
@@ -5,7 +5,7 @@ use super::{
 
 use serde::Deserialize;
 use serde_with::serde_as;
-
+use std::prelude::v1::*;
 pub enum BlockId {
     Hash(FieldElement),
     Number(u64),

--- a/starknet-core/src/types/call_contract.rs
+++ b/starknet-core/src/types/call_contract.rs
@@ -1,7 +1,7 @@
 use super::{super::serde::unsigned_field_element::UfeHex, FieldElement};
-
 use serde::Deserialize;
 use serde_with::serde_as;
+use std::prelude::v1::*;
 
 #[serde_as]
 #[derive(Debug, Deserialize)]

--- a/starknet-core/src/types/contract_artifact.rs
+++ b/starknet-core/src/types/contract_artifact.rs
@@ -10,8 +10,8 @@ use super::{
 use flate2::{write::GzEncoder, Compression};
 use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::{serde_as, SerializeAs};
+use std::prelude::v1::*;
 use std::{collections::BTreeMap, io::Write};
-
 const API_VERSION: FieldElement = FieldElement::ZERO;
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/starknet-core/src/types/contract_code.rs
+++ b/starknet-core/src/types/contract_code.rs
@@ -2,7 +2,7 @@ use super::{super::serde::unsigned_field_element::UfeHex, FieldElement};
 
 use serde::{de::Error as DeError, Deserialize, Serialize, Serializer};
 use serde_with::serde_as;
-
+use std::prelude::v1::*;
 #[serde_as]
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]

--- a/starknet-core/src/types/state_update.rs
+++ b/starknet-core/src/types/state_update.rs
@@ -3,7 +3,7 @@ use super::{super::serde::unsigned_field_element::UfeHex, FieldElement};
 use serde::Deserialize;
 use serde_with::serde_as;
 use std::collections::HashMap;
-
+use std::prelude::v1::*;
 #[serde_as]
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]

--- a/starknet-core/src/types/trace.rs
+++ b/starknet-core/src/types/trace.rs
@@ -4,7 +4,7 @@ use ethereum_types::Address;
 use serde::Deserialize;
 use serde_with::serde_as;
 use starknet_crypto::FieldElement;
-
+use std::prelude::v1::*;
 #[serde_as]
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]

--- a/starknet-core/src/types/transaction.rs
+++ b/starknet-core/src/types/transaction.rs
@@ -5,9 +5,9 @@ use super::{
         TransactionStatus,
     },
 };
-
 use serde::Deserialize;
 use serde_with::serde_as;
+use std::prelude::v1::*;
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]

--- a/starknet-core/src/types/transaction_receipt.rs
+++ b/starknet-core/src/types/transaction_receipt.rs
@@ -7,7 +7,7 @@ use super::{
 use ethereum_types::Address as L1Address;
 use serde::Deserialize;
 use serde_with::serde_as;
-
+use std::prelude::v1::*;
 #[serde_as]
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]

--- a/starknet-core/src/types/transaction_request.rs
+++ b/starknet-core/src/types/transaction_request.rs
@@ -9,8 +9,8 @@ use super::{
 
 use serde::{Deserialize, Serialize, Serializer};
 use serde_with::serde_as;
+use std::prelude::v1::*;
 use std::sync::Arc;
-
 #[serde_as]
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]

--- a/starknet-core/src/utils.rs
+++ b/starknet-core/src/utils.rs
@@ -2,8 +2,8 @@ use crate::{crypto::compute_hash_on_elements, types::FieldElement};
 
 use sha3::{Digest, Keccak256};
 use starknet_crypto::pedersen_hash;
+use std::prelude::v1::*;
 use thiserror::Error;
-
 const DEFAULT_ENTRY_POINT_NAME: &str = "__default__";
 const DEFAULT_L1_ENTRY_POINT_NAME: &str = "__l1_default__";
 

--- a/starknet-crypto-codegen/Cargo.toml
+++ b/starknet-crypto-codegen/Cargo.toml
@@ -19,3 +19,11 @@ proc-macro = true
 starknet-curve = { version = "0.1.0", path = "../starknet-curve" }
 starknet-ff = { version = "0.2.0", path = "../starknet-ff" }
 syn = "1.0.96"
+no-std-compat = { version = "0.4.1", features = [
+    "alloc",
+    "compat_macros",
+    "std",
+] }
+[features]
+default = [ "std" ] # Default to using the std
+std = [ "no-std-compat/std" ]

--- a/starknet-crypto-codegen/src/lib.rs
+++ b/starknet-crypto-codegen/src/lib.rs
@@ -1,7 +1,10 @@
 // Code ported from the build.rs script here:
 //   https://github.com/eqlabs/pathfinder/blob/7f9a6bb0264943f93a633f61fc4e0bc9237f68a0/crates/stark_hash/build.rs
+#![no_std]
 
+extern crate no_std_compat as std;
 use std::fmt::Write;
+use std::prelude::v1::*;
 
 use proc_macro::TokenStream;
 use starknet_curve::{

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -25,7 +25,7 @@ rfc6979 = "0.3.1"
 sha2 = "0.10.6"
 thiserror = "1.0.30"
 zeroize = "1.5.0"
-hex = "0.4.3"
+hex = {version = "0.4.3", default-features = false}
 no-std-compat = { version = "0.4.1", features = [
     "alloc",
     "compat_macros",

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -19,7 +19,7 @@ starknet-ff = { version = "0.2.0", path = "../starknet-ff", default-features = f
 crypto-bigint = "0.4.9"
 hmac = "0.12.1"
 num-bigint = "0.4.3"
-num-integer = "0.1.44"
+num-integer = {version = "0.1.44", default-features = false}
 num-traits = {version = "0.2.15", default-features = false}
 rfc6979 = "0.3.1"
 sha2 = "0.10.6"

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -17,12 +17,12 @@ starknet-crypto-codegen = { version = "0.1.0", path = "../starknet-crypto-codege
 starknet-curve = { version = "0.1.0", path = "../starknet-curve", default-features = false }
 starknet-ff = { version = "0.2.0", path = "../starknet-ff", default-features = false }
 crypto-bigint = {version = "0.4.9", default-features = false}
-hmac = "0.12.1"
+hmac = {version = "0.12.1", default-features = false}
 num-bigint = {version = "0.4.3", default-features = false}
 num-integer = {version = "0.1.44", default-features = false}
 num-traits = {version = "0.2.15", default-features = false}
 rfc6979 = "0.3.1"
-sha2 = "0.10.6"
+sha2 = {version = "0.10.6", default-features = false}
 thiserror = "1.0.30"
 zeroize = "1.5.0"
 hex = {version = "0.4.3", default-features = false}

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 starknet-crypto-codegen = { version = "0.1.0", path = "../starknet-crypto-codegen", default-features = false }
 starknet-curve = { version = "0.1.0", path = "../starknet-curve", default-features = false }
 starknet-ff = { version = "0.2.0", path = "../starknet-ff", default-features = false }
-crypto-bigint = "0.4.9"
+crypto-bigint = {version = "0.4.9", default-features = false}
 hmac = "0.12.1"
 num-bigint = "0.4.3"
 num-integer = {version = "0.1.44", default-features = false}

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -37,7 +37,7 @@ std = [ "no-std-compat/std" ]
 
 [dev-dependencies]
 criterion = { version = "0.4.0", default-features = false }
-hex = {versio = "0.4.3", default-features = false}
+hex = {version = "0.4.3", default-features = false}
 hex-literal = "0.3.4"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.74"

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -39,7 +39,7 @@ std = [ "no-std-compat/std" ]
 criterion = { version = "0.4.0", default-features = false }
 hex = "0.4.3"
 hex-literal = "0.3.4"
-serde = { version = "1.0.152", features = ["derive"] }
+serde = { version = "1.0.150", features = ["derive"] }
 serde_json = "1.0.74"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -20,7 +20,7 @@ crypto-bigint = "0.4.9"
 hmac = "0.12.1"
 num-bigint = "0.4.3"
 num-integer = "0.1.44"
-num-traits = {version = "0.2.14", default-features = false}
+num-traits = {version = "0.2.15", default-features = false}
 rfc6979 = "0.3.1"
 sha2 = "0.10.6"
 thiserror = "1.0.30"

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -20,7 +20,7 @@ crypto-bigint = "0.4.9"
 hmac = "0.12.1"
 num-bigint = "0.4.3"
 num-integer = "0.1.44"
-num-traits = "0.2.14"
+num-traits = {version = "0.2.14", default-features = false}
 rfc6979 = "0.3.1"
 sha2 = "0.10.6"
 thiserror = "1.0.30"

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -37,9 +37,9 @@ std = [ "no-std-compat/std" ]
 
 [dev-dependencies]
 criterion = { version = "0.4.0", default-features = false }
-hex = "0.4.3"
+hex = {versio = "0.4.3", default-features = false}
 hex-literal = "0.3.4"
-serde = { version = "1.0.150", features = ["derive"] }
+serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.74"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -18,7 +18,7 @@ starknet-curve = { version = "0.1.0", path = "../starknet-curve", default-featur
 starknet-ff = { version = "0.2.0", path = "../starknet-ff", default-features = false }
 crypto-bigint = {version = "0.4.9", default-features = false}
 hmac = "0.12.1"
-num-bigint = "0.4.3"
+num-bigint = {version = "0.4.3", default-features = false}
 num-integer = {version = "0.1.44", default-features = false}
 num-traits = {version = "0.2.15", default-features = false}
 rfc6979 = "0.3.1"

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -26,6 +26,14 @@ sha2 = "0.10.6"
 thiserror = "1.0.30"
 zeroize = "1.5.0"
 hex = "0.4.3"
+no-std-compat = { version = "0.4.1", features = [
+    "alloc",
+    "compat_macros",
+    "std",
+] }
+[features]
+default = [ "std" ] # Default to using the std
+std = [ "no-std-compat/std" ]
 
 [dev-dependencies]
 criterion = { version = "0.4.0", default-features = false }
@@ -56,3 +64,4 @@ harness = false
 [[bench]]
 name = "rfc6979_generate_k"
 harness = false
+

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -33,7 +33,7 @@ no-std-compat = { version = "0.4.1", features = [
 ] }
 [features]
 default = [ "std" ] # Default to using the std
-std = [ "no-std-compat/std" ]
+std = [ "no-std-compat/std", "starknet-crypto-codegen/std", "starknet-curve/std", "starknet-ff/std" ]
 
 [dev-dependencies]
 criterion = { version = "0.4.0", default-features = false }

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -13,9 +13,9 @@ Low-level cryptography utilities for Starknet
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-crypto-codegen = { version = "0.1.0", path = "../starknet-crypto-codegen" }
-starknet-curve = { version = "0.1.0", path = "../starknet-curve" }
-starknet-ff = { version = "0.2.0", path = "../starknet-ff" }
+starknet-crypto-codegen = { version = "0.1.0", path = "../starknet-crypto-codegen", default-features = false }
+starknet-curve = { version = "0.1.0", path = "../starknet-curve", default-features = false }
+starknet-ff = { version = "0.2.0", path = "../starknet-ff", default-features = false }
 crypto-bigint = "0.4.9"
 hmac = "0.12.1"
 num-bigint = "0.4.3"

--- a/starknet-crypto/src/ecdsa.rs
+++ b/starknet-crypto/src/ecdsa.rs
@@ -27,12 +27,14 @@ pub struct Signature {
 
 impl fmt::Display for Signature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
+        // TODO: uncomment and find a way to make it work with no_std
+        /*write!(
             f,
             "{}{}",
             hex::encode(self.r.to_bytes_be()),
             hex::encode(self.s.to_bytes_be()),
-        )
+        )*/
+        Ok(())
     }
 }
 

--- a/starknet-crypto/src/ecdsa.rs
+++ b/starknet-crypto/src/ecdsa.rs
@@ -7,7 +7,7 @@ use crate::{
     fe_utils::{add_unbounded, bigint_mul_mod_floor, mod_inverse, mul_mod_floor},
     FieldElement, SignError, VerifyError,
 };
-use std::fmt;
+use std::{fmt, prelude::v1::*};
 
 const ELEMENT_UPPER_BOUND: FieldElement = FieldElement::from_mont([
     18446743986131435553,

--- a/starknet-crypto/src/lib.rs
+++ b/starknet-crypto/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!("../README.md")]
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate no_std_compat as std;
 

--- a/starknet-crypto/src/lib.rs
+++ b/starknet-crypto/src/lib.rs
@@ -1,4 +1,7 @@
 #![doc = include_str!("../README.md")]
+#![no_std]
+
+extern crate no_std_compat as std;
 
 mod ecdsa;
 mod error;

--- a/starknet-crypto/src/rfc6979.rs
+++ b/starknet-crypto/src/rfc6979.rs
@@ -4,7 +4,7 @@ use sha2::digest::{crypto_common::BlockSizeUser, FixedOutputReset, HashMarker};
 use zeroize::{Zeroize, Zeroizing};
 
 use crate::FieldElement;
-
+use std::prelude::v1::*;
 const EC_ORDER: U256 =
     U256::from_be_hex("0800000000000010ffffffffffffffffb781126dcae7b2321e66a241adc64d2f");
 

--- a/starknet-curve/Cargo.toml
+++ b/starknet-curve/Cargo.toml
@@ -13,7 +13,7 @@ Stark curve
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-ff = { version = "0.2.0", path = "../starknet-ff" }
+starknet-ff = { version = "0.2.0", path = "../starknet-ff", default-features = false }
 no-std-compat = { version = "0.4.1", features = [
     "alloc",
     "compat_macros",
@@ -21,4 +21,4 @@ no-std-compat = { version = "0.4.1", features = [
 ] }
 [features]
 default = [ "std" ] # Default to using the std
-std = [ "no-std-compat/std" ]
+std = [ "no-std-compat/std", "starknet-ff/std" ]

--- a/starknet-curve/Cargo.toml
+++ b/starknet-curve/Cargo.toml
@@ -14,3 +14,11 @@ keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
 starknet-ff = { version = "0.2.0", path = "../starknet-ff" }
+no-std-compat = { version = "0.4.1", features = [
+    "alloc",
+    "compat_macros",
+    "std",
+] }
+[features]
+default = [ "std" ] # Default to using the std
+std = [ "no-std-compat/std" ]

--- a/starknet-curve/src/lib.rs
+++ b/starknet-curve/src/lib.rs
@@ -1,4 +1,7 @@
 #![doc = include_str!("../README.md")]
+#![no_std]
+
+extern crate no_std_compat as std;
 
 mod ec_point;
 

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -16,8 +16,8 @@ keywords = ["ethereum", "starknet", "web3"]
 all-features = true
 
 [dependencies]
-ark-ff = "0.3.0"
-bigdecimal = { version = "0.3.0", optional = true }
+ark-ff = {version = "0.3.0", default-features = false}
+bigdecimal = { version = "0.3.0", optional = true, default-features = false }
 crypto-bigint = "0.4.9"
 hex = {version = "0.4.3", default-features = false}
 num-bigint = { version = "0.4.3", optional = true }

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -17,6 +17,8 @@ all-features = true
 
 [dependencies]
 ark-ff = {version = "0.3.0", default-features = false}
+ark-std = { version = "0.3.0", default-features = false }
+ark-serialize = { version = "0.3.0",  default-features = false }
 bigdecimal = { version = "0.3.0", optional = true, default-features = false }
 crypto-bigint = {version = "0.4.9", default-features = false}
 hex = {version = "0.4.3", default-features = false}
@@ -38,4 +40,4 @@ wasm-bindgen-test = "0.3.29"
 [features]
 default = ["bigdecimal"]
 bigdecimal = ["dep:bigdecimal", "dep:num-bigint"]
-std = [ "no-std-compat/std" ]
+std = [ "no-std-compat/std", "ark-std/std", "ark-serialize/std" ]

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -18,7 +18,6 @@ all-features = true
 [dependencies]
 ark-ff = {version = "0.3.0", default-features = false}
 ark-std = { version = "0.3.0", default-features = false }
-ark-serialize = { version = "0.3.0",  default-features = false }
 bigdecimal = { version = "0.3.0", optional = true, default-features = false }
 crypto-bigint = {version = "0.4.9", default-features = false}
 hex = {version = "0.4.3", default-features = false}
@@ -40,4 +39,4 @@ wasm-bindgen-test = "0.3.29"
 [features]
 default = ["bigdecimal"]
 bigdecimal = ["dep:bigdecimal", "dep:num-bigint"]
-std = [ "no-std-compat/std", "ark-std/std", "ark-serialize/std" ]
+std = [ "no-std-compat/std", "ark-std/std"]

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 ark-ff = "0.3.0"
 bigdecimal = { version = "0.3.0", optional = true }
 crypto-bigint = "0.4.9"
-hex = "0.4.3"
+hex = {version = "0.4.3", default-features = false}
 num-bigint = { version = "0.4.3", optional = true }
 serde = "1.0.152"
 thiserror = "1.0.30"

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 [dependencies]
 ark-ff = {version = "0.3.0", default-features = false}
 bigdecimal = { version = "0.3.0", optional = true, default-features = false }
-crypto-bigint = "0.4.9"
+crypto-bigint = {version = "0.4.9", default-features = false}
 hex = {version = "0.4.3", default-features = false}
 num-bigint = { version = "0.4.3", optional = true }
 serde = "1.0.152"

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -21,7 +21,7 @@ ark-std = { version = "0.3.0", default-features = false }
 bigdecimal = { version = "0.3.0", optional = true, default-features = false }
 crypto-bigint = {version = "0.4.9", default-features = false}
 hex = {version = "0.4.3", default-features = false}
-num-bigint = { version = "0.4.3", optional = true }
+num-bigint = { version = "0.4.3", optional = true, default-features = false }
 serde = "1.0.152"
 thiserror = "1.0.30"
 no-std-compat = { version = "0.4.1", features = [

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -23,6 +23,11 @@ hex = "0.4.3"
 num-bigint = { version = "0.4.3", optional = true }
 serde = "1.0.152"
 thiserror = "1.0.30"
+no-std-compat = { version = "0.4.1", features = [
+    "alloc",
+    "compat_macros",
+    "std",
+] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.3", features = ["js"] }
@@ -33,3 +38,4 @@ wasm-bindgen-test = "0.3.29"
 [features]
 default = ["bigdecimal"]
 bigdecimal = ["dep:bigdecimal", "dep:num-bigint"]
+std = [ "no-std-compat/std" ]

--- a/starknet-ff/src/lib.rs
+++ b/starknet-ff/src/lib.rs
@@ -1,10 +1,13 @@
 #![allow(clippy::comparison_chain)]
+#![no_std]
+
+extern crate no_std_compat as std;
 
 use crate::fr::FrParameters;
-
 use ark_ff::{fields::Fp256, BigInteger, BigInteger256, Field, PrimeField, SquareRootField};
 use crypto_bigint::{CheckedAdd, CheckedMul, Zero, U256};
 use serde::{Deserialize, Serialize};
+use std::prelude::v1::*;
 use std::{
     fmt::{Debug, Display, LowerHex, UpperHex},
     str::FromStr,

--- a/starknet-macros/Cargo.toml
+++ b/starknet-macros/Cargo.toml
@@ -18,7 +18,13 @@ proc-macro = true
 [dependencies]
 starknet-core = { version = "0.2.0", path = "../starknet-core" }
 syn = "1.0.96"
+no-std-compat = { version = "0.4.1", features = [
+    "alloc",
+    "compat_macros",
+    "std",
+] }
 
 [features]
 default = []
 use_imported_type = []
+std = [ "no-std-compat/std" ]

--- a/starknet-macros/src/lib.rs
+++ b/starknet-macros/src/lib.rs
@@ -1,8 +1,12 @@
+#![no_std]
+
+extern crate no_std_compat as std;
 use proc_macro::TokenStream;
 use starknet_core::{
     types::FieldElement,
     utils::{cairo_short_string_to_felt, get_selector_from_name},
 };
+use std::prelude::v1::*;
 use syn::{parse_macro_input, LitStr};
 
 #[proc_macro]

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -22,6 +22,11 @@ thiserror = "1.0.30"
 serde = "1.0.152"
 serde_json = "1.0.74"
 serde_with = "2.2.0"
+no-std-compat = { version = "0.4.1", features = [
+    "alloc",
+    "compat_macros",
+    "std",
+] }
 
 [dev-dependencies]
 flate2 = "1.0.22"
@@ -31,3 +36,4 @@ tokio = { version = "1.15.0", features = ["full"] }
 [features]
 default = []
 no_unknown_fields = []
+std = [ "no-std-compat/std" ]

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -5,8 +5,8 @@ use starknet_core::{serde::unsigned_field_element::UfeHex, types::FieldElement};
 use crate::jsonrpc::models::*;
 
 mod transports;
+use std::prelude::v1::*;
 pub use transports::{HttpTransport, JsonRpcTransport};
-
 /// Temporary module for holding JSON-RPC data models until the provider switch:
 ///
 /// https://github.com/xJonathanLEI/starknet-rs/issues/77#issuecomment-1150184364

--- a/starknet-providers/src/jsonrpc/models/conversions.rs
+++ b/starknet-providers/src/jsonrpc/models/conversions.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use starknet_core as core;
-
+use std::prelude::v1::*;
 impl From<core::types::BlockId> for BlockId {
     fn from(value: core::types::BlockId) -> Self {
         match value {

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -6,7 +6,7 @@ use starknet_core::{
 };
 
 pub use starknet_core::types::L1Address as EthAddress;
-
+use std::prelude::v1::*;
 mod serde_impls;
 
 /// Temporary module before JSON-RPC becomes the de-facto provider:

--- a/starknet-providers/src/jsonrpc/models/serde_impls.rs
+++ b/starknet-providers/src/jsonrpc/models/serde_impls.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{DeserializeAs, SerializeAs};
 
 use super::{SyncStatus, SyncStatusType};
-
+use std::prelude::v1::*;
 pub(crate) struct NumAsHex;
 
 impl SerializeAs<u64> for NumAsHex {

--- a/starknet-providers/src/jsonrpc/provider.rs
+++ b/starknet-providers/src/jsonrpc/provider.rs
@@ -10,7 +10,7 @@ use starknet_core::types::{
     FieldElement, StateUpdate, TransactionInfo, TransactionReceipt, TransactionRequest,
     TransactionSimulationInfo, TransactionStatusInfo, TransactionTrace,
 };
-
+use std::prelude::v1::*;
 #[derive(Debug, thiserror::Error)]
 pub enum JsonRpcProviderError<T> {
     #[error("Method not supported")]

--- a/starknet-providers/src/jsonrpc/transports/http.rs
+++ b/starknet-providers/src/jsonrpc/transports/http.rs
@@ -1,10 +1,10 @@
-use async_trait::async_trait;
-use reqwest::{Client, Url};
-use serde::{de::DeserializeOwned, Serialize};
-
 use crate::jsonrpc::{
     transports::JsonRpcTransport, JsonRpcMethod, JsonRpcRequest, JsonRpcResponse,
 };
+use async_trait::async_trait;
+use reqwest::{Client, Url};
+use serde::{de::DeserializeOwned, Serialize};
+use std::prelude::v1::*;
 
 #[derive(Debug)]
 pub struct HttpTransport {

--- a/starknet-providers/src/jsonrpc/transports/mod.rs
+++ b/starknet-providers/src/jsonrpc/transports/mod.rs
@@ -1,9 +1,9 @@
+use crate::jsonrpc::{JsonRpcMethod, JsonRpcResponse};
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 use serde::{de::DeserializeOwned, Serialize};
 use std::error::Error;
-
-use crate::jsonrpc::{JsonRpcMethod, JsonRpcResponse};
+use std::prelude::v1::*;
 
 mod http;
 pub use http::HttpTransport;

--- a/starknet-providers/src/lib.rs
+++ b/starknet-providers/src/lib.rs
@@ -1,4 +1,7 @@
 #![doc = include_str!("../README.md")]
+#![no_std]
+
+extern crate no_std_compat as std;
 
 mod provider;
 pub use provider::{Provider, ProviderError};

--- a/starknet-providers/src/provider.rs
+++ b/starknet-providers/src/provider.rs
@@ -7,6 +7,7 @@ use starknet_core::types::{
     TransactionRequest, TransactionSimulationInfo, TransactionStatusInfo, TransactionTrace,
 };
 use std::error::Error;
+use std::prelude::v1::*;
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]

--- a/starknet-providers/src/sequencer_gateway.rs
+++ b/starknet-providers/src/sequencer_gateway.rs
@@ -14,6 +14,7 @@ use starknet_core::{
         TransactionRequest, TransactionSimulationInfo, TransactionStatusInfo, TransactionTrace,
     },
 };
+use std::prelude::v1::*;
 use url::Url;
 
 #[derive(Clone)]

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -17,6 +17,14 @@ starknet-core = { version = "0.2.0", path = "../starknet-core" }
 starknet-crypto = { version = "0.2.0", path = "../starknet-crypto" }
 async-trait = "0.1.52"
 thiserror = "1.0.30"
+no-std-compat = { version = "0.4.1", features = [
+    "alloc",
+    "compat_macros",
+    "std",
+] }
+[features]
+default = [ "std" ] # Default to using the std
+std = [ "no-std-compat/std" ]
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.29"

--- a/starknet-signers/src/lib.rs
+++ b/starknet-signers/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+extern crate no_std_compat as std;
+
 mod key_pair;
 pub use key_pair::{SigningKey, VerifyingKey};
 

--- a/starknet-signers/src/local_wallet.rs
+++ b/starknet-signers/src/local_wallet.rs
@@ -5,6 +5,7 @@ use starknet_core::{
     crypto::{EcdsaSignError, Signature},
     types::FieldElement,
 };
+use std::prelude::v1::*;
 
 #[derive(Debug, Clone)]
 pub struct LocalWallet {

--- a/starknet-signers/src/signer.rs
+++ b/starknet-signers/src/signer.rs
@@ -3,7 +3,7 @@ use crate::VerifyingKey;
 use async_trait::async_trait;
 use starknet_core::{crypto::Signature, types::FieldElement};
 use std::error::Error;
-
+use std::prelude::v1::*;
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait Signer {


### PR DESCRIPTION
# Description

This PR enables `no_std` compatibility for `starknet-rs`.
It uses [no-std-compat](https://crates.io/crates/no-std-compat) crate to achieve this goal.

# Usage

If you want to use a crate from `starknet-rs` with `no-std` support you can do like this:

```toml
starknet-crypto = { git = "...", rev = "...", default-features = false }

std = [
  "starknet-crypto/std",
]
```