### PR TITLE
fix: function_invocation should be optional

### DIFF
--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -122,7 +122,12 @@ async fn can_simulate_execution() {
         .await
         .unwrap();
 
-    assert!(!result.trace.function_invocation.internal_calls.is_empty());
+    assert!(!result
+        .trace
+        .function_invocation
+        .unwrap()
+        .internal_calls
+        .is_empty());
 }
 
 #[tokio::test]

--- a/starknet-core/src/types/trace.rs
+++ b/starknet-core/src/types/trace.rs
@@ -18,7 +18,8 @@ pub struct BlockTraces {
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct TransactionTrace {
     /// An object describing the invocation of a specific function.
-    pub function_invocation: FunctionInvocation,
+    #[serde(default)]
+    pub function_invocation: Option<FunctionInvocation>,
     /// An object describing the invocation of a fee transfer.
     #[serde(default)]
     pub fee_transfer_invocation: Option<FunctionInvocation>,
@@ -147,17 +148,22 @@ mod tests {
             "../../test-data/raw_gateway_responses/get_transaction_trace/3_with_call_type.txt"
         ))
         .unwrap();
-        match new_tx.function_invocation.call_type {
-            Some(call_type) => assert_eq!(call_type, CallType::Call),
+        match &new_tx.function_invocation.as_ref().unwrap().call_type {
+            Some(call_type) => assert_eq!(call_type, &CallType::Call),
             None => panic!("Empty call_type"),
         }
-        assert!(&new_tx.function_invocation.class_hash.is_some());
+        assert!(&new_tx.function_invocation.unwrap().class_hash.is_some());
 
         let old_tx: TransactionTrace = serde_json::from_str(include_str!(
             "../../test-data/raw_gateway_responses/get_transaction_trace/1_with_messages.txt"
         ))
         .unwrap();
-        assert!(&old_tx.function_invocation.call_type.is_none());
-        assert!(&old_tx.function_invocation.class_hash.is_none());
+        assert!(&old_tx
+            .function_invocation
+            .as_ref()
+            .unwrap()
+            .call_type
+            .is_none());
+        assert!(&old_tx.function_invocation.unwrap().class_hash.is_none());
     }
 }

--- a/starknet-providers/tests/sequencer_goerli.rs
+++ b/starknet-providers/tests/sequencer_goerli.rs
@@ -135,6 +135,7 @@ async fn sequencer_goerli_can_simulate_transaction() {
         simulation
             .trace
             .function_invocation
+            .unwrap()
             .execution_resources
             .n_steps
             > 0


### PR DESCRIPTION
Turns out all fields except `signature` should be optional in transaction traces as `DECLARE` transactions don't have any of those:

```
$ curl "https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction_trace?transactionHash=0x049385a99d26e93ed8eb09471892e5225e4946e79d8800c9044c0c0c2f7506f8"
{"signature": []}
```