### PR TITLE
ci: build and lint no_std

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -52,3 +52,7 @@ jobs:
       - name: Run Clippy lints
         run: |
           cargo clippy --all --all-targets -- -D warnings
+      - name: Run Clippy lints (no_std)
+        run: |
+          cargo clippy --package starknet-crypto --no-default-features -- -D warnings
+          cargo clippy --package starknet-crypto --no-default-features --features alloc -- -D warnings

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -118,3 +118,53 @@ jobs:
       - name: Run starknet-macros tests
         run: |
           (cd ./starknet-macros && wasm-pack test --node)
+
+  no-std-build:
+    name: no-std build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure:
+
+      - name: Add --target thumbv6m-none-eabi target
+        run: |
+          rustup target add thumbv6m-none-eabi
+
+      - name: Build starknet-ff
+        run: |
+          cargo build --package starknet-ff \
+            --target thumbv6m-none-eabi \
+            --no-default-features
+
+          cargo build --package starknet-ff \
+            --target thumbv6m-none-eabi \
+            --no-default-features \
+            --features alloc
+
+          cargo build --package starknet-ff \
+            --target thumbv6m-none-eabi \
+            --no-default-features \
+            --features serde
+
+      - name: Build starknet-crypto
+        run: |
+          cargo build --package starknet-crypto \
+            --target thumbv6m-none-eabi \
+            --no-default-features
+
+          cargo build --package starknet-crypto \
+            --target thumbv6m-none-eabi \
+            --no-default-features \
+            --features alloc


### PR DESCRIPTION
`no_std` support was added in #306 but the CI isn't enforcing it now. This PR adds building and linting of `no_std` feature combinations to make sure we don't accidentally break it.