### PR TITLE
docs: use production mode for wasm example

### DIFF
--- a/examples/starknet-wasm/webpack.config.js
+++ b/examples/starknet-wasm/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = {
       crateDirectory: path.resolve(__dirname, "."),
     }),
   ],
-  mode: "development",
+  mode: "production",
   experiments: {
     asyncWebAssembly: true,
   },


### PR DESCRIPTION
We've been using the `development` mode for the Webpack wasm example. The `wasm-pack` plugin inherits the setting and uses `--debug` for compiling the wasm module, which gives a bad impression on the size and performance of the resulting module.

This PR changes to use `production` mode instead. The built wasm module before this change is **270 KB** in size and it's now only **51 KB**.