### PR TITLE
chore: sync poseidon code to pathfinder `00a1a74a`

### DIFF
--- a/starknet-crypto-codegen/src/poseidon/mod.rs
+++ b/starknet-crypto-codegen/src/poseidon/mod.rs
@@ -1,5 +1,5 @@
 // Code ported from the build.rs script here:
-//   https://github.com/eqlabs/pathfinder/blob/ab3f2e849cd94d5dc3c7c02040adff4ad7d0597b/crates/stark_poseidon/build.rs
+//   https://github.com/eqlabs/pathfinder/blob/00a1a74a90a7b8a7f1d07ac3e616be1cb39cf8f1/crates/stark_poseidon/build.rs
 
 use std::fmt::Write;
 

--- a/starknet-crypto/README.md
+++ b/starknet-crypto/README.md
@@ -59,6 +59,6 @@ rfc6979_generate_k      time:   [8.6301 µs 8.6353 µs 8.6414 µs]
 
 Most of the code in this crate for the Pedersen hash implementation was inspired and modified from the awesome [`pathfinder` from Equilibrium](https://github.com/eqlabs/pathfinder/blob/b091cb889e624897dbb0cbec3c1df9a9e411eb1e/crates/pedersen/src/lib.rs).
 
-The Poseidon hash implementation was also ported from [`pathfinder`](https://github.com/eqlabs/pathfinder/blob/ab3f2e849cd94d5dc3c7c02040adff4ad7d0597b/crates/stark_poseidon/src/lib.rs).
+The Poseidon hash implementation was also ported from [`pathfinder`](https://github.com/eqlabs/pathfinder/blob/00a1a74a90a7b8a7f1d07ac3e616be1cb39cf8f1/crates/stark_poseidon/src/lib.rs).
 
 Based on this solid foundation, ECDSA functionalities were inspired and ported from the [`crypto-cpp` implementation from StarkWare](https://github.com/starkware-libs/crypto-cpp/blob/95864fbe11d5287e345432dbe1e80dea3c35fc58/src/starkware/crypto/ecdsa.cc).

--- a/starknet-crypto/src/poseidon_hash.rs
+++ b/starknet-crypto/src/poseidon_hash.rs
@@ -1,5 +1,5 @@
 // Code ported from the the implementation from pathfinder here:
-//   https://github.com/eqlabs/pathfinder/blob/ab3f2e849cd94d5dc3c7c02040adff4ad7d0597b/crates/stark_poseidon/src/lib.rs
+//   https://github.com/eqlabs/pathfinder/blob/00a1a74a90a7b8a7f1d07ac3e616be1cb39cf8f1/crates/stark_poseidon/src/lib.rs
 
 use starknet_crypto_codegen::poseidon_consts;
 use starknet_ff::FieldElement;
@@ -12,7 +12,7 @@ poseidon_consts!();
 #[derive(Debug, Default)]
 pub struct PoseidonHasher {
     state: [FieldElement; 3],
-    accumulator: Option<FieldElement>,
+    buffer: Option<FieldElement>,
 }
 
 impl PoseidonHasher {
@@ -23,14 +23,14 @@ impl PoseidonHasher {
 
     /// Absorbs message into the hash.
     pub fn update(&mut self, msg: FieldElement) {
-        match self.accumulator.take() {
+        match self.buffer.take() {
             Some(previous_message) => {
                 self.state[0] += previous_message;
                 self.state[1] += msg;
                 permute_comp(&mut self.state);
             }
             None => {
-                self.accumulator = Some(msg);
+                self.buffer = Some(msg);
             }
         }
     }
@@ -38,7 +38,7 @@ impl PoseidonHasher {
     /// Finishes and returns hash.
     pub fn finalize(mut self) -> FieldElement {
         // Applies padding
-        match self.accumulator.take() {
+        match self.buffer.take() {
             Some(last_message) => {
                 self.state[0] += last_message;
                 self.state[1] += FieldElement::ONE;


### PR DESCRIPTION
https://github.com/eqlabs/pathfinder/pull/914 is now merged with minor changes since we ported the code over. This PR port those minor additional changes (a single field name change) and updates the commit mark to `00a1a74a90a7b8a7f1d07ac3e616be1cb39cf8f1`.