### PR TITLE
feat: expose Poiseidon permutation function

### DIFF
--- a/starknet-crypto/src/lib.rs
+++ b/starknet-crypto/src/lib.rs
@@ -19,7 +19,9 @@ pub use starknet_ff::FieldElement;
 
 pub use pedersen_hash::pedersen_hash;
 
-pub use poseidon_hash::{poseidon_hash, poseidon_hash_many, poseidon_hash_single, PoseidonHasher};
+pub use poseidon_hash::{
+    poseidon_hash, poseidon_hash_many, poseidon_hash_single, poseidon_permute_comp, PoseidonHasher,
+};
 
 pub use ecdsa::{get_public_key, recover, sign, verify, Signature};
 


### PR DESCRIPTION
Turns out there are use cases (like https://github.com/lambdaclass/cairo-rs/pull/875) that would need access to the Poisedon permutation function. `starknet-crypto` is supposed to expose low-level primitives and the function should be made public.