### PR TITLE
release: bump starknet-crypto to 0.4.0 (and deps)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "crypto-bigint",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto-codegen"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "starknet-curve",
  "starknet-ff",
@@ -1646,14 +1646,14 @@ dependencies = [
 
 [[package]]
 name = "starknet-curve"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "starknet-ff",
 ]
 
 [[package]]
 name = "starknet-ff"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ark-ff",
  "bigdecimal",

--- a/examples/starknet-wasm/Cargo.toml
+++ b/examples/starknet-wasm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-starknet-ff = { version = "0.3.0", path = "../../starknet-ff" }
-starknet-crypto = { version = "0.3.0", path = "../../starknet-crypto" }
+starknet-ff = { version = "0.3.1", path = "../../starknet-ff" }
+starknet-crypto = { version = "0.4.0", path = "../../starknet-crypto" }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 wasm-bindgen = "0.2.79"

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -16,8 +16,8 @@ keywords = ["ethereum", "starknet", "web3"]
 all-features = true
 
 [dependencies]
-starknet-crypto = { version = "0.3.0", path = "../starknet-crypto" }
-starknet-ff = { version = "0.3.0", path = "../starknet-ff", features = [
+starknet-crypto = { version = "0.4.0", path = "../starknet-crypto" }
+starknet-ff = { version = "0.3.1", path = "../starknet-ff", features = [
     "serde",
 ] }
 base64 = "0.13.0"

--- a/starknet-crypto-codegen/Cargo.toml
+++ b/starknet-crypto-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-crypto-codegen"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -16,6 +16,6 @@ keywords = ["ethereum", "starknet", "web3", "no_std"]
 proc-macro = true
 
 [dependencies]
-starknet-curve = { version = "0.2.0", path = "../starknet-curve" }
-starknet-ff = { version = "0.3.0", path = "../starknet-ff", default-features = false }
+starknet-curve = { version = "0.2.1", path = "../starknet-curve" }
+starknet-ff = { version = "0.3.1", path = "../starknet-ff", default-features = false }
 syn = { version = "1.0.96", default-features = false }

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-crypto"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,9 +13,9 @@ Low-level cryptography utilities for Starknet
 keywords = ["ethereum", "starknet", "web3", "no_std"]
 
 [dependencies]
-starknet-crypto-codegen = { version = "0.2.0", path = "../starknet-crypto-codegen" }
-starknet-curve = { version = "0.2.0", path = "../starknet-curve" }
-starknet-ff = { version = "0.3.0", path = "../starknet-ff", default-features = false }
+starknet-crypto-codegen = { version = "0.3.0", path = "../starknet-crypto-codegen" }
+starknet-curve = { version = "0.2.1", path = "../starknet-curve" }
+starknet-ff = { version = "0.3.1", path = "../starknet-ff", default-features = false }
 crypto-bigint = { version = "0.4.9", default-features = false }
 hmac = { version = "0.12.1", default-features = false }
 num-bigint = { version = "0.4.3", default-features = false }

--- a/starknet-curve/Cargo.toml
+++ b/starknet-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-curve"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,7 +13,7 @@ Stark curve
 keywords = ["ethereum", "starknet", "web3", "no_std"]
 
 [dependencies]
-starknet-ff = { version = "0.3.0", path = "../starknet-ff", default-features = false }
+starknet-ff = { version = "0.3.1", path = "../starknet-ff", default-features = false }
 
 [features]
 bigdecimal = ["starknet-ff/bigdecimal"]

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-ff"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
 starknet-core = { version = "0.2.0", path = "../starknet-core" }
-starknet-crypto = { version = "0.3.0", path = "../starknet-crypto" }
+starknet-crypto = { version = "0.4.0", path = "../starknet-crypto" }
 async-trait = "0.1.52"
 thiserror = "1.0.30"
 


### PR DESCRIPTION
Making a new release for `starknet-crypto` as the Poseidon hash function becomes available, bumping `starknet-crypto` to `0.4.0`.

`starknet-ff` and `starknet-curve` were only bumped for patch version as no breaking changes were made.