### PR TITLE
feat: revert breaking change on `Signature`

### DIFF
--- a/starknet-crypto/src/ecdsa.rs
+++ b/starknet-crypto/src/ecdsa.rs
@@ -22,12 +22,42 @@ pub struct Signature {
     pub r: FieldElement,
     /// The `s` value of a signature
     pub s: FieldElement,
+}
+
+/// Stark ECDSA signature with `v`
+#[derive(Debug)]
+pub struct ExtendedSignature {
+    /// The `r` value of a signature
+    pub r: FieldElement,
+    /// The `s` value of a signature
+    pub s: FieldElement,
     /// The `v` value of a signature
     pub v: FieldElement,
 }
 
+impl From<ExtendedSignature> for Signature {
+    fn from(value: ExtendedSignature) -> Self {
+        Self {
+            r: value.r,
+            s: value.s,
+        }
+    }
+}
+
 #[cfg(feature = "signature-display")]
 impl core::fmt::Display for Signature {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(
+            f,
+            "{}{}",
+            hex::encode(self.r.to_bytes_be()),
+            hex::encode(self.s.to_bytes_be()),
+        )
+    }
+}
+
+#[cfg(feature = "signature-display")]
+impl core::fmt::Display for ExtendedSignature {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(
             f,
@@ -58,7 +88,7 @@ pub fn sign(
     private_key: &FieldElement,
     message: &FieldElement,
     k: &FieldElement,
-) -> Result<Signature, SignError> {
+) -> Result<ExtendedSignature, SignError> {
     if message >= &ELEMENT_UPPER_BOUND {
         return Err(SignError::InvalidMessageHash);
     }
@@ -83,7 +113,7 @@ pub fn sign(
 
     let v = full_r.y & FieldElement::ONE;
 
-    Ok(Signature { r, s, v })
+    Ok(ExtendedSignature { r, s, v })
 }
 
 /// Verifies if a signature is valid over a message hash given a Stark public key.

--- a/starknet-crypto/src/lib.rs
+++ b/starknet-crypto/src/lib.rs
@@ -23,7 +23,7 @@ pub use poseidon_hash::{
     poseidon_hash, poseidon_hash_many, poseidon_hash_single, poseidon_permute_comp, PoseidonHasher,
 };
 
-pub use ecdsa::{get_public_key, recover, sign, verify, Signature};
+pub use ecdsa::{get_public_key, recover, sign, verify, ExtendedSignature, Signature};
 
 pub use crate::rfc6979::generate_k as rfc6979_generate_k;
 

--- a/starknet-signers/src/key_pair.rs
+++ b/starknet-signers/src/key_pair.rs
@@ -28,7 +28,7 @@ impl SigningKey {
     }
 
     pub fn sign(&self, hash: &FieldElement) -> Result<Signature, EcdsaSignError> {
-        ecdsa_sign(&self.secret_scalar, hash)
+        ecdsa_sign(&self.secret_scalar, hash).map(|sig| sig.into())
     }
 }
 
@@ -155,14 +155,10 @@ mod tests {
             "04e44e759cea02c23568bb4d8a09929bbca8768ab68270d50c18d214166ccd9a",
         )
         .unwrap();
-        let v = FieldElement::from_hex_be(
-            "0000000000000000000000000000000000000000000000000000000000000000",
-        )
-        .unwrap();
 
         let verifying_key = VerifyingKey::from_scalar(public_key);
 
-        assert!(verifying_key.verify(&hash, &Signature { r, s, v }).unwrap());
+        assert!(verifying_key.verify(&hash, &Signature { r, s }).unwrap());
     }
 
     #[test]
@@ -185,13 +181,9 @@ mod tests {
             "04e44e759cea02c23568bb4d8a09929bbca8768ab68270d50c18d214166ccd9b",
         )
         .unwrap();
-        let v = FieldElement::from_hex_be(
-            "0000000000000000000000000000000000000000000000000000000000000000",
-        )
-        .unwrap();
 
         let verifying_key = VerifyingKey::from_scalar(public_key);
 
-        assert!(!verifying_key.verify(&hash, &Signature { r, s, v }).unwrap());
+        assert!(!verifying_key.verify(&hash, &Signature { r, s }).unwrap());
     }
 }


### PR DESCRIPTION
Undoes the addition of the `v` field to `Signature` introduced in #315 by @greged93.

We don't want the `v` field in `Signature` because the same struct is also used by `starknet-core` for signature verification, which does not make use of `v`. The addition of the field forces users to supply a `v` value for that.

A new struct `ExtendedSignature` is added instead, which can be converted into `Signature`.