### PR TITLE
release: bump starknet-crypto to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "crypto-bigint",

--- a/examples/starknet-wasm/Cargo.toml
+++ b/examples/starknet-wasm/Cargo.toml
@@ -20,6 +20,6 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 starknet-ff = { version = "0.3.1", path = "../../starknet-ff" }
-starknet-crypto = { version = "0.4.0", path = "../../starknet-crypto" }
+starknet-crypto = { version = "0.4.1", path = "../../starknet-crypto" }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 wasm-bindgen = "0.2.79"

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 all-features = true
 
 [dependencies]
-starknet-crypto = { version = "0.4.0", path = "../starknet-crypto" }
+starknet-crypto = { version = "0.4.1", path = "../starknet-crypto" }
 starknet-ff = { version = "0.3.1", path = "../starknet-ff", features = [
     "serde",
 ] }

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-crypto"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
 starknet-core = { version = "0.2.0", path = "../starknet-core" }
-starknet-crypto = { version = "0.4.0", path = "../starknet-crypto" }
+starknet-crypto = { version = "0.4.1", path = "../starknet-crypto" }
 async-trait = "0.1.52"
 thiserror = "1.0.30"
 


### PR DESCRIPTION
Technically we should release `0.5.0` as #322 was a breaking change. However, under romantic versioning, I'm just gonna bump the patch version because I've yanked `0.4.0` soon after release so that no one installs it by accident.