### PR TITLE
fix: missing v for Display impl for `ExtendedSignature`

### DIFF
--- a/starknet-crypto/src/ecdsa.rs
+++ b/starknet-crypto/src/ecdsa.rs
@@ -61,9 +61,10 @@ impl core::fmt::Display for ExtendedSignature {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(
             f,
-            "{}{}",
+            "{}{}{:02x}",
             hex::encode(self.r.to_bytes_be()),
             hex::encode(self.s.to_bytes_be()),
+            self.v
         )
     }
 }


### PR DESCRIPTION
As pointed out in https://github.com/xJonathanLEI/starknet-rs/pull/322#discussion_r1132115169, `v` is missing from the `Display` implementation of `ExtendedSignature`). Thanks to @milancermak for spotting this!