### PR TITLE
feat: enable feature signature-display by default

### DIFF
--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -27,7 +27,7 @@ zeroize = { version = "1.5.0", default-features = false }
 hex = { version = "0.4.3", default-features = false, optional = true }
 
 [features]
-default = ["std"]
+default = ["std", "signature-display"]
 std = []
 alloc = ["hex?/alloc"]
 signature-display = ["dep:hex", "alloc"]


### PR DESCRIPTION
We should probably enable this by default. `no_std` users would disable all default features anyways.