### PR TITLE
docs: use starknet-core for the starknet-cxx example instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,7 +1657,7 @@ version = "0.1.0"
 dependencies = [
  "cxx",
  "cxx-build",
- "starknet-crypto",
+ "starknet-core",
 ]
 
 [[package]]

--- a/examples/starknet-cxx/README.md
+++ b/examples/starknet-cxx/README.md
@@ -1,10 +1,10 @@
 # Example usage of starknet-rs from C++
 
-This is a quick demo on exposing `starknet-crypto` to C++ with the [cxx](https://github.com/dtolnay/cxx) bridge and [corrosion](https://github.com/corrosion-rs/corrosion).
+This is a quick demo on exposing `starknet-core` to C++ with the [cxx](https://github.com/dtolnay/cxx) bridge and [corrosion](https://github.com/corrosion-rs/corrosion).
 
 ## **WARNING**
 
-As noted in the [`starknet-crypto` page](../../starknet-crypto/), you're advised to use high-level constructs exposed through `starknet-core` instead if you're not familiar with cryptographic primitives. `starknet-crypto` is chosen here considering that the C++ audience might prefer low-level libraries, but it's possible to wrap `starknet-core` as well.
+As noted in the [`starknet-crypto` page](../../starknet-crypto/), you're advised to use high-level constructs exposed through `starknet-core` instead if you're not familiar with cryptographic primitives, as we're doing here. However, it's possible to wrap the underlying `starknet-crypto` crate directly _if you know what you're doing._
 
 ## Note
 
@@ -31,5 +31,5 @@ $ ./main
 pedersen_hash():
   0x030e480bed5fe53fa909cc0f8c4d99b8f9f2c016be4c41e13a4848797979c662
 ecdsa_sign():
-  0x0411494b501a98abd8262b0da1351e17899a0c4ef23dd2f96fec5ba847310b200405c3191ab3883ef2b763af35bc5f5d15b3b4e99461d70e84c654a351a7c81b
+  0x0543b191c671bc1f9b2f4e643a5711535cf34cb8330ab22e2416e8cdda8db05402f139920a75d2209e972b1bf82dc72e4c1edb8355fdbae7b4910ea7c32e70e2
 ```

--- a/examples/starknet-cxx/main.cpp
+++ b/examples/starknet-cxx/main.cpp
@@ -7,11 +7,9 @@ int main() {
         "0x208a0a10250e382e1e4bbe2880906c2791bf6275695e02fbbc6aeff9cd8b31a"
     );
 
-    // WARNING: DO NOT hard code the k value in real code!! Doing so would expose the private key.
     auto signature = ecdsa_sign(
         "0x1",
-        "0x2",
-        "0x3"
+        "0x2"
     );
   
     std::cout << "pedersen_hash():" << "\n"

--- a/examples/starknet-cxx/starknet-cxx/Cargo.toml
+++ b/examples/starknet-cxx/starknet-cxx/Cargo.toml
@@ -8,10 +8,11 @@ edition = "2021"
 cxx = "1.0"
 
 # Using path dependency here to make development easier. However, you probably want to fetch the
-# crate from crates.io instead, which means changing the next line to:
+# crate from GitHub instead (because the `starknet-core` crate isn't being published to crates.io
+# regularly like `starknet-crypto` at the moment), which means changing the next line to:
 #
-# starknet-crypto = "0.4.2"
-starknet-crypto = { version = "0.4.2", path = "../../../starknet-crypto" }
+# starknet-core = { git = "https://github.com/xJonathanLEI/starknet-rs" }
+starknet-core = { path = "../../../starknet-core" }
 
 [build-dependencies]
 cxx-build = "1.0"

--- a/examples/starknet-cxx/starknet-cxx/src/lib.rs
+++ b/examples/starknet-cxx/starknet-cxx/src/lib.rs
@@ -13,14 +13,14 @@
 //! create idiomatic bindings, which is way too much work to maintain as an example, and should be
 //! a project of its own.
 
-use starknet_crypto::{FieldElement, Signature};
+use starknet_core::{crypto::Signature, types::FieldElement};
 
 #[cxx::bridge]
 mod ffi {
     extern "Rust" {
         fn pedersen_hash(x: &str, y: &str) -> String;
 
-        fn ecdsa_sign(private_key: &str, message: &str, k: &str) -> String;
+        fn ecdsa_sign(private_key: &str, message: &str) -> String;
     }
 }
 
@@ -29,16 +29,15 @@ pub fn pedersen_hash(x: &str, y: &str) -> String {
     let x = FieldElement::from_hex_be(x).unwrap();
     let y = FieldElement::from_hex_be(y).unwrap();
 
-    format!("{:#064x}", starknet_crypto::pedersen_hash(&x, &y))
+    format!("{:#064x}", starknet_core::crypto::pedersen_hash(&x, &y))
 }
 
-fn ecdsa_sign(private_key: &str, message: &str, k: &str) -> String {
+fn ecdsa_sign(private_key: &str, message: &str) -> String {
     // WARNING: no error handling here
     let private_key = FieldElement::from_hex_be(private_key).unwrap();
     let message = FieldElement::from_hex_be(message).unwrap();
-    let k = FieldElement::from_hex_be(k).unwrap();
 
-    let signature: Signature = starknet_crypto::sign(&private_key, &message, &k)
+    let signature: Signature = starknet_core::crypto::ecdsa_sign(&private_key, &message)
         // WARNING: no error handling here
         .unwrap()
         .into();


### PR DESCRIPTION
See #329.

It seems extremely easy for people to shoot themselves in the foot for using `starknet-crypto` directly, especially for developers not familiar with Rust - it's harder for them to inspect the code to see what's _really_ going on.

This PR changes to wrap `starknet-core` instead, and only expose the high-level `ecdsa_sign` function, which takes care of the `k` generation.