### PR TITLE
fix: add alias for `contract_address` in `TransactionInfo`

### DIFF
--- a/starknet-core/src/types/transaction.rs
+++ b/starknet-core/src/types/transaction.rs
@@ -130,7 +130,7 @@ pub struct DeployAccountTransaction {
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct InvokeFunctionTransaction {
     #[serde_as(as = "UfeHex")]
-    pub contract_address: FieldElement,
+    pub sender_address: FieldElement,
     #[serde_as(as = "Option<UfeHex>")]
     pub entry_point_selector: Option<FieldElement>,
     #[serde_as(deserialize_as = "Vec<UfeHex>")]

--- a/starknet-providers/src/jsonrpc/models/codegen.rs
+++ b/starknet-providers/src/jsonrpc/models/codegen.rs
@@ -48,10 +48,10 @@ pub struct EmittedEvent {
     #[serde_as(as = "Vec<UfeHex>")]
     pub data: Vec<FieldElement>,
     /// The hash of the block in which the event was emitted
-    #[serde_as(as = "UfeHex")]
-    pub block_hash: FieldElement,
+    #[serde_as(as = "Option<UfeHex>")]
+    pub block_hash: Option<FieldElement>,
     /// The number of the block in which the event was emitted
-    pub block_number: u64,
+    pub block_number: Option<u64>,
     /// The transaction that emitted the event
     #[serde_as(as = "UfeHex")]
     pub transaction_hash: FieldElement,


### PR DESCRIPTION
### Purpose
Referencing [this issue](https://github.com/xJonathanLEI/starknet-rs/issues/333)

A backwards incompatible API change in `feeder_gateway/get_transaction` renamed `contract_address` to `sender_address`. This is deployed on Goerli, but not yet on Mainnet, so we alias and accept either. 

An example request on Goerli is [here](https://alpha4.starknet.io/feeder_gateway/get_transaction?transactionHash=0x2dc44b315aeb84e2a68367263d15d54ee229c1692c02f1d833ef870f7b6ce1a); where `sender_address` is present, but `contract_address` is not.

A sample mainnet request is [here](https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=0x1dc1bd0cfbc145d1583ec973fc99ca7b47cf4ace9eb469f405cbf3f7817f882); note that `contract_address` is still present.

### Testing
- Tested against both Goerli and Mainnet `get_transaction` calls

