### PR TITLE
feat: sierra class hash calculation

### DIFF
--- a/starknet-core/src/utils.rs
+++ b/starknet-core/src/utils.rs
@@ -79,7 +79,7 @@ pub fn get_storage_var_address(
         for arg in args.iter() {
             res = pedersen_hash(&res, arg);
         }
-        Ok(res % ADDR_BOUND)
+        Ok(normalize_address(res))
     } else {
         Err(NonAsciiNameError)
     }
@@ -133,13 +133,17 @@ pub fn get_contract_address(
     constructor_calldata: &[FieldElement],
     deployer_address: FieldElement,
 ) -> FieldElement {
-    compute_hash_on_elements(&[
+    normalize_address(compute_hash_on_elements(&[
         CONTRACT_ADDRESS_PREFIX,
         deployer_address,
         salt,
         class_hash,
         compute_hash_on_elements(constructor_calldata),
-    ]) % ADDR_BOUND
+    ]))
+}
+
+pub fn normalize_address(address: FieldElement) -> FieldElement {
+    address % ADDR_BOUND
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Resolves task 3 of #313:

> support computing class hashes of Cairo 1 contracts

With this PR the library is capable of calculating hashes for all 3 types of contract classes in existence.

Note that in this PR I'm hard-coding to use the Pythonic JSON formatting for the ABI to match the class hash calculated from the official `cairo-lang` CLI, just to make sure we're doing it right, but that's not necessary. In a future PR we should make the formatting plug-able with a `AbiFormatter` trait, allowing users to specify how the ABI should be formatted, including not uploading ABI at all (`VoidFormatter`?).