### PR TITLE
feat: support declare v2 transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,6 +1568,7 @@ name = "starknet-accounts"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "serde",
  "serde_json",
  "starknet-core",
  "starknet-providers",

--- a/README.md
+++ b/README.md
@@ -82,15 +82,19 @@ Examples can be found in the [examples folder](./examples):
 
    Make sure your account has some L2 Goerli ETH to pay for the transaction fee. You can use [this faucet](https://faucet.goerli.starknet.io/) to fund your account.
 
-4. [Declare contract on `alpha-goerli` testnet](./examples/declare_contract.rs)
+4. [Declare Cairo 1 contract on `alpha-goerli` testnet](./examples/declare_cairo1_contract.rs)
 
-   Declaring contracts without going through an account (and thus not paying fees) has been deprecated, so please make sure your account has enough L2 Goerli ETH for the fees.
+   Make sure your account has some L2 Goerli ETH to pay for the transaction fee. You can use [this faucet](https://faucet.goerli.starknet.io/) to fund your account.
 
-5. [Query the latest block number with JSON-RPC](./examples/jsonrpc.rs)
+5. [Declare legacy Cairo 0 contract on `alpha-goerli` testnet](./examples/declare_cairo0_contract.rs)
 
-6. [Call a contract view function via sequencer gateway](./examples/sequencer_erc20_balance.rs)
+   Make sure your account has some L2 Goerli ETH to pay for the transaction fee. You can use [this faucet](https://faucet.goerli.starknet.io/) to fund your account.
 
-7. [Deploy an Argent X account to a pre-funded address](./examples/deploy_argent_account.rs)
+6. [Query the latest block number with JSON-RPC](./examples/jsonrpc.rs)
+
+7. [Call a contract view function via sequencer gateway](./examples/sequencer_erc20_balance.rs)
+
+8. [Deploy an Argent X account to a pre-funded address](./examples/deploy_argent_account.rs)
 
 ## License
 

--- a/examples/declare_cairo0_contract.rs
+++ b/examples/declare_cairo0_contract.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+
+use starknet::{
+    accounts::{Account, SingleOwnerAccount},
+    core::{
+        chain_id,
+        types::{contract::legacy::LegacyContractClass, FieldElement},
+    },
+    providers::SequencerGatewayProvider,
+    signers::{LocalWallet, SigningKey},
+};
+
+#[tokio::main]
+async fn main() {
+    let contract_artifact: LegacyContractClass =
+        serde_json::from_reader(std::fs::File::open("/path/to/contract/artifact.json").unwrap())
+            .unwrap();
+    let provider = SequencerGatewayProvider::starknet_alpha_goerli();
+    let signer = LocalWallet::from(SigningKey::from_secret_scalar(
+        FieldElement::from_hex_be("YOUR_PRIVATE_KEY_IN_HEX_HERE").unwrap(),
+    ));
+    let address = FieldElement::from_hex_be("YOUR_ACCOUNT_CONTRACT_ADDRESS_IN_HEX_HERE").unwrap();
+
+    let account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+
+    let result = account
+        .declare_legacy(Arc::new(contract_artifact))
+        .send()
+        .await
+        .unwrap();
+
+    dbg!(result);
+}

--- a/examples/declare_cairo1_contract.rs
+++ b/examples/declare_cairo1_contract.rs
@@ -4,7 +4,7 @@ use starknet::{
     accounts::{Account, SingleOwnerAccount},
     core::{
         chain_id,
-        types::{contract::legacy::LegacyContractClass, FieldElement},
+        types::{contract::SierraClass, FieldElement},
     },
     providers::SequencerGatewayProvider,
     signers::{LocalWallet, SigningKey},
@@ -12,9 +12,15 @@ use starknet::{
 
 #[tokio::main]
 async fn main() {
-    let contract_artifact: LegacyContractClass =
+    // Sierra class artifact. Output of the `starknet-compile` command
+    let contract_artifact: SierraClass =
         serde_json::from_reader(std::fs::File::open("/path/to/contract/artifact.json").unwrap())
             .unwrap();
+
+    // Class hash of the compiled CASM class from the `starknet-sierra-compile` command
+    let compiled_class_hash =
+        FieldElement::from_hex_be("COMPILED_CASM_CLASS_HASH_IN_HEX_HERE").unwrap();
+
     let provider = SequencerGatewayProvider::starknet_alpha_goerli();
     let signer = LocalWallet::from(SigningKey::from_secret_scalar(
         FieldElement::from_hex_be("YOUR_PRIVATE_KEY_IN_HEX_HERE").unwrap(),
@@ -23,8 +29,11 @@ async fn main() {
 
     let account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
 
+    // We need to flatten the ABI into a string first
+    let flatten_class = contract_artifact.flantten().unwrap();
+
     let result = account
-        .declare(Arc::new(contract_artifact))
+        .declare(Arc::new(flatten_class), compiled_class_hash)
         .send()
         .await
         .unwrap();

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -20,5 +20,6 @@ async-trait = "0.1.52"
 thiserror = "1.0.30"
 
 [dev-dependencies]
+serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.74"
 tokio = { version = "1.15.0", features = ["full"] }

--- a/starknet-accounts/src/lib.rs
+++ b/starknet-accounts/src/lib.rs
@@ -1,7 +1,8 @@
 mod account;
 pub use account::{
-    Account, AccountError, ConnectedAccount, Declaration, Execution, PreparedDeclaration,
-    PreparedExecution, RawDeclaration, RawExecution,
+    Account, AccountError, ConnectedAccount, Declaration, Execution, LegacyDeclaration,
+    PreparedDeclaration, PreparedExecution, PreparedLegacyDeclaration, RawDeclaration,
+    RawExecution, RawLegacyDeclaration,
 };
 
 mod call;

--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -1,7 +1,10 @@
 use starknet_accounts::{Account, Call, ConnectedAccount, SingleOwnerAccount};
 use starknet_core::{
     chain_id,
-    types::{contract::legacy::LegacyContractClass, AddTransactionResultCode, FieldElement},
+    types::{
+        contract::{legacy::LegacyContractClass, SierraClass},
+        AddTransactionResultCode, FieldElement,
+    },
     utils::get_selector_from_name,
 };
 use starknet_providers::SequencerGatewayProvider;
@@ -186,7 +189,63 @@ async fn can_execute_tst_mint() {
 }
 
 #[tokio::test]
-async fn can_declare_oz_account_contract() {
+async fn can_declare_cairo1_contract() {
+    // This test case is not very useful, same as `can_execute_tst_mint` above.
+
+    #[derive(serde::Deserialize)]
+    struct ContractHashes {
+        compiled_class_hash: String,
+    }
+
+    let provider = SequencerGatewayProvider::starknet_alpha_goerli();
+    let signer = LocalWallet::from(SigningKey::from_secret_scalar(
+        FieldElement::from_hex_be(
+            "00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        )
+        .unwrap(),
+    ));
+    let address = FieldElement::from_hex_be(
+        "02da37a17affbd2df4ede7120dae305ec36dfe94ec96a8c3f49bbf59f4e9a9fa",
+    )
+    .unwrap();
+    let account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+
+    let contract_artifact = serde_json::from_str::<SierraClass>(include_str!(
+        "../test-data/cairo1/artifacts/abi_types_sierra.txt"
+    ))
+    .unwrap();
+    let hashes = serde_json::from_str::<ContractHashes>(include_str!(
+        "../test-data/cairo1/artifacts/abi_types.hashes.json"
+    ))
+    .unwrap();
+
+    // Cairo 1 contract classes are not allowed to be declared multiple times. We spam the network
+    // by exploiting the fact that ABI is part of the class hash.
+    let mut flatten_class = contract_artifact.flantten().unwrap();
+    flatten_class.abi = format!(
+        "Declared from starknet-rs test case. Timestamp: {}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    );
+
+    let result = account
+        .declare(
+            Arc::new(flatten_class),
+            FieldElement::from_hex_be(&hashes.compiled_class_hash).unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    dbg!(&result);
+
+    assert_eq!(result.code, AddTransactionResultCode::TransactionReceived);
+}
+
+#[tokio::test]
+async fn can_declare_cairo0_contract() {
     // This test case is not very useful, same as `can_execute_tst_mint` above.
 
     let provider = SequencerGatewayProvider::starknet_alpha_goerli();
@@ -206,7 +265,7 @@ async fn can_declare_oz_account_contract() {
         serde_json::from_str(include_str!("../test-data/cairo0/artifacts/oz_account.txt")).unwrap();
 
     let result = account
-        .declare(Arc::new(contract_artifact))
+        .declare_legacy(Arc::new(contract_artifact))
         .send()
         .await
         .unwrap();

--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -34,6 +34,8 @@ mod transaction_request;
 pub use transaction_request::{
     AccountTransaction, AddTransactionResult, AddTransactionResultCode, CallFunction,
     CallL1Handler, DeclareTransaction as DeclareTransactionRequest,
+    DeclareV1Transaction as DeclareV1TransactionRequest,
+    DeclareV2Transaction as DeclareV2TransactionRequest,
     DeployAccountTransaction as DeployAccountTransactionRequest,
     InvokeFunctionTransaction as InvokeFunctionTransactionRequest, TransactionRequest,
 };

--- a/starknet-providers/src/jsonrpc/models/conversions.rs
+++ b/starknet-providers/src/jsonrpc/models/conversions.rs
@@ -24,8 +24,8 @@ impl From<FeeEstimate> for core::types::FeeEstimate {
     }
 }
 
-impl From<core::types::DeclareTransactionRequest> for BroadcastedDeclareTransaction {
-    fn from(value: core::types::DeclareTransactionRequest) -> Self {
+impl From<core::types::DeclareV1TransactionRequest> for BroadcastedDeclareTransaction {
+    fn from(value: core::types::DeclareV1TransactionRequest) -> Self {
         Self {
             max_fee: value.max_fee,
             version: 1,
@@ -37,8 +37,8 @@ impl From<core::types::DeclareTransactionRequest> for BroadcastedDeclareTransact
     }
 }
 
-impl From<core::types::DeclareTransactionRequest> for BroadcastedTransaction {
-    fn from(value: core::types::DeclareTransactionRequest) -> Self {
+impl From<core::types::DeclareV1TransactionRequest> for BroadcastedTransaction {
+    fn from(value: core::types::DeclareV1TransactionRequest) -> Self {
         Self::Declare(value.into())
     }
 }
@@ -87,13 +87,18 @@ impl From<core::types::DeployAccountTransactionRequest> for BroadcastedTransacti
     }
 }
 
-impl From<core::types::AccountTransaction> for BroadcastedTransaction {
-    fn from(value: core::types::AccountTransaction) -> Self {
-        match value {
-            core::types::AccountTransaction::Declare(tx) => tx.into(),
+impl TryFrom<core::types::AccountTransaction> for BroadcastedTransaction {
+    type Error = &'static str;
+
+    fn try_from(value: core::types::AccountTransaction) -> Result<Self, Self::Error> {
+        Ok(match value {
+            core::types::AccountTransaction::Declare(tx) => match tx {
+                core::types::DeclareTransactionRequest::V1(tx) => tx.into(),
+                _ => return Err("Declare v2 not support for JSON-RPC yet"),
+            },
             core::types::AccountTransaction::InvokeFunction(tx) => tx.into(),
             core::types::AccountTransaction::DeployAccount(tx) => tx.into(),
-        }
+        })
     }
 }
 

--- a/starknet-providers/src/sequencer_gateway.rs
+++ b/starknet-providers/src/sequencer_gateway.rs
@@ -66,6 +66,8 @@ pub enum ErrorCode {
     UndeclaredClass,
     #[serde(rename = "StarknetErrorCode.INVALID_TRANSACTION_NONCE")]
     InvalidTransactionNonce,
+    #[serde(rename = "StarknetErrorCode.CLASS_ALREADY_DECLARED")]
+    ClassAlreadyDeclared,
 }
 
 impl SequencerGatewayProvider {
@@ -595,6 +597,7 @@ impl TryFrom<ErrorCode> for StarknetError {
             ErrorCode::MalformedRequest => Err(()),
             ErrorCode::UndeclaredClass => Ok(Self::ClassHashNotFound),
             ErrorCode::InvalidTransactionNonce => Err(()),
+            ErrorCode::ClassAlreadyDeclared => Err(()),
         }
     }
 }


### PR DESCRIPTION
There you go. `DECLARE` v2 supported. It's now possible to declare Cairo 1 contracts with `starknet-rs`.

However, this only partially resolves task 4 of #313:

> support sending Declare v2 transactions

as JSON-RPC support is not enabled yet. With this PR declaration is only possible via the sequencer gateway.

This is because the current specs version (0.2.1) does not support `DECLARE` v2. We will need to manually patch the spec to make it work, which is quite some work, and I will deal with that in a separate PR.