### PR TITLE
feat(jsonrpc): declare v2 transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,6 +1575,7 @@ dependencies = [
  "starknet-signers",
  "thiserror",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -23,3 +23,4 @@ thiserror = "1.0.30"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.74"
 tokio = { version = "1.15.0", features = ["full"] }
+url = "2.2.2"

--- a/starknet-core/src/types/contract/mod.rs
+++ b/starknet-core/src/types/contract/mod.rs
@@ -81,7 +81,7 @@ pub struct FlattenedSierraClass {
 }
 
 #[serde_as]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct CompressedSierraClass {
     #[serde(serialize_with = "base64_ser")]

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 starknet-core = { version = "0.2.0", path = "../starknet-core" }
 async-trait = "0.1.52"
 auto_impl = "0.5.0"
+flate2 = "1.0.24"
 url = "2.2.2"
 reqwest = { version = "0.11.8", default-features = false, features = ["json", "rustls-tls"] }
 thiserror = "1.0.30"
@@ -24,7 +25,6 @@ serde_json = "1.0.74"
 serde_with = "2.2.0"
 
 [dev-dependencies]
-flate2 = "1.0.22"
 starknet-providers = { path = ".", features = ["no_unknown_fields"] }
 tokio = { version = "1.15.0", features = ["full"] }
 

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -110,6 +110,13 @@ pub enum BlockId {
     Tag(BlockTag),
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ContractClass {
+    Sierra(SierraContractClass),
+    Legacy(LegacyContractClass),
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type")]
 pub enum Transaction {
@@ -154,6 +161,24 @@ pub enum BroadcastedInvokeTransaction {
     V0(BroadcastedInvokeTransactionV0),
     #[serde(rename = "0x1")]
     V1(BroadcastedInvokeTransactionV1),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "version")]
+pub enum DeclareTransaction {
+    #[serde(rename = "0x1")]
+    V1(DeclareTransactionV1),
+    #[serde(rename = "0x2")]
+    V2(DeclareTransactionV2),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "version")]
+pub enum BroadcastedDeclareTransaction {
+    #[serde(rename = "0x1")]
+    V1(BroadcastedDeclareTransactionV1),
+    #[serde(rename = "0x2")]
+    V2(BroadcastedDeclareTransactionV2),
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/starknet-providers/src/jsonrpc/models/serde_impls.rs
+++ b/starknet-providers/src/jsonrpc/models/serde_impls.rs
@@ -110,6 +110,24 @@ mod enum_ser_impls {
         }
     }
 
+    impl Serialize for DeclareTransaction {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            match self {
+                Self::V1(variant) => variant.serialize(serializer),
+                Self::V2(variant) => variant.serialize(serializer),
+            }
+        }
+    }
+
+    impl Serialize for BroadcastedDeclareTransaction {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            match self {
+                Self::V1(variant) => variant.serialize(serializer),
+                Self::V2(variant) => variant.serialize(serializer),
+            }
+        }
+    }
+
     impl Serialize for TransactionReceipt {
         fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
             match self {


### PR DESCRIPTION
This PR adds `DECLARE` v2 support to JSON-RPC.

Together with #343, resolves task 4 of #313:

> support sending Declare v2 transactions