### PR TITLE
feat(jsonrpc): `BlockId` deserialization

### DIFF
--- a/starknet-providers/src/jsonrpc/models/codegen.rs
+++ b/starknet-providers/src/jsonrpc/models/codegen.rs
@@ -3,7 +3,7 @@
 //     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen
 
 // Code generated with version:
-//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen#521667e90c981b224254a4114215dfc658004b23
+//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen#ca92f96a5f50ee31a2be0eecc0d744be415e3f6e
 
 // Code generation requested but not implemented for these types:
 // - `BLOCK_ID`
@@ -75,7 +75,8 @@ pub struct Event {
 
 /// An event filter/query.
 #[serde_as]
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct EventFilter {
     /// From block
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/starknet-providers/src/jsonrpc/models/mod.rs
+++ b/starknet-providers/src/jsonrpc/models/mod.rs
@@ -219,36 +219,6 @@ pub enum ContractAbiEntry {
     Struct(StructAbiEntry),
 }
 
-impl Serialize for BlockId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        #[serde_as]
-        #[derive(Serialize)]
-        struct BlockHash {
-            #[serde_as(as = "UfeHex")]
-            block_hash: FieldElement,
-        }
-
-        #[derive(Serialize)]
-        struct BlockNumber {
-            block_number: u64,
-        }
-
-        match self {
-            Self::Hash(hash) => BlockHash::serialize(&BlockHash { block_hash: *hash }, serializer),
-            Self::Number(number) => BlockNumber::serialize(
-                &BlockNumber {
-                    block_number: *number,
-                },
-                serializer,
-            ),
-            Self::Tag(tag) => BlockTag::serialize(tag, serializer),
-        }
-    }
-}
-
 impl AsRef<FunctionCall> for FunctionCall {
     fn as_ref(&self) -> &FunctionCall {
         self

--- a/starknet-providers/src/jsonrpc/models/serde_impls.rs
+++ b/starknet-providers/src/jsonrpc/models/serde_impls.rs
@@ -64,6 +64,69 @@ impl<'de> Deserialize<'de> for SyncStatusType {
     }
 }
 
+mod block_id {
+    use serde::{Deserialize, Deserializer, Serialize};
+    use serde_with::serde_as;
+    use starknet_core::{serde::unsigned_field_element::UfeHex, types::FieldElement};
+
+    use crate::jsonrpc::models::{BlockId, BlockTag};
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum BlockIdDe {
+        Hash(BlockHash),
+        Number(BlockNumber),
+        Tag(BlockTag),
+    }
+
+    #[serde_as]
+    #[derive(Serialize, Deserialize)]
+    #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
+    struct BlockHash {
+        #[serde_as(as = "UfeHex")]
+        block_hash: FieldElement,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
+    struct BlockNumber {
+        block_number: u64,
+    }
+
+    impl Serialize for BlockId {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Hash(hash) => {
+                    BlockHash::serialize(&BlockHash { block_hash: *hash }, serializer)
+                }
+                Self::Number(number) => BlockNumber::serialize(
+                    &BlockNumber {
+                        block_number: *number,
+                    },
+                    serializer,
+                ),
+                Self::Tag(tag) => BlockTag::serialize(tag, serializer),
+            }
+        }
+    }
+
+    impl<'de> Deserialize<'de> for BlockId {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            Ok(match BlockIdDe::deserialize(deserializer)? {
+                BlockIdDe::Hash(hash) => Self::Hash(hash.block_hash),
+                BlockIdDe::Number(number) => Self::Number(number.block_number),
+                BlockIdDe::Tag(tag) => Self::Tag(tag),
+            })
+        }
+    }
+}
+
 // Deriving the Serialize trait directly results in duplicate fields since the variants also write
 // the tag fields when individually serialized.
 mod enum_ser_impls {
@@ -149,6 +212,32 @@ mod enum_ser_impls {
                 Self::Deploy(variant) => variant.serialize(serializer),
                 Self::DeployAccount(variant) => variant.serialize(serializer),
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use starknet_core::types::FieldElement;
+
+    use super::super::{BlockId, BlockTag};
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    fn test_blockid_serde() {
+        for (block_id, json) in [
+            (
+                BlockId::Hash(FieldElement::from_hex_be("0x1234").unwrap()),
+                "{\"block_hash\":\"0x1234\"}",
+            ),
+            (BlockId::Number(1234), "{\"block_number\":1234}"),
+            (BlockId::Tag(BlockTag::Latest), "\"latest\""),
+            (BlockId::Tag(BlockTag::Pending), "\"pending\""),
+        ]
+        .into_iter()
+        {
+            assert_eq!(serde_json::to_string(&block_id).unwrap(), json);
+            assert_eq!(serde_json::from_str::<BlockId>(json).unwrap(), block_id);
         }
     }
 }


### PR DESCRIPTION
This PR makes it possible to deserialize `BlockId`, which is useful for applications using `starknet-rs` on the server side.