### PR TITLE
test: re-enable jsonrpc class tests

### DIFF
--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -166,8 +166,6 @@ async fn jsonrpc_get_transaction_receipt() {
 }
 
 #[tokio::test]
-// https://github.com/eqlabs/pathfinder/pull/986
-#[ignore = "Disabled until pathfinder releases the fix"]
 async fn jsonrpc_get_class() {
     let rpc_client = create_jsonrpc_client();
 
@@ -215,8 +213,6 @@ async fn jsonrpc_get_class_hash_at() {
 }
 
 #[tokio::test]
-// https://github.com/eqlabs/pathfinder/pull/986
-#[ignore = "Disabled until pathfinder releases the fix"]
 async fn jsonrpc_get_class_at() {
     let rpc_client = create_jsonrpc_client();
 


### PR DESCRIPTION
It looks like Infura has finally upgrade to `pathfinder` 0.5.3, unblocking the test cases we had to ignore before. This PR re-enables the 2 tests.