### PR TITLE
chore: bump `crypto-bigint` to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2538c4e68e52548bacb3e83ac549f903d44f011ac9d5abb5e132e67d0808f7"
+dependencies = [
+ "generic-array",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,7 +1289,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.4.9",
  "hmac",
  "zeroize",
 ]
@@ -1593,7 +1604,7 @@ name = "starknet-crypto"
 version = "0.4.3"
 dependencies = [
  "criterion",
- "crypto-bigint",
+ "crypto-bigint 0.5.1",
  "hex",
  "hex-literal",
  "hmac",
@@ -1642,7 +1653,7 @@ version = "0.3.1"
 dependencies = [
  "ark-ff",
  "bigdecimal",
- "crypto-bigint",
+ "crypto-bigint 0.5.1",
  "getrandom",
  "hex",
  "num-bigint",

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["ethereum", "starknet", "web3", "no_std"]
 starknet-crypto-codegen = { version = "0.3.0", path = "../starknet-crypto-codegen" }
 starknet-curve = { version = "0.2.1", path = "../starknet-curve" }
 starknet-ff = { version = "0.3.1", path = "../starknet-ff", default-features = false }
-crypto-bigint = { version = "0.4.9", default-features = false }
+crypto-bigint = { version = "0.5.1", default-features = false, features = ["generic-array", "zeroize"] }
 hmac = { version = "0.12.1", default-features = false }
 num-bigint = { version = "0.4.3", default-features = false }
 num-integer = { version = "0.1.44", default-features = false }

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 
 [dependencies]
 ark-ff = { version = "0.4.2", default-features = false }
-crypto-bigint = { version = "0.4.9", default-features = false }
+crypto-bigint = { version = "0.5.1", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 serde = { version = "1.0.152", optional = true, default-features = false }
 bigdecimal = { version = "0.3.0", optional = true }

--- a/starknet-ff/src/lib.rs
+++ b/starknet-ff/src/lib.rs
@@ -16,7 +16,7 @@ use ark_ff::{
     fields::{Field, Fp256, PrimeField},
     BigInteger, BigInteger256,
 };
-use crypto_bigint::{CheckedAdd, CheckedMul, Zero, U256};
+use crypto_bigint::{CheckedAdd, CheckedMul, NonZero, Zero, U256};
 
 mod fr;
 
@@ -273,10 +273,13 @@ impl FieldElement {
     pub fn floor_div(&self, rhs: FieldElement) -> FieldElement {
         let lhs: U256 = self.into();
         let rhs: U256 = (&rhs).into();
-        let div_result = lhs.div_rem(&rhs);
+        let is_rhs_zero: bool = rhs.is_zero().into();
 
-        if div_result.is_some().into() {
-            let (quotient, _) = div_result.unwrap();
+        if !is_rhs_zero {
+            let rhs = NonZero::from_uint(rhs);
+
+            let div_result = lhs.div_rem(&rhs);
+            let (quotient, _) = div_result;
 
             // It's safe to unwrap here since `rem` is never out of range
             FieldElement {
@@ -375,10 +378,12 @@ impl ops::Rem<FieldElement> for FieldElement {
 
         let lhs: U256 = (&self).into();
         let rhs: U256 = (&rhs).into();
-        let div_result = lhs.div_rem(&rhs);
+        let is_rhs_zero: bool = rhs.is_zero().into();
 
-        if div_result.is_some().into() {
-            let (_, rem) = div_result.unwrap();
+        if !is_rhs_zero {
+            let rhs = NonZero::from_uint(rhs);
+
+            let (_, rem) = lhs.div_rem(&rhs);
 
             // It's safe to unwrap here since `rem` is never out of range
             FieldElement {


### PR DESCRIPTION
Bumps `crypto-bigint` and resolves breaking changes.