### PR TITLE
feat: allow setting fee estimate multiplier

### DIFF
--- a/starknet-accounts/src/account/declaration.rs
+++ b/starknet-accounts/src/account/declaration.rs
@@ -54,6 +54,13 @@ impl<'a, A> Declaration<'a, A> {
         }
     }
 
+    pub fn fee_estimate_multiplier(self, fee_estimate_multiplier: f64) -> Self {
+        Self {
+            fee_estimate_multiplier,
+            ..self
+        }
+    }
+
     /// Calling this function after manually specifying `nonce` and `max_fee` turns [Declaration]
     /// into [PreparedDeclaration]. Returns `Err` if either field is `None`.
     pub fn prepared(self) -> Result<PreparedDeclaration<'a, A>, NotPreparedError> {
@@ -183,6 +190,13 @@ impl<'a, A> LegacyDeclaration<'a, A> {
     pub fn max_fee(self, max_fee: FieldElement) -> Self {
         Self {
             max_fee: Some(max_fee),
+            ..self
+        }
+    }
+
+    pub fn fee_estimate_multiplier(self, fee_estimate_multiplier: f64) -> Self {
+        Self {
+            fee_estimate_multiplier,
             ..self
         }
     }

--- a/starknet-accounts/src/account/execution.rs
+++ b/starknet-accounts/src/account/execution.rs
@@ -46,6 +46,13 @@ impl<'a, A> Execution<'a, A> {
         }
     }
 
+    pub fn fee_estimate_multiplier(self, fee_estimate_multiplier: f64) -> Self {
+        Self {
+            fee_estimate_multiplier,
+            ..self
+        }
+    }
+
     /// Calling this function after manually specifying `nonce` and `max_fee` turns [Execution] into
     /// [PreparedExecution]. Returns `Err` if either field is `None`.
     pub fn prepared(self) -> Result<PreparedExecution<'a, A>, NotPreparedError> {


### PR DESCRIPTION
Somehow missed this during the account feature revamp. This allows setting a higher fee buffer without manually estimating fees first.