### PR TITLE
feat: setting fee estimate multiplier for `AccountDeployment`

### DIFF
--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -129,6 +129,13 @@ impl<'f, F> AccountDeployment<'f, F> {
         }
     }
 
+    pub fn fee_estimate_multiplier(self, fee_estimate_multiplier: f64) -> Self {
+        Self {
+            fee_estimate_multiplier,
+            ..self
+        }
+    }
+
     /// Calling this function after manually specifying `nonce` and `max_fee` turns
     /// [AccountDeployment] into [PreparedAccountDeployment]. Returns `Err` if either field is
     /// `None`.


### PR DESCRIPTION
I missed `AccountDeployment` in #361. This PR adds the same `fee_estimate_multiplier()` function for `AccountDeployment` too.