### PR TITLE
feat: allow setting target block for account

### DIFF
--- a/examples/declare_cairo0_contract.rs
+++ b/examples/declare_cairo0_contract.rs
@@ -4,7 +4,7 @@ use starknet::{
     accounts::{Account, SingleOwnerAccount},
     core::{
         chain_id,
-        types::{contract::legacy::LegacyContractClass, FieldElement},
+        types::{contract::legacy::LegacyContractClass, BlockId, FieldElement},
     },
     providers::SequencerGatewayProvider,
     signers::{LocalWallet, SigningKey},
@@ -21,7 +21,11 @@ async fn main() {
     ));
     let address = FieldElement::from_hex_be("YOUR_ACCOUNT_CONTRACT_ADDRESS_IN_HEX_HERE").unwrap();
 
-    let account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+
+    // `SingleOwnerAccount` defaults to checking nonce and estimating fees against the latest
+    // block. Optionally change the target block to pending with the following line:
+    account.set_block_id(BlockId::Pending);
 
     let result = account
         .declare_legacy(Arc::new(contract_artifact))

--- a/examples/declare_cairo1_contract.rs
+++ b/examples/declare_cairo1_contract.rs
@@ -4,7 +4,7 @@ use starknet::{
     accounts::{Account, SingleOwnerAccount},
     core::{
         chain_id,
-        types::{contract::SierraClass, FieldElement},
+        types::{contract::SierraClass, BlockId, FieldElement},
     },
     providers::SequencerGatewayProvider,
     signers::{LocalWallet, SigningKey},
@@ -27,7 +27,11 @@ async fn main() {
     ));
     let address = FieldElement::from_hex_be("YOUR_ACCOUNT_CONTRACT_ADDRESS_IN_HEX_HERE").unwrap();
 
-    let account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+
+    // `SingleOwnerAccount` defaults to checking nonce and estimating fees against the latest
+    // block. Optionally change the target block to pending with the following line:
+    account.set_block_id(BlockId::Pending);
 
     // We need to flatten the ABI into a string first
     let flattened_class = contract_artifact.flatten().unwrap();

--- a/examples/deploy_contract.rs
+++ b/examples/deploy_contract.rs
@@ -5,7 +5,7 @@ use starknet::{
     contract::ContractFactory,
     core::{
         chain_id,
-        types::{contract::legacy::LegacyContractClass, FieldElement},
+        types::{contract::legacy::LegacyContractClass, BlockId, FieldElement},
     },
     macros::felt,
     providers::SequencerGatewayProvider,
@@ -25,7 +25,11 @@ async fn main() {
         FieldElement::from_hex_be("YOUR_PRIVATE_KEY_IN_HEX_HERE").unwrap(),
     ));
     let address = FieldElement::from_hex_be("YOUR_ACCOUNT_CONTRACT_ADDRESS_IN_HEX_HERE").unwrap();
-    let account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+
+    // `SingleOwnerAccount` defaults to checking nonce and estimating fees against the latest
+    // block. Optionally change the target block to pending with the following line:
+    account.set_block_id(BlockId::Pending);
 
     // Wrapping in `Arc` is meaningless here. It's just showcasing it could be done as
     // `Arc<Account>` implements `Account` too.

--- a/examples/mint_tokens.rs
+++ b/examples/mint_tokens.rs
@@ -1,6 +1,10 @@
 use starknet::{
     accounts::{Account, Call, SingleOwnerAccount},
-    core::{chain_id, types::FieldElement, utils::get_selector_from_name},
+    core::{
+        chain_id,
+        types::{BlockId, FieldElement},
+        utils::get_selector_from_name,
+    },
     providers::SequencerGatewayProvider,
     signers::{LocalWallet, SigningKey},
 };
@@ -17,7 +21,11 @@ async fn main() {
     )
     .unwrap();
 
-    let account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+
+    // `SingleOwnerAccount` defaults to checking nonce and estimating fees against the latest
+    // block. Optionally change the target block to pending with the following line:
+    account.set_block_id(BlockId::Pending);
 
     let result = account
         .execute(vec![Call {

--- a/starknet-accounts/src/single_owner.rs
+++ b/starknet-accounts/src/single_owner.rs
@@ -1,7 +1,7 @@
 use crate::{Account, ConnectedAccount, RawDeclaration, RawExecution, RawLegacyDeclaration};
 
 use async_trait::async_trait;
-use starknet_core::types::{contract::ComputeClassHashError, FieldElement};
+use starknet_core::types::{contract::ComputeClassHashError, BlockId, FieldElement};
 use starknet_providers::Provider;
 use starknet_signers::Signer;
 
@@ -15,6 +15,7 @@ where
     signer: S,
     address: FieldElement,
     chain_id: FieldElement,
+    block_id: BlockId,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -36,7 +37,13 @@ where
             signer,
             address,
             chain_id,
+            block_id: BlockId::Latest,
         }
+    }
+
+    pub fn set_block_id(&mut self, block_id: BlockId) -> &Self {
+        self.block_id = block_id;
+        self
     }
 }
 
@@ -111,5 +118,9 @@ where
 
     fn provider(&self) -> &Self::Provider {
         &self.provider
+    }
+
+    fn block_id(&self) -> BlockId {
+        self.block_id
     }
 }

--- a/starknet-core/src/types/block.rs
+++ b/starknet-core/src/types/block.rs
@@ -6,6 +6,7 @@ use super::{
 use serde::Deserialize;
 use serde_with::serde_as;
 
+#[derive(Debug, Clone, Copy)]
 pub enum BlockId {
     Hash(FieldElement),
     Number(u64),


### PR DESCRIPTION
This PR enables setting the target block ID for `SingleOwnerAccount`. Currently, the account is hard-coded to make queries (for nonce and fees) against the latest block. With this change users can now specify a different one, for example the pending block.

I was reluctant to add this because the whole concept of a pending block will likely be removed anyways, but that's probably gonna take quite a while to happen, so here we go.