### PR TITLE
feat: restrict all error types to be Send + Sync

### DIFF
--- a/starknet-accounts/src/account/mod.rs
+++ b/starknet-accounts/src/account/mod.rs
@@ -21,7 +21,7 @@ mod execution;
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait Account: Sized {
-    type SignError: Error;
+    type SignError: Error + Send + Sync;
 
     fn address(&self) -> FieldElement;
 

--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -43,7 +43,7 @@ const ADDR_BOUND: FieldElement = FieldElement::from_mont([
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait AccountFactory: Sized {
     type Provider: Provider;
-    type SignError: Error;
+    type SignError: Error + Send + Sync;
 
     fn class_hash(&self) -> FieldElement;
 

--- a/starknet-providers/src/jsonrpc/transports/mod.rs
+++ b/starknet-providers/src/jsonrpc/transports/mod.rs
@@ -12,7 +12,7 @@ pub use http::HttpTransport;
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[auto_impl(&, Box, Arc)]
 pub trait JsonRpcTransport {
-    type Error: Error + Send;
+    type Error: Error + Send + Sync;
 
     async fn send_request<P, R>(
         &self,

--- a/starknet-providers/src/provider.rs
+++ b/starknet-providers/src/provider.rs
@@ -13,7 +13,7 @@ use std::error::Error;
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[auto_impl(&, Box, Arc)]
 pub trait Provider {
-    type Error: Error + Send;
+    type Error: Error + Send + Sync;
 
     async fn add_transaction(
         &self,

--- a/starknet-signers/src/signer.rs
+++ b/starknet-signers/src/signer.rs
@@ -7,8 +7,8 @@ use std::error::Error;
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait Signer {
-    type GetPublicKeyError: Error + Send;
-    type SignError: Error + Send;
+    type GetPublicKeyError: Error + Send + Sync;
+    type SignError: Error + Send + Sync;
 
     async fn get_public_key(&self) -> Result<VerifyingKey, Self::GetPublicKeyError>;
 


### PR DESCRIPTION
Makes the life of downstream application developers easier since they will have fewer constraints to write explicitly, unless there's a use case screwed by this that I'm not aware of.