### PR TITLE
fix: panic in ecdsa verify and recover

### DIFF
--- a/starknet-core/src/crypto.rs
+++ b/starknet-core/src/crypto.rs
@@ -14,6 +14,8 @@ pub enum EcdsaSignError {
 pub enum EcdsaVerifyError {
     #[error("message hash out of range")]
     MessageHashOutOfRange,
+    #[error("invalid public key")]
+    InvalidPublicKey,
     #[error("signature r value out of range")]
     SignatureROutOfRange,
     #[error("signature s value out of range")]
@@ -66,6 +68,7 @@ pub fn ecdsa_verify(
     match verify(public_key, message_hash, &signature.r, &signature.s) {
         Ok(result) => Ok(result),
         Err(VerifyError::InvalidMessageHash) => Err(EcdsaVerifyError::MessageHashOutOfRange),
+        Err(VerifyError::InvalidPublicKey) => Err(EcdsaVerifyError::InvalidPublicKey),
         Err(VerifyError::InvalidR) => Err(EcdsaVerifyError::SignatureROutOfRange),
         Err(VerifyError::InvalidS) => Err(EcdsaVerifyError::SignatureSOutOfRange),
     }

--- a/starknet-crypto/src/error.rs
+++ b/starknet-crypto/src/error.rs
@@ -24,6 +24,7 @@ mod verify_error {
     /// Errors when performing ECDSA [`verify`](fn.verify) operations
     #[derive(Debug)]
     pub enum VerifyError {
+        InvalidPublicKey,
         InvalidMessageHash,
         InvalidR,
         InvalidS,
@@ -36,6 +37,7 @@ mod verify_error {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             match self {
                 Self::InvalidMessageHash => write!(f, "Invalid message hash"),
+                Self::InvalidPublicKey => write!(f, "Invalid public key"),
                 Self::InvalidR => write!(f, "Invalid r"),
                 Self::InvalidS => write!(f, "Invalid s"),
             }

--- a/starknet-curve/src/ec_point.rs
+++ b/starknet-curve/src/ec_point.rs
@@ -21,13 +21,13 @@ pub struct ProjectivePoint {
 }
 
 impl AffinePoint {
-    pub fn from_x(x: FieldElement) -> Self {
+    pub fn from_x(x: FieldElement) -> Option<Self> {
         let y_squared = x * x * x + ALPHA * x + BETA;
-        Self {
+        y_squared.sqrt().map(|y| Self {
             x,
-            y: y_squared.sqrt().unwrap(), // TODO: check if calling `unwrap()` here is safe
+            y,
             infinity: false,
-        }
+        })
     }
 
     fn identity() -> AffinePoint {


### PR DESCRIPTION
Fixes #365.

This PR fixes a panic when calling `verify()` or `recover()` in `starknet-crypto` as the library always assumed that inputs are valid.

Downstream applications should upgrade to `0.4.4` (to be published after this PR) asap to avoid invalid inputs from crashing them.