### PR TITLE
perf: projective point for ecdsa ops

### DIFF
--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -64,5 +64,9 @@ name = "ecdsa_verify"
 harness = false
 
 [[bench]]
+name = "ecdsa_recover"
+harness = false
+
+[[bench]]
 name = "rfc6979_generate_k"
 harness = false

--- a/starknet-crypto/benches/ecdsa_recover.rs
+++ b/starknet-crypto/benches/ecdsa_recover.rs
@@ -1,0 +1,28 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use starknet_crypto::{recover, sign, FieldElement};
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let private_key = FieldElement::from_hex_be(
+        "0000000000000000000000000000000000000000000000000000000000000001",
+    )
+    .unwrap();
+    let message = FieldElement::from_hex_be(
+        "0000000000000000000000000000000000000000000000000000000000000001",
+    )
+    .unwrap();
+    let k = FieldElement::from_hex_be(
+        "0000000000000000000000000000000000000000000000000000000000000001",
+    )
+    .unwrap();
+
+    let signature = sign(&private_key, &message, &k).unwrap();
+
+    c.bench_function("ecdsa_recover", |b| {
+        b.iter(|| {
+            _ = black_box(recover(&message, &signature.r, &signature.s, &signature.v).unwrap());
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
Migrated all multiplications between EC points and field elements in ECDSA to projective points. Included a new benchmark for the `ecdsa_recover` function.
Refactored the `ecdsa_verify` changes too so all use a little helper to reduce boilerplate.

Results:
```
ecdsa_get_public_key    time:   [113.13 µs 113.20 µs 113.28 µs]
                        change: [-92.975% -92.959% -92.940%] (p = 0.00 < 0.05)
                        Performance has improved.

ecdsa_recover           time:   [412.73 µs 413.33 µs 414.48 µs]
                        change: [-88.145% -88.120% -88.082%] (p = 0.00 < 0.05)
                        Performance has improved.

ecdsa_sign              time:   [160.00 µs 160.06 µs 160.14 µs]
                        change: [-90.003% -89.985% -89.967%] (p = 0.00 < 0.05)
                        Performance has improved.

ecdsa_verify            time:   [412.61 µs 412.77 µs 412.98 µs]
                        change: [-3.8553% -1.8908% -0.5588%] (p = 0.01 < 0.05)
                        Change within noise threshold.
```