### PR TITLE
release: bump starknet-crypto to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "criterion",
  "crypto-bigint",

--- a/examples/starknet-wasm/Cargo.toml
+++ b/examples/starknet-wasm/Cargo.toml
@@ -20,6 +20,6 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 starknet-ff = { version = "0.3.2", path = "../../starknet-ff" }
-starknet-crypto = { version = "0.5.0", path = "../../starknet-crypto" }
+starknet-crypto = { version = "0.5.1", path = "../../starknet-crypto" }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 wasm-bindgen = "0.2.84"

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 all-features = true
 
 [dependencies]
-starknet-crypto = { version = "0.5.0", path = "../starknet-crypto" }
+starknet-crypto = { version = "0.5.1", path = "../starknet-crypto" }
 starknet-ff = { version = "0.3.2", path = "../starknet-ff", features = [
     "serde",
 ] }

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-crypto"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
 starknet-core = { version = "0.2.0", path = "../starknet-core" }
-starknet-crypto = { version = "0.5.0", path = "../starknet-crypto" }
+starknet-crypto = { version = "0.5.1", path = "../starknet-crypto" }
 async-trait = "0.1.68"
 thiserror = "1.0.40"
 


### PR DESCRIPTION
Makes another `starknet-crypto` release to make performance improvements from #368 available on crates.io.