### PR TITLE
feat(jsonrpc): server-side request parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Examples can be found in the [examples folder](./examples):
 
 8. [Deploy an Argent X account to a pre-funded address](./examples/deploy_argent_account.rs)
 
+9. [Parsing a JSON-RPC request on the server side](./examples/parse_jsonrpc_request.rs)
+
 ## License
 
 Licensed under either of

--- a/examples/parse_jsonrpc_request.rs
+++ b/examples/parse_jsonrpc_request.rs
@@ -1,0 +1,28 @@
+use starknet_providers::jsonrpc::{JsonRpcRequest, JsonRpcRequestData};
+
+fn main() {
+    // Let's pretend this is the raw request body coming from HTTP
+    let raw_request = r###"{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "method": "starknet_getBlockTransactionCount",
+    "params": [{ "block_number": 200 }]
+}"###;
+
+    // Your server framework should handle this for you. Here we deserialize manually to see what's
+    // going on.
+    let parsed_request =
+        serde_json::from_str::<JsonRpcRequest>(raw_request).expect("unable to parse request");
+
+    println!("Request received: {:#?}", parsed_request);
+
+    match parsed_request.data {
+        JsonRpcRequestData::GetBlockTransactionCount(req) => {
+            println!(
+                "starknet_getBlockTransactionCount request received for block: {:?}",
+                req.block_id
+            );
+        }
+        _ => panic!("Request handler for this method has not been implemented"),
+    }
+}

--- a/starknet-providers/src/jsonrpc/transports/http.rs
+++ b/starknet-providers/src/jsonrpc/transports/http.rs
@@ -2,14 +2,20 @@ use async_trait::async_trait;
 use reqwest::{Client, Url};
 use serde::{de::DeserializeOwned, Serialize};
 
-use crate::jsonrpc::{
-    transports::JsonRpcTransport, JsonRpcMethod, JsonRpcRequest, JsonRpcResponse,
-};
+use crate::jsonrpc::{transports::JsonRpcTransport, JsonRpcMethod, JsonRpcResponse};
 
 #[derive(Debug)]
 pub struct HttpTransport {
     client: Client,
     url: Url,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcRequest<T> {
+    id: u64,
+    jsonrpc: &'static str,
+    method: JsonRpcMethod,
+    params: T,
 }
 
 impl HttpTransport {


### PR DESCRIPTION
This PR adds a new public type `JsonRpcRequest` for easy parsing of jsonrpc requests on the server side. A new example `parse_jsonrpc_request` has also been added to demonstrate how it would work. With this new type, jsonrpc server implementations would simply need to write handlers for the different data variants - no need to fiddle with parsing params or mapping request data types to methods names.

Do note that the automatic generation of response types hasn't been implemented yet, meaning server implementations would still need to manually put together the response types at the moment.