### PR TITLE
feat: random `SigningKey` generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,6 +1785,7 @@ name = "starknet-signers"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "crypto-bigint",
  "eth-keystore",
  "rand",
  "starknet-core",

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -17,10 +17,11 @@ starknet-core = { version = "0.2.0", path = "../starknet-core" }
 starknet-crypto = { version = "0.5.1", path = "../starknet-crypto" }
 async-trait = "0.1.68"
 thiserror = "1.0.40"
+crypto-bigint = { version = "0.5.1", default-features = false }
+rand = { version = "0.8.5", features = ["std_rng"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 eth-keystore = { version = "0.5.0", default-features = false }
-rand = { version = "0.8.5", features = ["std_rng"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.34"


### PR DESCRIPTION
Supports cryptographically secure random `SigningKey` generation. This will be useful for generating new keystores in `starkli`.