### PR TITLE
feat: implement `Provider` for `SequencerGatewayProvider`

### DIFF
--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -26,7 +26,6 @@ fn create_jsonrpc_client() -> JsonRpcClient<HttpTransport> {
 }
 
 #[tokio::test]
-#[ignore = "disabled until sequencer properly implements the Provider trait"]
 async fn can_get_nonce_with_sequencer() {
     can_get_nonce_inner(create_sequencer_client()).await
 }
@@ -37,7 +36,6 @@ async fn can_get_nonce_with_jsonrpc() {
 }
 
 #[tokio::test]
-#[ignore = "disabled until sequencer properly implements the Provider trait"]
 async fn can_estimate_fee_with_sequencer() {
     can_estimate_fee_inner(create_sequencer_client()).await
 }
@@ -51,7 +49,6 @@ async fn can_estimate_fee_with_jsonrpc() {
 // TODO: add `simulate` test cases back once transaction simulation in supported
 
 #[tokio::test]
-#[ignore = "disabled until sequencer properly implements the Provider trait"]
 async fn can_execute_tst_mint_with_sequencer() {
     can_execute_tst_mint_inner(create_sequencer_client()).await
 }
@@ -62,7 +59,6 @@ async fn can_execute_tst_mint_with_jsonrpc() {
 }
 
 #[tokio::test]
-#[ignore = "disabled until sequencer properly implements the Provider trait"]
 async fn can_declare_cairo1_contract_with_sequencer() {
     can_declare_cairo1_contract_inner(create_sequencer_client()).await
 }
@@ -75,7 +71,6 @@ async fn can_declare_cairo1_contract_with_jsonrpc() {
 }
 
 #[tokio::test]
-#[ignore = "disabled until sequencer properly implements the Provider trait"]
 async fn can_declare_cairo0_contract_with_sequencer() {
     can_declare_cairo0_contract_inner(create_sequencer_client()).await
 }

--- a/starknet-core/src/types/codegen.rs
+++ b/starknet-core/src/types/codegen.rs
@@ -3,7 +3,7 @@
 //     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen
 
 // Code generated with version:
-//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen#3728a718d67fc9039763a309f31a6ed379699460
+//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen#8fd635c4ef0fcde33b138f3a3b3c580c37e2e378
 
 // Code generation requested but not implemented for these types:
 // - `BLOCK_ID`
@@ -845,11 +845,13 @@ pub struct StateDiff {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct StateUpdate {
-    #[serde_as(as = "UfeHex")]
-    pub block_hash: FieldElement,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<UfeHex>")]
+    pub block_hash: Option<FieldElement>,
     /// The new global state root
-    #[serde_as(as = "UfeHex")]
-    pub new_root: FieldElement,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<UfeHex>")]
+    pub new_root: Option<FieldElement>,
     /// The previous global state root
     #[serde_as(as = "UfeHex")]
     pub old_root: FieldElement,

--- a/starknet-core/src/types/contract/mod.rs
+++ b/starknet-core/src/types/contract/mod.rs
@@ -1,15 +1,9 @@
-use std::io::Write;
-
-use flate2::{write::GzEncoder, Compression};
 use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::serde_as;
 use starknet_crypto::{poseidon_hash_many, PoseidonHasher};
 
 use crate::{
-    serde::{
-        byte_array::base64::serialize as base64_ser, json::to_string_pythonic,
-        unsigned_field_element::UfeHex,
-    },
+    serde::{json::to_string_pythonic, unsigned_field_element::UfeHex},
     types::{ContractEntryPoint, EntryPointsByType, FieldElement, FlattenedSierraClass},
     utils::{
         cairo_short_string_to_felt, normalize_address, starknet_keccak, CairoShortStringToFeltError,
@@ -67,17 +61,6 @@ pub struct CompiledClass {
     pub hints: Vec<Hint>,
     pub pythonic_hints: Option<Vec<PythonicHint>>,
     pub entry_points_by_type: CompiledClassEntrypointList,
-}
-
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
-pub struct CompressedSierraClass {
-    #[serde(serialize_with = "base64_ser")]
-    pub sierra_program: Vec<u8>,
-    pub contract_class_version: String,
-    pub entry_points_by_type: EntryPointsByType,
-    pub abi: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -259,30 +242,6 @@ impl FlattenedSierraClass {
         hasher.update(poseidon_hash_many(&self.sierra_program));
 
         normalize_address(hasher.finalize())
-    }
-
-    pub fn compress(&self) -> Result<CompressedSierraClass, CompressProgramError> {
-        #[serde_as]
-        #[derive(Serialize)]
-        struct SierraProgram<'a>(#[serde_as(as = "Vec<UfeHex>")] &'a Vec<FieldElement>);
-
-        let program_json = serde_json::to_string(&SierraProgram(&self.sierra_program))
-            .map_err(CompressProgramError::Json)?;
-
-        // Use best compression level to optimize for payload size
-        let mut gzip_encoder = GzEncoder::new(Vec::new(), Compression::best());
-        gzip_encoder
-            .write_all(program_json.as_bytes())
-            .map_err(CompressProgramError::Io)?;
-
-        let compressed_program = gzip_encoder.finish().map_err(CompressProgramError::Io)?;
-
-        Ok(CompressedSierraClass {
-            sierra_program: compressed_program,
-            contract_class_version: self.contract_class_version.clone(),
-            entry_points_by_type: self.entry_points_by_type.clone(),
-            abi: self.abi.clone(),
-        })
     }
 }
 

--- a/starknet-core/src/types/conversions.rs
+++ b/starknet-core/src/types/conversions.rs
@@ -1,0 +1,54 @@
+use super::{
+    contract::legacy::{
+        RawLegacyAbiEntry, RawLegacyConstructor, RawLegacyEvent, RawLegacyFunction,
+        RawLegacyL1Handler, RawLegacyMember, RawLegacyStruct,
+    },
+    LegacyContractAbiEntry, LegacyFunctionAbiType,
+};
+
+impl From<LegacyContractAbiEntry> for RawLegacyAbiEntry {
+    fn from(value: LegacyContractAbiEntry) -> Self {
+        match value {
+            LegacyContractAbiEntry::Function(inner) => match inner.r#type {
+                LegacyFunctionAbiType::Function => RawLegacyAbiEntry::Function(RawLegacyFunction {
+                    inputs: inner.inputs,
+                    name: inner.name,
+                    outputs: inner.outputs,
+                    state_mutability: inner.state_mutability,
+                }),
+                LegacyFunctionAbiType::L1Handler => {
+                    RawLegacyAbiEntry::L1Handler(RawLegacyL1Handler {
+                        inputs: inner.inputs,
+                        name: inner.name,
+                        outputs: inner.outputs,
+                    })
+                }
+                LegacyFunctionAbiType::Constructor => {
+                    RawLegacyAbiEntry::Constructor(RawLegacyConstructor {
+                        inputs: inner.inputs,
+                        name: inner.name,
+                        outputs: inner.outputs,
+                    })
+                }
+            },
+            LegacyContractAbiEntry::Event(inner) => RawLegacyAbiEntry::Event(RawLegacyEvent {
+                data: inner.data,
+                keys: inner.keys,
+                name: inner.name,
+            }),
+            LegacyContractAbiEntry::Struct(inner) => RawLegacyAbiEntry::Struct(RawLegacyStruct {
+                members: inner
+                    .members
+                    .into_iter()
+                    .map(|item| RawLegacyMember {
+                        name: item.name,
+                        offset: item.offset,
+                        r#type: item.r#type,
+                    })
+                    .collect(),
+                name: inner.name,
+                size: inner.size,
+            }),
+        }
+    }
+}

--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -8,6 +8,8 @@ pub use ethereum_types::Address as L1Address;
 
 pub use starknet_ff::*;
 
+mod conversions;
+
 mod serde_impls;
 
 // TODO: better namespacing of exports?

--- a/starknet-providers/src/sequencer/mod.rs
+++ b/starknet-providers/src/sequencer/mod.rs
@@ -5,6 +5,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Error as SerdeJsonError;
 use serde_with::serde_as;
 use starknet_core::{
+    chain_id,
     serde::unsigned_field_element::UfeHex,
     types::{
         contract::{legacy::LegacyContractCode, CompiledClass},
@@ -26,6 +27,7 @@ pub struct SequencerGatewayProvider {
     client: Client,
     gateway_url: Url,
     feeder_gateway_url: Url,
+    chain_id: FieldElement,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -81,19 +83,25 @@ pub enum ErrorCode {
 }
 
 impl SequencerGatewayProvider {
-    pub fn new(gateway_url: impl Into<Url>, feeder_gateway_url: impl Into<Url>) -> Self {
-        Self::new_with_client(gateway_url, feeder_gateway_url, Client::new())
+    pub fn new(
+        gateway_url: impl Into<Url>,
+        feeder_gateway_url: impl Into<Url>,
+        chain_id: FieldElement,
+    ) -> Self {
+        Self::new_with_client(gateway_url, feeder_gateway_url, chain_id, Client::new())
     }
 
     pub fn new_with_client(
         gateway_url: impl Into<Url>,
         feeder_gateway_url: impl Into<Url>,
+        chain_id: FieldElement,
         client: Client,
     ) -> Self {
         Self {
             client,
             gateway_url: gateway_url.into(),
             feeder_gateway_url: feeder_gateway_url.into(),
+            chain_id,
         }
     }
 
@@ -101,6 +109,7 @@ impl SequencerGatewayProvider {
         Self::new(
             Url::parse("https://alpha-mainnet.starknet.io/gateway").unwrap(),
             Url::parse("https://alpha-mainnet.starknet.io/feeder_gateway").unwrap(),
+            chain_id::MAINNET,
         )
     }
 
@@ -108,6 +117,7 @@ impl SequencerGatewayProvider {
         Self::new(
             Url::parse("https://alpha4.starknet.io/gateway").unwrap(),
             Url::parse("https://alpha4.starknet.io/feeder_gateway").unwrap(),
+            chain_id::TESTNET,
         )
     }
 
@@ -115,13 +125,7 @@ impl SequencerGatewayProvider {
         Self::new(
             Url::parse("https://alpha4-2.starknet.io/gateway").unwrap(),
             Url::parse("https://alpha4-2.starknet.io/feeder_gateway").unwrap(),
-        )
-    }
-
-    pub fn starknet_nile_localhost() -> Self {
-        Self::new(
-            Url::parse("http://127.0.0.1:5050/gateway").unwrap(),
-            Url::parse("http://127.0.0.1:5050/feeder_gateway").unwrap(),
+            chain_id::TESTNET2,
         )
     }
 }

--- a/starknet-providers/src/sequencer/mod.rs
+++ b/starknet-providers/src/sequencer/mod.rs
@@ -16,7 +16,7 @@ use url::Url;
 // Sequencer specific model types. Not exposed by design to discourage sequencer usage.
 #[allow(unused)]
 pub mod models;
-use models::*;
+use models::{conversions::ConversionError, *};
 
 // Allows sequencer gateway to be used as if it's jsonrpc.
 mod provider;
@@ -716,6 +716,12 @@ impl TryFrom<ErrorCode> for StarknetError {
             ErrorCode::InvalidTransactionNonce => Err(()),
             ErrorCode::ClassAlreadyDeclared => Err(()),
         }
+    }
+}
+
+impl From<ConversionError> for ProviderError<GatewayClientError> {
+    fn from(_value: ConversionError) -> Self {
+        Self::Other(GatewayClientError::ModelConversionError)
     }
 }
 

--- a/starknet-providers/src/sequencer/models/contract.rs
+++ b/starknet-providers/src/sequencer/models/contract.rs
@@ -1,9 +1,16 @@
+use std::io::Write;
+
+use flate2::{write::GzEncoder, Compression};
 use serde::{Deserialize, Deserializer, Serialize};
+use serde_with::serde_as;
 use starknet_core::{
-    serde::byte_array::base64::serialize as base64_ser,
+    serde::{byte_array::base64::serialize as base64_ser, unsigned_field_element::UfeHex},
     types::{
-        contract::legacy::{LegacyContractClass, RawLegacyAbiEntry, RawLegacyEntryPoints},
-        FlattenedSierraClass,
+        contract::{
+            legacy::{LegacyContractClass, RawLegacyAbiEntry, RawLegacyEntryPoints},
+            CompressProgramError,
+        },
+        EntryPointsByType, FieldElement, FlattenedSierraClass,
     },
 };
 
@@ -13,6 +20,17 @@ use starknet_core::{
 pub enum DeployedClass {
     SierraClass(FlattenedSierraClass),
     LegacyClass(LegacyContractClass),
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
+pub struct CompressedSierraClass {
+    #[serde(serialize_with = "base64_ser")]
+    pub sierra_program: Vec<u8>,
+    pub contract_class_version: String,
+    pub entry_points_by_type: EntryPointsByType,
+    pub abi: String,
 }
 
 /// This type exists because of an `offset` issue. Without this type declaration of pre 0.11.0
@@ -43,5 +61,33 @@ impl<'de> Deserialize<'de> for DeployedClass {
         Err(serde::de::Error::custom(
             "data did not match any variant of enum DeployedClass",
         ))
+    }
+}
+
+impl CompressedSierraClass {
+    pub fn from_flattened(
+        flattened_class: &FlattenedSierraClass,
+    ) -> Result<Self, CompressProgramError> {
+        #[serde_as]
+        #[derive(Serialize)]
+        struct SierraProgram<'a>(#[serde_as(as = "Vec<UfeHex>")] &'a Vec<FieldElement>);
+
+        let program_json = serde_json::to_string(&SierraProgram(&flattened_class.sierra_program))
+            .map_err(CompressProgramError::Json)?;
+
+        // Use best compression level to optimize for payload size
+        let mut gzip_encoder = GzEncoder::new(Vec::new(), Compression::best());
+        gzip_encoder
+            .write_all(program_json.as_bytes())
+            .map_err(CompressProgramError::Io)?;
+
+        let compressed_program = gzip_encoder.finish().map_err(CompressProgramError::Io)?;
+
+        Ok(CompressedSierraClass {
+            sierra_program: compressed_program,
+            contract_class_version: flattened_class.contract_class_version.clone(),
+            entry_points_by_type: flattened_class.entry_points_by_type.clone(),
+            abi: flattened_class.abi.clone(),
+        })
     }
 }

--- a/starknet-providers/src/sequencer/models/conversions.rs
+++ b/starknet-providers/src/sequencer/models/conversions.rs
@@ -600,3 +600,13 @@ impl TryFrom<TransactionStatus> for core::TransactionStatus {
         }
     }
 }
+
+impl From<core::FunctionCall> for CallFunction {
+    fn from(value: core::FunctionCall) -> Self {
+        Self {
+            contract_address: value.contract_address,
+            entry_point_selector: value.entry_point_selector,
+            calldata: value.calldata,
+        }
+    }
+}

--- a/starknet-providers/src/sequencer/models/conversions.rs
+++ b/starknet-providers/src/sequencer/models/conversions.rs
@@ -1,4 +1,4 @@
-use starknet_core::types as core;
+use starknet_core::types::{self as core, FieldElement};
 
 use super::*;
 
@@ -56,6 +56,45 @@ impl TryFrom<Block> for core::MaybePendingBlockWithTxHashes {
     }
 }
 
+impl TryFrom<Block> for core::MaybePendingBlockWithTxs {
+    type Error = ConversionError;
+
+    fn try_from(value: Block) -> Result<Self, Self::Error> {
+        match (value.block_hash, value.block_number, value.state_root) {
+            // Confirmed block
+            (Some(block_hash), Some(block_number), Some(state_root)) => {
+                Ok(Self::Block(core::BlockWithTxs {
+                    status: value.status.try_into()?,
+                    block_hash,
+                    parent_hash: value.parent_block_hash,
+                    block_number,
+                    new_root: state_root,
+                    timestamp: value.timestamp,
+                    sequencer_address: value.sequencer_address.unwrap_or_default(),
+                    transactions: value
+                        .transactions
+                        .into_iter()
+                        .map(|tx| tx.try_into())
+                        .collect::<Result<_, _>>()?,
+                }))
+            }
+            // Pending block
+            (None, None, None) => Ok(Self::PendingBlock(core::PendingBlockWithTxs {
+                transactions: value
+                    .transactions
+                    .into_iter()
+                    .map(|tx| tx.try_into())
+                    .collect::<Result<_, _>>()?,
+                timestamp: value.timestamp,
+                sequencer_address: value.sequencer_address.unwrap_or_default(),
+                parent_hash: value.parent_block_hash,
+            })),
+            // Unknown combination
+            _ => Err(ConversionError),
+        }
+    }
+}
+
 impl TryFrom<BlockStatus> for core::BlockStatus {
     type Error = ConversionError;
 
@@ -67,5 +106,124 @@ impl TryFrom<BlockStatus> for core::BlockStatus {
             BlockStatus::AcceptedOnL2 => Ok(Self::AcceptedOnL2),
             BlockStatus::AcceptedOnL1 => Ok(Self::AcceptedOnL1),
         }
+    }
+}
+
+impl TryFrom<TransactionType> for core::Transaction {
+    type Error = ConversionError;
+
+    fn try_from(value: TransactionType) -> Result<Self, Self::Error> {
+        match value {
+            TransactionType::Declare(inner) => Ok(Self::Declare(inner.try_into()?)),
+            TransactionType::Deploy(inner) => Ok(Self::Deploy(inner.try_into()?)),
+            TransactionType::DeployAccount(inner) => Ok(Self::DeployAccount(inner.into())),
+            TransactionType::InvokeFunction(inner) => Ok(Self::Invoke(inner.try_into()?)),
+            TransactionType::L1Handler(inner) => Ok(Self::L1Handler(inner.try_into()?)),
+        }
+    }
+}
+
+impl TryFrom<DeclareTransaction> for core::DeclareTransaction {
+    type Error = ConversionError;
+
+    fn try_from(value: DeclareTransaction) -> Result<Self, Self::Error> {
+        if value.version == FieldElement::ONE {
+            Ok(Self::V1(core::DeclareTransactionV1 {
+                transaction_hash: value.transaction_hash,
+                max_fee: value.max_fee,
+                signature: value.signature,
+                nonce: value.nonce,
+                class_hash: value.class_hash,
+                sender_address: value.sender_address,
+            }))
+        } else if value.version == FieldElement::TWO {
+            Ok(Self::V2(core::DeclareTransactionV2 {
+                transaction_hash: value.transaction_hash,
+                max_fee: value.max_fee,
+                signature: value.signature,
+                nonce: value.nonce,
+                class_hash: value.class_hash,
+                compiled_class_hash: value.compiled_class_hash.ok_or(ConversionError)?,
+                sender_address: value.sender_address,
+            }))
+        } else {
+            Err(ConversionError)
+        }
+    }
+}
+
+impl TryFrom<DeployTransaction> for core::DeployTransaction {
+    type Error = ConversionError;
+
+    fn try_from(value: DeployTransaction) -> Result<Self, Self::Error> {
+        Ok(Self {
+            transaction_hash: value.transaction_hash,
+            class_hash: value.class_hash,
+            version: value.version.try_into().map_err(|_| ConversionError)?,
+            contract_address_salt: value.contract_address_salt,
+            constructor_calldata: value.constructor_calldata,
+        })
+    }
+}
+
+impl From<DeployAccountTransaction> for core::DeployAccountTransaction {
+    fn from(value: DeployAccountTransaction) -> Self {
+        Self {
+            transaction_hash: value.transaction_hash,
+            max_fee: value.max_fee,
+            signature: value.signature,
+            nonce: value.nonce,
+            contract_address_salt: value.contract_address_salt,
+            constructor_calldata: value.constructor_calldata,
+            class_hash: value.class_hash,
+        }
+    }
+}
+
+impl TryFrom<InvokeFunctionTransaction> for core::InvokeTransaction {
+    type Error = ConversionError;
+
+    fn try_from(value: InvokeFunctionTransaction) -> Result<Self, Self::Error> {
+        if value.version == FieldElement::ZERO {
+            Ok(Self::V0(core::InvokeTransactionV0 {
+                transaction_hash: value.transaction_hash,
+                max_fee: value.max_fee,
+                signature: value.signature,
+                nonce: value.nonce.unwrap_or_default(),
+                contract_address: value.sender_address,
+                entry_point_selector: value.entry_point_selector.ok_or(ConversionError)?,
+                calldata: value.calldata,
+            }))
+        } else if value.version == FieldElement::ONE {
+            Ok(Self::V1(core::InvokeTransactionV1 {
+                transaction_hash: value.transaction_hash,
+                max_fee: value.max_fee,
+                signature: value.signature,
+                nonce: value.nonce.ok_or(ConversionError)?,
+                sender_address: value.sender_address,
+                calldata: value.calldata,
+            }))
+        } else {
+            Err(ConversionError)
+        }
+    }
+}
+
+impl TryFrom<L1HandlerTransaction> for core::L1HandlerTransaction {
+    type Error = ConversionError;
+
+    fn try_from(value: L1HandlerTransaction) -> Result<Self, Self::Error> {
+        Ok(Self {
+            transaction_hash: value.transaction_hash,
+            version: value.version.try_into().map_err(|_| ConversionError)?,
+            nonce: value
+                .nonce
+                .unwrap_or_default()
+                .try_into()
+                .map_err(|_| ConversionError)?,
+            contract_address: value.contract_address,
+            entry_point_selector: value.entry_point_selector,
+            calldata: value.calldata,
+        })
     }
 }

--- a/starknet-providers/src/sequencer/models/conversions.rs
+++ b/starknet-providers/src/sequencer/models/conversions.rs
@@ -756,6 +756,19 @@ impl From<core::CompressedLegacyContractClass> for CompressedLegacyContractClass
     }
 }
 
+impl TryFrom<DeployedClass> for core::ContractClass {
+    type Error = ConversionError;
+
+    fn try_from(value: DeployedClass) -> Result<Self, Self::Error> {
+        match value {
+            DeployedClass::SierraClass(inner) => Ok(Self::Sierra(inner)),
+            DeployedClass::LegacyClass(inner) => {
+                Ok(Self::Legacy(inner.compress().map_err(|_| ConversionError)?))
+            }
+        }
+    }
+}
+
 fn convert_legacy_entry_point(
     value: core::LegacyContractEntryPoint,
 ) -> contract_legacy::RawLegacyEntryPoint {

--- a/starknet-providers/src/sequencer/models/conversions.rs
+++ b/starknet-providers/src/sequencer/models/conversions.rs
@@ -292,3 +292,14 @@ impl From<DeployedContract> for core::DeployedContractItem {
         }
     }
 }
+
+impl TryFrom<TransactionInfo> for core::Transaction {
+    type Error = ConversionError;
+
+    fn try_from(value: TransactionInfo) -> Result<Self, Self::Error> {
+        match value.r#type {
+            Some(tx) => tx.try_into(),
+            None => Err(ConversionError),
+        }
+    }
+}

--- a/starknet-providers/src/sequencer/models/conversions.rs
+++ b/starknet-providers/src/sequencer/models/conversions.rs
@@ -1,0 +1,71 @@
+use starknet_core::types as core;
+
+use super::*;
+
+#[derive(Debug, thiserror::Error)]
+#[error("unable to convert type")]
+pub struct ConversionError;
+
+impl From<core::BlockId> for BlockId {
+    fn from(value: core::BlockId) -> Self {
+        match value {
+            core::BlockId::Hash(hash) => Self::Hash(hash),
+            core::BlockId::Number(num) => Self::Number(num),
+            core::BlockId::Tag(core::BlockTag::Latest) => Self::Latest,
+            core::BlockId::Tag(core::BlockTag::Pending) => Self::Pending,
+        }
+    }
+}
+
+impl TryFrom<Block> for core::MaybePendingBlockWithTxHashes {
+    type Error = ConversionError;
+
+    fn try_from(value: Block) -> Result<Self, Self::Error> {
+        match (value.block_hash, value.block_number, value.state_root) {
+            // Confirmed block
+            (Some(block_hash), Some(block_number), Some(state_root)) => {
+                Ok(Self::Block(core::BlockWithTxHashes {
+                    status: value.status.try_into()?,
+                    block_hash,
+                    parent_hash: value.parent_block_hash,
+                    block_number,
+                    new_root: state_root,
+                    timestamp: value.timestamp,
+                    sequencer_address: value.sequencer_address.unwrap_or_default(),
+                    transactions: value
+                        .transactions
+                        .iter()
+                        .map(|tx| tx.transaction_hash())
+                        .collect(),
+                }))
+            }
+            // Pending block
+            (None, None, None) => Ok(Self::PendingBlock(core::PendingBlockWithTxHashes {
+                transactions: value
+                    .transactions
+                    .iter()
+                    .map(|tx| tx.transaction_hash())
+                    .collect(),
+                timestamp: value.timestamp,
+                sequencer_address: value.sequencer_address.unwrap_or_default(),
+                parent_hash: value.parent_block_hash,
+            })),
+            // Unknown combination
+            _ => Err(ConversionError),
+        }
+    }
+}
+
+impl TryFrom<BlockStatus> for core::BlockStatus {
+    type Error = ConversionError;
+
+    fn try_from(value: BlockStatus) -> Result<Self, Self::Error> {
+        match value {
+            BlockStatus::Pending => Ok(Self::Pending),
+            BlockStatus::Aborted => Err(ConversionError),
+            BlockStatus::Reverted => Ok(Self::Rejected),
+            BlockStatus::AcceptedOnL2 => Ok(Self::AcceptedOnL2),
+            BlockStatus::AcceptedOnL1 => Ok(Self::AcceptedOnL1),
+        }
+    }
+}

--- a/starknet-providers/src/sequencer/models/mod.rs
+++ b/starknet-providers/src/sequencer/models/mod.rs
@@ -2,6 +2,8 @@
 // migration to becoming jsonrpc-centric. This file, along with all other sequencer-related types,
 // will be removed after the sequencer API is removed from the network.
 
+pub(crate) mod conversions;
+
 mod block;
 pub use block::{Block, BlockId, BlockStatus};
 

--- a/starknet-providers/src/sequencer/models/transaction.rs
+++ b/starknet-providers/src/sequencer/models/transaction.rs
@@ -167,6 +167,18 @@ pub struct L1HandlerTransaction {
     pub version: FieldElement,
 }
 
+impl TransactionType {
+    pub fn transaction_hash(&self) -> FieldElement {
+        match self {
+            TransactionType::Declare(inner) => inner.transaction_hash,
+            TransactionType::Deploy(inner) => inner.transaction_hash,
+            TransactionType::DeployAccount(inner) => inner.transaction_hash,
+            TransactionType::InvokeFunction(inner) => inner.transaction_hash,
+            TransactionType::L1Handler(inner) => inner.transaction_hash,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/starknet-providers/src/sequencer/models/transaction_request.rs
+++ b/starknet-providers/src/sequencer/models/transaction_request.rs
@@ -2,11 +2,11 @@ use serde::{Deserialize, Serialize, Serializer};
 use serde_with::serde_as;
 use starknet_core::{
     serde::unsigned_field_element::{UfeHex, UfeHexOption},
-    types::{contract::CompressedSierraClass, FieldElement, L1Address},
+    types::{FieldElement, L1Address},
 };
 use std::sync::Arc;
 
-use super::contract::CompressedLegacyContractClass;
+use super::contract::{CompressedLegacyContractClass, CompressedSierraClass};
 
 #[serde_as]
 #[derive(Debug, Deserialize)]

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use async_trait::async_trait;
 use starknet_core::types::{
     BlockHashAndNumber, BlockId, BroadcastedDeclareTransaction,
@@ -24,7 +26,10 @@ impl Provider for SequencerGatewayProvider {
     where
         B: AsRef<BlockId> + Send + Sync,
     {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        Ok(self
+            .get_block(block_id.as_ref().to_owned().into())
+            .await?
+            .try_into()?)
     }
 
     async fn get_block_with_txs<B>(

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -205,7 +205,13 @@ impl Provider for SequencerGatewayProvider {
         R: AsRef<FunctionCall> + Send + Sync,
         B: AsRef<BlockId> + Send + Sync,
     {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        Ok(self
+            .call_contract(
+                request.as_ref().to_owned().into(),
+                block_id.as_ref().to_owned().into(),
+            )
+            .await?
+            .result)
     }
 
     async fn estimate_fee<R, B>(

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -165,7 +165,12 @@ impl Provider for SequencerGatewayProvider {
         B: AsRef<BlockId> + Send + Sync,
         A: AsRef<FieldElement> + Send + Sync,
     {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        Ok(self
+            .get_class_hash_at(
+                *contract_address.as_ref(),
+                block_id.as_ref().to_owned().into(),
+            )
+            .await?)
     }
 
     async fn get_class_at<B, A>(

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -244,7 +244,11 @@ impl Provider for SequencerGatewayProvider {
     async fn block_hash_and_number(
         &self,
     ) -> Result<BlockHashAndNumber, ProviderError<Self::Error>> {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        let block = self.get_block(super::models::BlockId::Latest).await?;
+        Ok(BlockHashAndNumber {
+            block_hash: block.block_hash.ok_or(ConversionError)?,
+            block_number: block.block_number.ok_or(ConversionError)?,
+        })
     }
 
     async fn chain_id(&self) -> Result<FieldElement, ProviderError<Self::Error>> {

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -39,7 +39,10 @@ impl Provider for SequencerGatewayProvider {
     where
         B: AsRef<BlockId> + Send + Sync,
     {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        Ok(self
+            .get_block(block_id.as_ref().to_owned().into())
+            .await?
+            .try_into()?)
     }
 
     async fn get_state_update<B>(

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -352,6 +352,15 @@ impl Provider for SequencerGatewayProvider {
     where
         D: AsRef<BroadcastedDeployAccountTransaction> + Send + Sync,
     {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        let result = self
+            .add_transaction(super::models::TransactionRequest::DeployAccount(
+                deploy_account_transaction.as_ref().to_owned().into(),
+            ))
+            .await?;
+
+        Ok(DeployAccountTransactionResult {
+            transaction_hash: result.transaction_hash,
+            contract_address: result.address.ok_or(ConversionError)?,
+        })
     }
 }

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -323,7 +323,16 @@ impl Provider for SequencerGatewayProvider {
     where
         D: AsRef<BroadcastedDeclareTransaction> + Send + Sync,
     {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        let result = self
+            .add_transaction(super::models::TransactionRequest::Declare(
+                declare_transaction.as_ref().to_owned().try_into()?,
+            ))
+            .await?;
+
+        Ok(DeclareTransactionResult {
+            transaction_hash: result.transaction_hash,
+            class_hash: result.class_hash.ok_or(ConversionError)?,
+        })
     }
 
     async fn add_deploy_transaction<D>(

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -12,7 +12,10 @@ use starknet_core::types::{
 };
 
 use crate::{
-    sequencer::{models::conversions::TransactionWithReceipt, GatewayClientError},
+    sequencer::{
+        models::conversions::{ConversionError, TransactionWithReceipt},
+        GatewayClientError,
+    },
     Provider, ProviderError, SequencerGatewayProvider,
 };
 
@@ -234,7 +237,8 @@ impl Provider for SequencerGatewayProvider {
     }
 
     async fn block_number(&self) -> Result<u64, ProviderError<Self::Error>> {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        let block = self.get_block(super::models::BlockId::Latest).await?;
+        Ok(block.block_number.ok_or(ConversionError)?)
     }
 
     async fn block_hash_and_number(

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -305,7 +305,15 @@ impl Provider for SequencerGatewayProvider {
     where
         I: AsRef<BroadcastedInvokeTransaction> + Send + Sync,
     {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        let result = self
+            .add_transaction(super::models::TransactionRequest::InvokeFunction(
+                invoke_transaction.as_ref().to_owned().into(),
+            ))
+            .await?;
+
+        Ok(InvokeTransactionResult {
+            transaction_hash: result.transaction_hash,
+        })
     }
 
     async fn add_declare_transaction<D>(

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -69,7 +69,13 @@ impl Provider for SequencerGatewayProvider {
         K: AsRef<FieldElement> + Send + Sync,
         B: AsRef<BlockId> + Send + Sync,
     {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        Ok(self
+            .get_storage_at(
+                *contract_address.as_ref(),
+                *key.as_ref(),
+                block_id.as_ref().to_owned().into(),
+            )
+            .await?)
     }
 
     async fn get_transaction_by_hash<H>(

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -223,7 +223,14 @@ impl Provider for SequencerGatewayProvider {
         R: AsRef<BroadcastedTransaction> + Send + Sync,
         B: AsRef<BlockId> + Send + Sync,
     {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        Ok(self
+            .estimate_fee(
+                request.as_ref().to_owned().try_into()?,
+                block_id.as_ref().to_owned().into(),
+                false,
+            )
+            .await?
+            .into())
     }
 
     async fn block_number(&self) -> Result<u64, ProviderError<Self::Error>> {

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -252,7 +252,7 @@ impl Provider for SequencerGatewayProvider {
     }
 
     async fn chain_id(&self) -> Result<FieldElement, ProviderError<Self::Error>> {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        Ok(self.chain_id)
     }
 
     async fn pending_transactions(&self) -> Result<Vec<Transaction>, ProviderError<Self::Error>> {

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -256,7 +256,16 @@ impl Provider for SequencerGatewayProvider {
     }
 
     async fn pending_transactions(&self) -> Result<Vec<Transaction>, ProviderError<Self::Error>> {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        let block = self.get_block(super::models::BlockId::Pending).await?;
+        if block.status == super::models::BlockStatus::Pending {
+            Ok(block
+                .transactions
+                .into_iter()
+                .map(|tx| tx.try_into())
+                .collect::<Result<_, _>>()?)
+        } else {
+            Ok(vec![])
+        }
     }
 
     async fn syncing(&self) -> Result<SyncStatusType, ProviderError<Self::Error>> {

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -290,7 +290,12 @@ impl Provider for SequencerGatewayProvider {
         B: AsRef<BlockId> + Send + Sync,
         A: AsRef<FieldElement> + Send + Sync,
     {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        Ok(self
+            .get_nonce(
+                *contract_address.as_ref(),
+                block_id.as_ref().to_owned().into(),
+            )
+            .await?)
     }
 
     async fn add_invoke_transaction<I>(

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -192,7 +192,8 @@ impl Provider for SequencerGatewayProvider {
     where
         B: AsRef<BlockId> + Send + Sync,
     {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        let block = self.get_block(block_id.as_ref().to_owned().into()).await?;
+        Ok(block.transactions.len() as u64)
     }
 
     async fn call<R, B>(

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -156,7 +156,10 @@ impl Provider for SequencerGatewayProvider {
         B: AsRef<BlockId> + Send + Sync,
         H: AsRef<FieldElement> + Send + Sync,
     {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        Ok(self
+            .get_class_by_hash(*class_hash.as_ref(), block_id.as_ref().to_owned().into())
+            .await?
+            .try_into()?)
     }
 
     async fn get_class_hash_at<B, A>(

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -188,7 +188,13 @@ impl Provider for SequencerGatewayProvider {
         B: AsRef<BlockId> + Send + Sync,
         A: AsRef<FieldElement> + Send + Sync,
     {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        Ok(self
+            .get_full_contract(
+                *contract_address.as_ref(),
+                block_id.as_ref().to_owned().into(),
+            )
+            .await?
+            .try_into()?)
     }
 
     async fn get_block_transaction_count<B>(

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -269,7 +269,7 @@ impl Provider for SequencerGatewayProvider {
     }
 
     async fn syncing(&self) -> Result<SyncStatusType, ProviderError<Self::Error>> {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        Ok(SyncStatusType::NotSyncing)
     }
 
     async fn get_events(

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -52,7 +52,10 @@ impl Provider for SequencerGatewayProvider {
     where
         B: AsRef<BlockId> + Send + Sync,
     {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        Ok(self
+            .get_state_update(block_id.as_ref().to_owned().into())
+            .await?
+            .into())
     }
 
     async fn get_storage_at<A, K, B>(

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -85,7 +85,10 @@ impl Provider for SequencerGatewayProvider {
     where
         H: AsRef<FieldElement> + Send + Sync,
     {
-        Err(ProviderError::Other(Self::Error::MethodNotSupported))
+        Ok(self
+            .get_transaction(*transaction_hash.as_ref())
+            .await?
+            .try_into()?)
     }
 
     async fn get_transaction_by_block_id_and_index<B>(

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -64,7 +64,7 @@ async fn jsonrpc_get_state_update() {
         .await
         .unwrap();
 
-    assert!(state_update.new_root > FieldElement::ZERO);
+    assert!(state_update.new_root.unwrap() > FieldElement::ZERO);
 }
 
 #[tokio::test]


### PR DESCRIPTION
We moved the whole library to be jsonrpc-first in #385, but left out the implementation of the new `Provider` for `SequencerGatewayProvider` to make that PR still somewhat manageable. This PR implements almost all functions in `Provider` except the 2 below:

- `get_events`
- `add_deploy_transaction`

It's impossible to implement `get_events` and `add_deploy_transaction` is actually already gone (no longer in specs 0.3.0) anyways.

This PR also re-enables the sequencer-related test cases as the sequencer can now be actually used in places where `Provider` is expected.