### PR TITLE
release: bump starknet to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -1658,7 +1658,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "rand",
  "serde",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64 0.21.0",
  "criterion",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-ff"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ark-ff",
  "bigdecimal",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "starknet-core",
  "syn 2.0.15",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,12 +34,12 @@ members = [
 all-features = true
 
 [dependencies]
-starknet-core = { version = "0.2.0", path = "./starknet-core", default-features = false }
-starknet-providers = { version = "0.2.0", path = "./starknet-providers" }
-starknet-contract = { version = "0.1.0", path = "./starknet-contract" }
-starknet-signers = { version = "0.1.0", path = "./starknet-signers" }
-starknet-accounts = { version = "0.1.0", path = "./starknet-accounts" }
-starknet-macros = { version = "0.1.0", path = "./starknet-macros" }
+starknet-core = { version = "0.3.0", path = "./starknet-core", default-features = false }
+starknet-providers = { version = "0.3.0", path = "./starknet-providers" }
+starknet-contract = { version = "0.2.0", path = "./starknet-contract" }
+starknet-signers = { version = "0.2.0", path = "./starknet-signers" }
+starknet-accounts = { version = "0.2.0", path = "./starknet-accounts" }
+starknet-macros = { version = "0.2.0", path = "./starknet-macros" }
 
 [dev-dependencies]
 serde_json = "1.0.74"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To use the crate from [crates.io](https://crates.io/crates/starknet), add the fo
 
 ```toml
 [dependencies]
-starknet = "0.2.0"
+starknet = "0.3.0"
 ```
 
 Note that the [crates.io version](https://crates.io/crates/starknet) might be outdated. You may want to use the library directly from GitHub for all the latest features and fixes:

--- a/examples/starknet-wasm/Cargo.toml
+++ b/examples/starknet-wasm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-starknet-ff = { version = "0.3.2", path = "../../starknet-ff" }
+starknet-ff = { version = "0.3.3", path = "../../starknet-ff" }
 starknet-crypto = { version = "0.5.1", path = "../../starknet-crypto" }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 wasm-bindgen = "0.2.84"

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-accounts"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,9 +13,9 @@ Types for handling Starknet account abstraction
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.2.0", path = "../starknet-core" }
-starknet-providers = { version = "0.2.0", path = "../starknet-providers" }
-starknet-signers = { version = "0.1.0", path = "../starknet-signers" }
+starknet-core = { version = "0.3.0", path = "../starknet-core" }
+starknet-providers = { version = "0.3.0", path = "../starknet-providers" }
+starknet-signers = { version = "0.2.0", path = "../starknet-signers" }
 async-trait = "0.1.68"
 thiserror = "1.0.40"
 

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-contract"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,9 +13,9 @@ Types and utilities for Starknet smart contract deployment and interaction
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.2.0", path = "../starknet-core" }
-starknet-providers = { version = "0.2.0", path = "../starknet-providers" }
-starknet-accounts = { version = "0.1.0", path = "../starknet-accounts" }
+starknet-core = { version = "0.3.0", path = "../starknet-core" }
+starknet-providers = { version = "0.3.0", path = "../starknet-providers" }
+starknet-accounts = { version = "0.2.0", path = "../starknet-accounts" }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
 serde_with = "2.3.2"
@@ -23,6 +23,6 @@ thiserror = "1.0.40"
 
 [dev-dependencies]
 rand = { version = "0.8.5", features=["std_rng"] }
-starknet-signers = { version = "0.1.0", path = "../starknet-signers" }
+starknet-signers = { version = "0.2.0", path = "../starknet-signers" }
 tokio = { version = "1.27.0", features = ["full"] }
 url = "2.3.1"

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-core"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -17,7 +17,7 @@ all-features = true
 
 [dependencies]
 starknet-crypto = { version = "0.5.1", path = "../starknet-crypto" }
-starknet-ff = { version = "0.3.2", path = "../starknet-ff", features = [
+starknet-ff = { version = "0.3.3", path = "../starknet-ff", features = [
     "serde",
 ] }
 base64 = "0.21.0"

--- a/starknet-crypto-codegen/Cargo.toml
+++ b/starknet-crypto-codegen/Cargo.toml
@@ -17,5 +17,5 @@ proc-macro = true
 
 [dependencies]
 starknet-curve = { version = "0.3.0", path = "../starknet-curve" }
-starknet-ff = { version = "0.3.2", path = "../starknet-ff", default-features = false }
+starknet-ff = { version = "0.3.3", path = "../starknet-ff", default-features = false }
 syn = { version = "2.0.15", default-features = false }

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["ethereum", "starknet", "web3", "no_std"]
 [dependencies]
 starknet-crypto-codegen = { version = "0.3.1", path = "../starknet-crypto-codegen" }
 starknet-curve = { version = "0.3.0", path = "../starknet-curve" }
-starknet-ff = { version = "0.3.2", path = "../starknet-ff", default-features = false }
+starknet-ff = { version = "0.3.3", path = "../starknet-ff", default-features = false }
 crypto-bigint = { version = "0.5.1", default-features = false, features = ["generic-array", "zeroize"] }
 hmac = { version = "0.12.1", default-features = false }
 num-bigint = { version = "0.4.3", default-features = false }

--- a/starknet-curve/Cargo.toml
+++ b/starknet-curve/Cargo.toml
@@ -13,7 +13,7 @@ Stark curve
 keywords = ["ethereum", "starknet", "web3", "no_std"]
 
 [dependencies]
-starknet-ff = { version = "0.3.2", path = "../starknet-ff", default-features = false }
+starknet-ff = { version = "0.3.3", path = "../starknet-ff", default-features = false }
 
 [features]
 bigdecimal = ["starknet-ff/bigdecimal"]

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-ff"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/starknet-macros/Cargo.toml
+++ b/starknet-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-macros"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -16,7 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 proc-macro = true
 
 [dependencies]
-starknet-core = { version = "0.2.0", path = "../starknet-core" }
+starknet-core = { version = "0.3.0", path = "../starknet-core" }
 syn = "2.0.15"
 
 [features]

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-providers"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,7 +13,7 @@ Provider implementations for the starknet crate
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.2.0", path = "../starknet-core" }
+starknet-core = { version = "0.3.0", path = "../starknet-core" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 flate2 = "1.0.25"

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-signers"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,7 +13,7 @@ Starknet signer implementations
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.2.0", path = "../starknet-core" }
+starknet-core = { version = "0.3.0", path = "../starknet-core" }
 starknet-crypto = { version = "0.5.1", path = "../starknet-crypto" }
 async-trait = "0.1.68"
 thiserror = "1.0.40"


### PR DESCRIPTION
It's been a while (1 year+) since anything other than `starknet-crypto` and its dependencies was last published on crates.io. Now that we've merged #385 and #396, which contain some of the biggest breaking changes, it seems to be a good timing to resume publishing to crates.io.

This PR bumps versions of all crates except for those that are already up to date.