### PR TITLE
feat: derive `Clone` for contract types

### DIFF
--- a/starknet-core/src/types/contract/legacy.rs
+++ b/starknet-core/src/types/contract/legacy.rs
@@ -20,7 +20,7 @@ use std::{collections::BTreeMap, io::Write};
 
 const API_VERSION: FieldElement = FieldElement::ZERO;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct LegacyContractClass {
     pub abi: Vec<RawLegacyAbiEntry>,
@@ -38,7 +38,7 @@ pub struct RawLegacyEntryPoints {
 }
 
 #[serde_as]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct LegacyProgram {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -69,7 +69,7 @@ pub struct RawLegacyEntryPoint {
     pub selector: FieldElement,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct LegacyAttribute {
     pub accessible_scopes: Vec<String>,
@@ -81,7 +81,7 @@ pub struct LegacyAttribute {
     pub value: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct LegacyDebugInfo {
     /// A partial map from file name to its content. Files that are not in the map, are assumed to
@@ -91,7 +91,7 @@ pub struct LegacyDebugInfo {
     pub instruction_locations: BTreeMap<u64, LegacyInstructionLocation>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct LegacyHint {
     pub accessible_scopes: Vec<String>,
@@ -99,7 +99,7 @@ pub struct LegacyHint {
     pub flow_tracking_data: LegacyFlowTrackingData,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct LegacyIdentifier {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -123,7 +123,7 @@ pub struct LegacyIdentifier {
     pub value: Option<serde_json::Number>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct LegacyReferenceManager {
     pub references: Vec<LegacyReference>,
@@ -138,7 +138,7 @@ pub enum LegacyEntrypointOffset {
     U64AsInt(u64),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct LegacyInstructionLocation {
     pub accessible_scopes: Vec<String>,
@@ -148,14 +148,14 @@ pub struct LegacyInstructionLocation {
     pub inst: LegacyLocation,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct LegacyIdentifierMember {
     pub cairo_type: String,
     pub offset: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct LegacyReference {
     pub ap_tracking_data: LegacyApTrackingData,
@@ -163,14 +163,14 @@ pub struct LegacyReference {
     pub value: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct LegacyFlowTrackingData {
     pub ap_tracking: LegacyApTrackingData,
     pub reference_ids: BTreeMap<String, u64>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct LegacyHintLocation {
     pub location: LegacyLocation,
@@ -178,7 +178,7 @@ pub struct LegacyHintLocation {
     pub n_prefix_newlines: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct LegacyLocation {
     pub end_col: u64,
@@ -190,14 +190,14 @@ pub struct LegacyLocation {
     pub start_line: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct LegacyApTrackingData {
     pub group: u64,
     pub offset: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct LegacyInputFile {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -206,14 +206,14 @@ pub struct LegacyInputFile {
     pub content: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LegacyParentLocation {
     pub location: Box<LegacyLocation>,
     pub remark: String,
 }
 
 #[serde_as]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct LegacyContractCode {
     #[serde_as(as = "Vec<UfeHex>")]

--- a/starknet-core/src/types/contract/mod.rs
+++ b/starknet-core/src/types/contract/mod.rs
@@ -29,7 +29,7 @@ const PREFIX_COMPILED_CLASS_V1: FieldElement = FieldElement::from_mont([
     324306817650036332,
 ]);
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
 pub enum ContractArtifact {
@@ -39,7 +39,7 @@ pub enum ContractArtifact {
 }
 
 #[serde_as]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct SierraClass {
     #[serde_as(as = "Vec<UfeHex>")]
@@ -51,7 +51,7 @@ pub struct SierraClass {
 }
 
 #[serde_as]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct CompiledClass {
     pub prime: String,
@@ -63,7 +63,7 @@ pub struct CompiledClass {
     pub entry_points_by_type: CompiledClassEntrypointList,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct SierraClassDebugInfo {
     pub type_names: Vec<(u64, String)>,
@@ -80,7 +80,7 @@ pub struct CompiledClassEntrypointList {
     pub constructor: Vec<CompiledClassEntrypoint>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub enum AbiEntry {
@@ -90,7 +90,7 @@ pub enum AbiEntry {
     Enum(AbiEnum),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Hint {
     pub id: u64,
     // For convenience we just treat it as an opaque JSON value here, unless a use case justifies
@@ -98,7 +98,7 @@ pub struct Hint {
     pub code: Vec<serde_json::Value>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PythonicHint {
     pub id: u64,
     pub code: Vec<String>,
@@ -114,7 +114,7 @@ pub struct CompiledClassEntrypoint {
     pub builtins: Vec<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct AbiFunction {
     pub name: String,
@@ -123,41 +123,41 @@ pub struct AbiFunction {
     pub state_mutability: StateMutability,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct AbiEvent {
     pub name: String,
     pub inputs: Vec<AbiNamedMember>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct AbiStruct {
     pub name: String,
     pub members: Vec<AbiNamedMember>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct AbiEnum {
     pub name: String,
     pub variants: Vec<AbiNamedMember>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct AbiNamedMember {
     pub name: String,
     pub r#type: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct AbiOutput {
     pub r#type: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StateMutability {
     External,


### PR DESCRIPTION
Now you can clone class types.