### PR TITLE
test: re-enable ignored test case

### DIFF
--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -63,8 +63,6 @@ async fn can_declare_cairo1_contract_with_sequencer() {
 }
 
 #[tokio::test]
-// https://github.com/eqlabs/pathfinder/issues/1085
-#[ignore = "disabled due to pathfinder bug"]
 async fn can_declare_cairo1_contract_with_jsonrpc() {
     can_declare_cairo1_contract_inner(create_jsonrpc_client()).await
 }


### PR DESCRIPTION
The `pathfinder` bug has been fixed and we no longer need to skip that test.