### PR TITLE
fix: default event inputs

### DIFF
--- a/starknet-core/src/types/contract/mod.rs
+++ b/starknet-core/src/types/contract/mod.rs
@@ -127,6 +127,7 @@ pub struct AbiFunction {
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct AbiEvent {
     pub name: String,
+    #[serde(default)]
     pub inputs: Vec<AbiNamedMember>,
 }
 


### PR DESCRIPTION
cairo outputs abis with a default event with no inputs:

https://github.com/starkware-libs/cairo/blob/d80d29b52f8972f63ceb490567b26172245e95ff/crates/cairo-lang-starknet/test_data/minimal_contract.sierra.json#L468