### PR TITLE
refactor: unicode encoding in pythonic formatter

### DIFF
--- a/starknet-core/src/serde/json/mod.rs
+++ b/starknet-core/src/serde/json/mod.rs
@@ -39,6 +39,27 @@ impl Formatter for PythonicJsonFormatter {
     {
         writer.write_all(b": ")
     }
+
+    #[inline]
+    fn write_string_fragment<W>(&mut self, writer: &mut W, fragment: &str) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        let mut buf = [0, 0];
+
+        for c in fragment.chars() {
+            if c.is_ascii() {
+                writer.write_all(&[c as u8])?;
+            } else {
+                let buf = c.encode_utf16(&mut buf);
+                for i in buf {
+                    write!(writer, r"\u{:4x}", i)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[inline]

--- a/starknet-core/src/types/contract/legacy.rs
+++ b/starknet-core/src/types/contract/legacy.rs
@@ -466,7 +466,6 @@ impl LegacyContractClass {
         })
         .map_err(ComputeClassHashError::Json)?;
 
-        let serialized = Self::unicode_encode(&serialized);
         Ok(starknet_keccak(serialized.as_bytes()))
     }
 
@@ -482,28 +481,6 @@ impl LegacyContractClass {
                     .collect(),
             ),
         })
-    }
-
-    /// We need this because Python does this
-    fn unicode_encode(s: &str) -> String {
-        use std::fmt::Write;
-
-        let mut output = String::with_capacity(s.len());
-        let mut buf = [0, 0];
-
-        for c in s.chars() {
-            if c.is_ascii() {
-                output.push(c);
-            } else {
-                let buf = c.encode_utf16(&mut buf);
-                for i in buf {
-                    // Unwrapping should be safe here
-                    write!(output, r"\u{:4x}", i).unwrap();
-                }
-            }
-        }
-
-        output
     }
 }
 


### PR DESCRIPTION
This should increase performance of class hash calculation and reduce memory usage.

Replaces the temporary inefficient solution introduced in #404.