### PR TITLE
feat: use raw_value instead of arbitrary_precision

### DIFF
--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -25,7 +25,7 @@ ethereum-types = "0.14.1"
 flate2 = "1.0.25"
 hex = "0.4.3"
 serde = { version = "1.0.160", features = ["derive"] }
-serde_json = { version = "1.0.96", features = ["arbitrary_precision"] }
+serde_json = { version = "1.0.96", features = ["raw_value"] }
 serde_with = "2.3.2"
 sha3 = "0.10.7"
 thiserror = "1.0.40"

--- a/starknet-core/src/types/contract/legacy.rs
+++ b/starknet-core/src/types/contract/legacy.rs
@@ -120,7 +120,7 @@ pub struct LegacyIdentifier {
     pub destination: Option<String>,
     pub r#type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub value: Option<serde_json::Number>,
+    pub value: Option<Box<serde_json::value::RawValue>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -351,7 +351,7 @@ impl Serialize for RawLegacyAbiEntry {
     }
 }
 
-// We need to manually implement this because `arbitrary_precision` doesn't work with `tag`:
+// We need to manually implement this because `raw_value` doesn't work with `tag`:
 //   https://github.com/serde-rs/serde/issues/1183
 impl<'de> Deserialize<'de> for RawLegacyAbiEntry {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/starknet-core/src/types/contract/mod.rs
+++ b/starknet-core/src/types/contract/mod.rs
@@ -291,7 +291,7 @@ impl CompiledClass {
     }
 }
 
-// We need to manually implement this because `arbitrary_precision` doesn't work with `untagged`:
+// We need to manually implement this because `raw_value` doesn't work with `untagged`:
 //   https://github.com/serde-rs/serde/issues/1183
 impl<'de> Deserialize<'de> for ContractArtifact {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/starknet-providers/src/sequencer/mod.rs
+++ b/starknet-providers/src/sequencer/mod.rs
@@ -760,7 +760,7 @@ impl From<RawFieldElementResponse> for Result<FieldElement, ProviderError<Gatewa
     }
 }
 
-// We need to manually implement this because `arbitrary_precision` doesn't work with `untagged`:
+// We need to manually implement this because `raw_value` doesn't work with `untagged`:
 //   https://github.com/serde-rs/serde/issues/1183
 impl<'de, T> Deserialize<'de> for GatewayResponse<T>
 where

--- a/starknet-providers/src/sequencer/models/contract.rs
+++ b/starknet-providers/src/sequencer/models/contract.rs
@@ -44,7 +44,7 @@ pub struct CompressedLegacyContractClass {
     pub abi: Option<Vec<RawLegacyAbiEntry>>,
 }
 
-// We need to manually implement this because `arbitrary_precision` doesn't work with `untagged`:
+// We need to manually implement this because `raw_value` doesn't work with `untagged`:
 //   https://github.com/serde-rs/serde/issues/1183
 impl<'de> Deserialize<'de> for DeployedClass {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>


### PR DESCRIPTION
The `arbitrary_precision` feature from `serde_json` is used mostly because of how the Cairo 0 artifact represents big numbers in raw number format instead of string. Without this feature enabled the correct class hash could not be obtained.

However, the implementation of this feature is problematic and has been causing issues. Switching to `raw_value` wouldn't resolve those as `raw_value` suffers from the very same issues as `arbitrary_precision`. What's less bad about `raw_value` is that using it is opt-in - it doesn't pollute number decoding like `arbitrary_precision` does. This is important due to how Cargo resolves dependencies - dependants of this library might be forced to enable the `serde_json` feature.

Resolves #394.