### PR TITLE
fix: missing L1Handler abi type

### DIFF
--- a/starknet-core/src/types/contract/mod.rs
+++ b/starknet-core/src/types/contract/mod.rs
@@ -92,6 +92,7 @@ pub enum AbiEntry {
     Constructor(AbiConstructor),
     Impl(AbiImpl),
     Interface(AbiInterface),
+    L1Handler(AbiFunction),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/starknet-core/test-data/contracts/cairo2/contracts/erc20.cairo
+++ b/starknet-core/test-data/contracts/cairo2/contracts/erc20.cairo
@@ -80,11 +80,6 @@ mod ERC20 {
             );
     }
 
-    #[l1_handler]
-    fn test_l1_handler(ref self: ContractState, from_address: felt252, arg1: felt252) {
-
-    }
-
     #[external(v0)]
     impl IERC20Impl of super::IERC20<ContractState> {
         fn get_name(self: @ContractState) -> felt252 {

--- a/starknet-core/test-data/contracts/cairo2/contracts/erc20.cairo
+++ b/starknet-core/test-data/contracts/cairo2/contracts/erc20.cairo
@@ -80,6 +80,11 @@ mod ERC20 {
             );
     }
 
+    #[l1_handler]
+    fn test_l1_handler(ref self: ContractState, from_address: felt252, arg1: felt252) {
+
+    }
+
     #[external(v0)]
     impl IERC20Impl of super::IERC20<ContractState> {
         fn get_name(self: @ContractState) -> felt252 {


### PR DESCRIPTION
Same as a function, only the name is changing.