### PR TITLE
refactor: move `L1Address` to `starknet-providers`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1690,7 +1690,6 @@ version = "0.3.2"
 dependencies = [
  "base64 0.21.0",
  "criterion",
- "ethereum-types",
  "flate2",
  "hex",
  "serde",
@@ -1780,6 +1779,7 @@ version = "0.3.0"
 dependencies = [
  "async-trait",
  "auto_impl",
+ "ethereum-types",
  "flate2",
  "reqwest",
  "serde",

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -21,7 +21,6 @@ starknet-ff = { version = "0.3.4", path = "../starknet-ff", features = [
     "serde",
 ] }
 base64 = "0.21.0"
-ethereum-types = "0.14.1"
 flate2 = "1.0.25"
 hex = "0.4.3"
 serde = { version = "1.0.160", features = ["derive"] }

--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -3,9 +3,6 @@ use serde_with::serde_as;
 
 use crate::serde::unsigned_field_element::UfeHex;
 
-// Re-export commonly used upstream types
-pub use ethereum_types::Address as L1Address;
-
 pub use starknet_ff::*;
 
 mod conversions;

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 starknet-core = { version = "0.3.2", path = "../starknet-core" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
+ethereum-types = "0.14.1"
 flate2 = "1.0.25"
 url = "2.3.1"
 reqwest = { version = "0.11.16", default-features = false, features = ["json", "rustls-tls"] }

--- a/starknet-providers/src/sequencer/models/contract_addresses.rs
+++ b/starknet-providers/src/sequencer/models/contract_addresses.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
-use starknet_core::types::L1Address;
+
+use super::L1Address;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/starknet-providers/src/sequencer/models/mod.rs
+++ b/starknet-providers/src/sequencer/models/mod.rs
@@ -2,6 +2,9 @@
 // migration to becoming jsonrpc-centric. This file, along with all other sequencer-related types,
 // will be removed after the sequencer API is removed from the network.
 
+// Re-export commonly used upstream types
+pub use ethereum_types::Address as L1Address;
+
 pub(crate) mod conversions;
 
 mod block;

--- a/starknet-providers/src/sequencer/models/trace.rs
+++ b/starknet-providers/src/sequencer/models/trace.rs
@@ -1,11 +1,8 @@
 use serde::Deserialize;
 use serde_with::serde_as;
-use starknet_core::{
-    serde::unsigned_field_element::UfeHex,
-    types::{FieldElement, L1Address},
-};
+use starknet_core::{serde::unsigned_field_element::UfeHex, types::FieldElement};
 
-use super::{EntryPointType, ExecutionResources};
+use super::{EntryPointType, ExecutionResources, L1Address};
 
 #[serde_as]
 #[derive(Debug, Deserialize)]

--- a/starknet-providers/src/sequencer/models/transaction_receipt.rs
+++ b/starknet-providers/src/sequencer/models/transaction_receipt.rs
@@ -2,10 +2,10 @@ use serde::Deserialize;
 use serde_with::serde_as;
 use starknet_core::{
     serde::unsigned_field_element::{UfeHex, UfePendingBlockHash},
-    types::{FieldElement, L1Address},
+    types::FieldElement,
 };
 
-use super::TransactionFailureReason;
+use super::{L1Address, TransactionFailureReason};
 
 #[serde_as]
 #[derive(Debug, Deserialize)]

--- a/starknet-providers/src/sequencer/models/transaction_request.rs
+++ b/starknet-providers/src/sequencer/models/transaction_request.rs
@@ -2,11 +2,14 @@ use serde::{Deserialize, Serialize, Serializer};
 use serde_with::serde_as;
 use starknet_core::{
     serde::unsigned_field_element::{UfeHex, UfeHexOption},
-    types::{FieldElement, L1Address},
+    types::FieldElement,
 };
 use std::sync::Arc;
 
-use super::contract::{CompressedLegacyContractClass, CompressedSierraClass};
+use super::{
+    contract::{CompressedLegacyContractClass, CompressedSierraClass},
+    L1Address,
+};
 
 #[serde_as]
 #[derive(Debug, Deserialize)]

--- a/starknet-providers/tests/sequencer_goerli.rs
+++ b/starknet-providers/tests/sequencer_goerli.rs
@@ -2,10 +2,10 @@
 
 use std::str::FromStr;
 
-use starknet_core::types::{FieldElement, L1Address};
+use starknet_core::types::FieldElement;
 use starknet_providers::{
     sequencer::models::{
-        AccountTransaction, BlockId, CallL1Handler, InvokeFunctionTransactionRequest,
+        AccountTransaction, BlockId, CallL1Handler, InvokeFunctionTransactionRequest, L1Address,
     },
     SequencerGatewayProvider,
 };


### PR DESCRIPTION
The type `L1Address` is only used in the sequencer client, so it makes more sense to put it in the `starknet-providers` crate.

In the future, we should add a `sequencer` feature to `starknet-providers` and hide this behind that as well.