### PR TITLE
feat: `no_std` support for `starknet-core`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -168,3 +168,9 @@ jobs:
             --target thumbv6m-none-eabi \
             --no-default-features \
             --features alloc
+
+      - name: Build starknet-core
+        run: |
+          cargo build --package starknet-core \
+            --target thumbv6m-none-eabi \
+            --no-default-features

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -16,18 +16,16 @@ keywords = ["ethereum", "starknet", "web3"]
 all-features = true
 
 [dependencies]
-starknet-crypto = { version = "0.5.1", path = "../starknet-crypto" }
-starknet-ff = { version = "0.3.4", path = "../starknet-ff", features = [
-    "serde",
-] }
-base64 = "0.21.0"
-flate2 = "1.0.25"
-hex = "0.4.3"
-serde = { version = "1.0.160", features = ["derive"] }
+starknet-crypto = { version = "0.5.1", path = "../starknet-crypto", default-features = false, features = [ "alloc" ] }
+starknet-ff = { version = "0.3.4", path = "../starknet-ff", default-features = false, features = ["serde"] }
+base64 = { version = "0.21.0", default-features = false, features = ["alloc"] }
+flate2 = { version = "1.0.25", optional = true }
+hex = { version = "0.4.3", default-features = false }
+serde = { version = "1.0.160", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.96", default-features = false, features = ["alloc", "raw_value"] }
 serde_json_pythonic = { version = "0.1.2", default-features = false, features = ["alloc", "raw_value"] }
-serde_with = "2.3.2"
-sha3 = "0.10.7"
+serde_with = { version = "2.3.2", default-features = false, features = ["alloc", "macros"] }
+sha3 = { version = "0.10.7", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", default-features = false }
@@ -37,7 +35,8 @@ starknet-core = { path = ".", features = ["no_unknown_fields"] }
 wasm-bindgen-test = "0.3.34"
 
 [features]
-default = ["bigdecimal"]
+default = ["std", "bigdecimal"]
+std = ["dep:flate2", "starknet-ff/std", "starknet-crypto/std"]
 bigdecimal = ["starknet-ff/bigdecimal", "starknet-crypto/bigdecimal"]
 no_unknown_fields = []
 

--- a/starknet-core/src/crypto.rs
+++ b/starknet-core/src/crypto.rs
@@ -5,7 +5,6 @@ use starknet_crypto::{rfc6979_generate_k, sign, verify, SignError, VerifyError};
 
 mod errors {
     use core::fmt::{Display, Formatter, Result};
-    use std::error::Error;
 
     #[derive(Debug)]
     pub enum EcdsaSignError {
@@ -20,7 +19,8 @@ mod errors {
         SignatureSOutOfRange,
     }
 
-    impl Error for EcdsaSignError {}
+    #[cfg(feature = "std")]
+    impl std::error::Error for EcdsaSignError {}
 
     impl Display for EcdsaSignError {
         fn fmt(&self, f: &mut Formatter<'_>) -> Result {
@@ -30,7 +30,8 @@ mod errors {
         }
     }
 
-    impl Error for EcdsaVerifyError {}
+    #[cfg(feature = "std")]
+    impl std::error::Error for EcdsaVerifyError {}
 
     impl Display for EcdsaVerifyError {
         fn fmt(&self, f: &mut Formatter<'_>) -> Result {

--- a/starknet-core/src/lib.rs
+++ b/starknet-core/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::comparison_chain)]
 #![doc = include_str!("../README.md")]
 
@@ -10,3 +11,5 @@ pub mod crypto;
 pub mod utils;
 
 pub mod chain_id;
+
+extern crate alloc;

--- a/starknet-core/src/serde/byte_array.rs
+++ b/starknet-core/src/serde/byte_array.rs
@@ -1,4 +1,6 @@
 pub mod base64 {
+    use alloc::{format, string::String, vec::Vec};
+
     use base64::{engine::general_purpose::STANDARD, Engine};
     use serde::{Deserialize, Deserializer, Serializer};
 

--- a/starknet-core/src/serde/num_hex.rs
+++ b/starknet-core/src/serde/num_hex.rs
@@ -1,4 +1,6 @@
 pub mod u64 {
+    use alloc::{format, string::String};
+
     use serde::{Deserialize, Deserializer, Serializer};
 
     pub fn serialize<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>

--- a/starknet-core/src/serde/unsigned_field_element.rs
+++ b/starknet-core/src/serde/unsigned_field_element.rs
@@ -1,3 +1,5 @@
+use alloc::{format, string::String};
+
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serializer};
 use serde_with::{DeserializeAs, SerializeAs};
 

--- a/starknet-core/src/types/codegen.rs
+++ b/starknet-core/src/types/codegen.rs
@@ -3,7 +3,7 @@
 //     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen
 
 // Code generated with version:
-//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen#73397c9d87962949675bca8fdc08faa88aa8ffb4
+//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen#5dbdcd62529ab8e3af4e9ef752945f8ae7e85ab9
 
 // Code generation requested but not implemented for these types:
 // - `BLOCK_ID`
@@ -18,7 +18,7 @@
 // - `TXN`
 // - `TXN_RECEIPT`
 
-use std::sync::Arc;
+use alloc::{format, string::String, vec::Vec};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::serde_as;
@@ -29,6 +29,11 @@ use crate::{
 };
 
 use super::{serde_impls::NumAsHex, *};
+
+#[cfg(all(not(no_rc), not(no_sync), target_has_atomic = "ptr"))]
+pub type OwnedPtr<T> = alloc::sync::Arc<T>;
+#[cfg(not(all(not(no_rc), not(no_sync), target_has_atomic = "ptr")))]
+pub type OwnedPtr<T> = alloc::boxed::Box<T>;
 
 /// Block status.
 ///
@@ -127,7 +132,7 @@ pub struct BroadcastedDeclareTransactionV1 {
     /// Nonce
     pub nonce: FieldElement,
     /// The class to be declared
-    pub contract_class: Arc<CompressedLegacyContractClass>,
+    pub contract_class: OwnedPtr<CompressedLegacyContractClass>,
     /// The address of the account contract sending the declaration transaction
     pub sender_address: FieldElement,
 }
@@ -144,7 +149,7 @@ pub struct BroadcastedDeclareTransactionV2 {
     /// Nonce
     pub nonce: FieldElement,
     /// The class to be declared
-    pub contract_class: Arc<FlattenedSierraClass>,
+    pub contract_class: OwnedPtr<FlattenedSierraClass>,
     /// The address of the account contract sending the declaration transaction
     pub sender_address: FieldElement,
     /// The hash of the cairo assembly resulting from the sierra compilation
@@ -1016,10 +1021,11 @@ pub enum StarknetError {
     ClassAlreadyDeclared,
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for StarknetError {}
 
-impl std::fmt::Display for StarknetError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for StarknetError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::FailedToReceiveTransaction => write!(f, "Failed to write transaction"),
             Self::ContractNotFound => write!(f, "Contract not found"),
@@ -1481,7 +1487,7 @@ impl<'de> Deserialize<'de> for BroadcastedDeclareTransactionV1 {
             max_fee: tagged.max_fee,
             signature: tagged.signature,
             nonce: tagged.nonce,
-            contract_class: Arc::new(tagged.contract_class),
+            contract_class: OwnedPtr::new(tagged.contract_class),
             sender_address: tagged.sender_address,
         })
     }
@@ -1565,7 +1571,7 @@ impl<'de> Deserialize<'de> for BroadcastedDeclareTransactionV2 {
             max_fee: tagged.max_fee,
             signature: tagged.signature,
             nonce: tagged.nonce,
-            contract_class: Arc::new(tagged.contract_class),
+            contract_class: OwnedPtr::new(tagged.contract_class),
             sender_address: tagged.sender_address,
             compiled_class_hash: tagged.compiled_class_hash,
         })

--- a/starknet-core/src/types/contract/mod.rs
+++ b/starknet-core/src/types/contract/mod.rs
@@ -1,3 +1,5 @@
+use alloc::{format, string::String, vec::Vec};
+
 use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json_pythonic::to_string_pythonic;
 use serde_with::serde_as;
@@ -239,8 +241,8 @@ pub enum EventFieldKind {
 }
 
 mod errors {
+    use alloc::string::String;
     use core::fmt::{Display, Formatter, Result};
-    use std::error::Error;
 
     #[derive(Debug)]
     pub enum ComputeClassHashError {
@@ -248,6 +250,7 @@ mod errors {
         Json(JsonError),
     }
 
+    #[cfg(feature = "std")]
     #[derive(Debug)]
     pub enum CompressProgramError {
         Json(JsonError),
@@ -259,7 +262,8 @@ mod errors {
         pub(crate) message: String,
     }
 
-    impl Error for ComputeClassHashError {}
+    #[cfg(feature = "std")]
+    impl std::error::Error for ComputeClassHashError {}
 
     impl Display for ComputeClassHashError {
         fn fmt(&self, f: &mut Formatter<'_>) -> Result {
@@ -270,8 +274,10 @@ mod errors {
         }
     }
 
-    impl Error for CompressProgramError {}
+    #[cfg(feature = "std")]
+    impl std::error::Error for CompressProgramError {}
 
+    #[cfg(feature = "std")]
     impl Display for CompressProgramError {
         fn fmt(&self, f: &mut Formatter<'_>) -> Result {
             match self {
@@ -281,7 +287,8 @@ mod errors {
         }
     }
 
-    impl Error for JsonError {}
+    #[cfg(feature = "std")]
+    impl std::error::Error for JsonError {}
 
     impl Display for JsonError {
         fn fmt(&self, f: &mut Formatter<'_>) -> Result {
@@ -289,7 +296,10 @@ mod errors {
         }
     }
 }
-pub use errors::{CompressProgramError, ComputeClassHashError, JsonError};
+pub use errors::{ComputeClassHashError, JsonError};
+
+#[cfg(feature = "std")]
+pub use errors::CompressProgramError;
 
 impl SierraClass {
     pub fn class_hash(&self) -> Result<FieldElement, ComputeClassHashError> {

--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -1,3 +1,5 @@
+use alloc::{string::String, vec::Vec};
+
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 

--- a/starknet-core/src/types/serde_impls.rs
+++ b/starknet-core/src/types/serde_impls.rs
@@ -1,3 +1,5 @@
+use alloc::{format, string::String};
+
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{DeserializeAs, SerializeAs};
 

--- a/starknet-core/src/utils.rs
+++ b/starknet-core/src/utils.rs
@@ -1,3 +1,5 @@
+use alloc::string::String;
+
 use crate::{crypto::compute_hash_on_elements, types::FieldElement};
 
 use sha3::{Digest, Keccak256};
@@ -37,7 +39,6 @@ pub struct UdcUniqueSettings {
 
 mod errors {
     use core::fmt::{Display, Formatter, Result};
-    use std::error::Error;
 
     #[derive(Debug)]
     pub struct NonAsciiNameError;
@@ -54,7 +55,8 @@ mod errors {
         UnexpectedNullTerminator,
     }
 
-    impl Error for NonAsciiNameError {}
+    #[cfg(feature = "std")]
+    impl std::error::Error for NonAsciiNameError {}
 
     impl Display for NonAsciiNameError {
         fn fmt(&self, f: &mut Formatter<'_>) -> Result {
@@ -62,7 +64,8 @@ mod errors {
         }
     }
 
-    impl Error for CairoShortStringToFeltError {}
+    #[cfg(feature = "std")]
+    impl std::error::Error for CairoShortStringToFeltError {}
 
     impl Display for CairoShortStringToFeltError {
         fn fmt(&self, f: &mut Formatter<'_>) -> Result {
@@ -77,7 +80,8 @@ mod errors {
         }
     }
 
-    impl Error for ParseCairoShortStringError {}
+    #[cfg(feature = "std")]
+    impl std::error::Error for ParseCairoShortStringError {}
 
     impl Display for ParseCairoShortStringError {
         fn fmt(&self, f: &mut Formatter<'_>) -> Result {


### PR DESCRIPTION
Resolves #403.

Supersedes #415.

Adds a new `std` feature to `starknet-core` that's enabled by default. When disabled, the crate compiles in a `no_std` environment.

Compared to #415, this PR only disables Cairo 0 class compression under `no_std`. All other features work.