### PR TITLE
refactor: remove `bigdecimal` feature from crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,6 +1645,7 @@ dependencies = [
  "starknet-accounts",
  "starknet-contract",
  "starknet-core",
+ "starknet-ff",
  "starknet-macros",
  "starknet-providers",
  "starknet-signers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
 all-features = true
 
 [dependencies]
+starknet-ff = { version = "0.3.4", path = "./starknet-ff", default-features = false }
 starknet-core = { version = "0.3.2", path = "./starknet-core", default-features = false }
 starknet-providers = { version = "0.3.0", path = "./starknet-providers" }
 starknet-contract = { version = "0.2.0", path = "./starknet-contract" }
@@ -48,7 +49,7 @@ url = "2.2.2"
 
 [features]
 default = ["bigdecimal"]
-bigdecimal = ["starknet-core/bigdecimal"]
+bigdecimal = ["starknet-ff/bigdecimal"]
 no_unknown_fields = [
     "starknet-core/no_unknown_fields",
     "starknet-providers/no_unknown_fields",

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -35,9 +35,8 @@ starknet-core = { path = ".", features = ["no_unknown_fields"] }
 wasm-bindgen-test = "0.3.34"
 
 [features]
-default = ["std", "bigdecimal"]
+default = ["std"]
 std = ["dep:flate2", "starknet-ff/std", "starknet-crypto/std"]
-bigdecimal = ["starknet-ff/bigdecimal", "starknet-crypto/bigdecimal"]
 no_unknown_fields = []
 
 [[bench]]

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -31,7 +31,6 @@ default = ["std", "signature-display"]
 std = []
 alloc = ["hex?/alloc"]
 signature-display = ["dep:hex", "alloc"]
-bigdecimal = ["starknet-curve/bigdecimal", "starknet-ff/bigdecimal"]
 
 [dev-dependencies]
 criterion = { version = "0.4.0", default-features = false }

--- a/starknet-curve/Cargo.toml
+++ b/starknet-curve/Cargo.toml
@@ -14,6 +14,3 @@ keywords = ["ethereum", "starknet", "web3", "no_std"]
 
 [dependencies]
 starknet-ff = { version = "0.3.4", path = "../starknet-ff", default-features = false }
-
-[features]
-bigdecimal = ["starknet-ff/bigdecimal"]


### PR DESCRIPTION
Removes the `bigdecimal` feature from `starknet-curve`, `starknet- crypto`, and `starknet-core`, as these crates just use/re-export the `starknet-ff` lib without being affected by the presence of `bigdecimal` anyways. There's no reason to have that feature. Users who do want to enable `bigdecimal` while using these crates need to manually import `starknet-ff`.

This feature still makes sense for `starknet` though, as it's designed to be a Just Works crate that's easy to consume.