### PR TITLE
release: bump crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,7 +1639,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "starknet"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde_json",
  "starknet-accounts",
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "rand",
  "serde",
@@ -1687,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "base64 0.21.0",
  "criterion",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "crypto-bigint",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto-codegen"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "starknet-curve",
  "starknet-ff",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-curve"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "starknet-ff",
 ]
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "starknet-core",
  "syn 2.0.15",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -35,12 +35,12 @@ all-features = true
 
 [dependencies]
 starknet-ff = { version = "0.3.4", path = "./starknet-ff", default-features = false }
-starknet-core = { version = "0.3.2", path = "./starknet-core", default-features = false }
-starknet-providers = { version = "0.3.0", path = "./starknet-providers" }
-starknet-contract = { version = "0.2.0", path = "./starknet-contract" }
-starknet-signers = { version = "0.2.1", path = "./starknet-signers" }
-starknet-accounts = { version = "0.2.0", path = "./starknet-accounts" }
-starknet-macros = { version = "0.1.0", path = "./starknet-macros" }
+starknet-core = { version = "0.4.0", path = "./starknet-core", default-features = false }
+starknet-providers = { version = "0.4.0", path = "./starknet-providers" }
+starknet-contract = { version = "0.3.0", path = "./starknet-contract" }
+starknet-signers = { version = "0.2.2", path = "./starknet-signers" }
+starknet-accounts = { version = "0.3.0", path = "./starknet-accounts" }
+starknet-macros = { version = "0.1.1", path = "./starknet-macros" }
 
 [dev-dependencies]
 serde_json = "1.0.74"

--- a/examples/starknet-wasm/Cargo.toml
+++ b/examples/starknet-wasm/Cargo.toml
@@ -20,6 +20,6 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 starknet-ff = { version = "0.3.4", path = "../../starknet-ff" }
-starknet-crypto = { version = "0.5.1", path = "../../starknet-crypto" }
+starknet-crypto = { version = "0.6.0", path = "../../starknet-crypto" }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 wasm-bindgen = "0.2.84"

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-accounts"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,9 +13,9 @@ Types for handling Starknet account abstraction
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.3.2", path = "../starknet-core" }
-starknet-providers = { version = "0.3.0", path = "../starknet-providers" }
-starknet-signers = { version = "0.2.1", path = "../starknet-signers" }
+starknet-core = { version = "0.4.0", path = "../starknet-core" }
+starknet-providers = { version = "0.4.0", path = "../starknet-providers" }
+starknet-signers = { version = "0.2.2", path = "../starknet-signers" }
 async-trait = "0.1.68"
 thiserror = "1.0.40"
 

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-contract"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,9 +13,9 @@ Types and utilities for Starknet smart contract deployment and interaction
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.3.2", path = "../starknet-core" }
-starknet-providers = { version = "0.3.0", path = "../starknet-providers" }
-starknet-accounts = { version = "0.2.0", path = "../starknet-accounts" }
+starknet-core = { version = "0.4.0", path = "../starknet-core" }
+starknet-providers = { version = "0.4.0", path = "../starknet-providers" }
+starknet-accounts = { version = "0.3.0", path = "../starknet-accounts" }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
 serde_with = "2.3.2"
@@ -23,6 +23,6 @@ thiserror = "1.0.40"
 
 [dev-dependencies]
 rand = { version = "0.8.5", features=["std_rng"] }
-starknet-signers = { version = "0.2.1", path = "../starknet-signers" }
+starknet-signers = { version = "0.2.2", path = "../starknet-signers" }
 tokio = { version = "1.27.0", features = ["full"] }
 url = "2.3.1"

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-core"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -16,7 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 all-features = true
 
 [dependencies]
-starknet-crypto = { version = "0.5.1", path = "../starknet-crypto", default-features = false, features = [ "alloc" ] }
+starknet-crypto = { version = "0.6.0", path = "../starknet-crypto", default-features = false, features = [ "alloc" ] }
 starknet-ff = { version = "0.3.4", path = "../starknet-ff", default-features = false, features = ["serde"] }
 base64 = { version = "0.21.0", default-features = false, features = ["alloc"] }
 flate2 = { version = "1.0.25", optional = true }

--- a/starknet-crypto-codegen/Cargo.toml
+++ b/starknet-crypto-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-crypto-codegen"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -16,6 +16,6 @@ keywords = ["ethereum", "starknet", "web3", "no_std"]
 proc-macro = true
 
 [dependencies]
-starknet-curve = { version = "0.3.0", path = "../starknet-curve" }
+starknet-curve = { version = "0.4.0", path = "../starknet-curve" }
 starknet-ff = { version = "0.3.4", path = "../starknet-ff", default-features = false }
 syn = { version = "2.0.15", default-features = false }

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-crypto"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,8 +13,8 @@ Low-level cryptography utilities for Starknet
 keywords = ["ethereum", "starknet", "web3", "no_std"]
 
 [dependencies]
-starknet-crypto-codegen = { version = "0.3.1", path = "../starknet-crypto-codegen" }
-starknet-curve = { version = "0.3.0", path = "../starknet-curve" }
+starknet-crypto-codegen = { version = "0.3.2", path = "../starknet-crypto-codegen" }
+starknet-curve = { version = "0.4.0", path = "../starknet-curve" }
 starknet-ff = { version = "0.3.4", path = "../starknet-ff", default-features = false }
 crypto-bigint = { version = "0.5.1", default-features = false, features = ["generic-array", "zeroize"] }
 hmac = { version = "0.12.1", default-features = false }

--- a/starknet-curve/Cargo.toml
+++ b/starknet-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-curve"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/starknet-macros/Cargo.toml
+++ b/starknet-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-macros"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -16,7 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 proc-macro = true
 
 [dependencies]
-starknet-core = { version = "0.3.2", path = "../starknet-core" }
+starknet-core = { version = "0.4.0", path = "../starknet-core" }
 syn = "2.0.15"
 
 [features]

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-providers"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,7 +13,7 @@ Provider implementations for the starknet crate
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.3.2", path = "../starknet-core" }
+starknet-core = { version = "0.4.0", path = "../starknet-core" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 ethereum-types = "0.14.1"

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-signers"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,8 +13,8 @@ Starknet signer implementations
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.3.2", path = "../starknet-core" }
-starknet-crypto = { version = "0.5.1", path = "../starknet-crypto" }
+starknet-core = { version = "0.4.0", path = "../starknet-core" }
+starknet-crypto = { version = "0.6.0", path = "../starknet-crypto" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 thiserror = "1.0.40"


### PR DESCRIPTION
Bumps all crates except `starknet-ff`. _patch_ or _minor_ is bumped depending on whether breaking changes have been introduced for any specific crate.