### PR TITLE
feat: enable `signature-display` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,6 +1645,7 @@ dependencies = [
  "starknet-accounts",
  "starknet-contract",
  "starknet-core",
+ "starknet-crypto",
  "starknet-ff",
  "starknet-macros",
  "starknet-providers",
@@ -1750,6 +1751,7 @@ dependencies = [
  "cxx",
  "cxx-build",
  "starknet-core",
+ "starknet-crypto",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ all-features = true
 
 [dependencies]
 starknet-ff = { version = "0.3.4", path = "./starknet-ff", default-features = false }
+starknet-crypto = { version = "0.6.0", path = "./starknet-crypto" }
 starknet-core = { version = "0.4.0", path = "./starknet-core", default-features = false }
 starknet-providers = { version = "0.4.0", path = "./starknet-providers" }
 starknet-contract = { version = "0.3.0", path = "./starknet-contract" }

--- a/examples/starknet-cxx/starknet-cxx/Cargo.toml
+++ b/examples/starknet-cxx/starknet-cxx/Cargo.toml
@@ -14,6 +14,11 @@ cxx = "1.0"
 # starknet-core = { git = "https://github.com/xJonathanLEI/starknet-rs" }
 starknet-core = { path = "../../../starknet-core" }
 
+# Same as above.
+# 
+# This entry is needed to enable the `signature-display` feature of `starknet-crypto`.
+starknet-crypto = { path = "../../../starknet-crypto", default-features = false, features = ["signature-display"] }
+
 [build-dependencies]
 cxx-build = "1.0"
 

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 all-features = true
 
 [dependencies]
-starknet-crypto = { version = "0.6.0", path = "../starknet-crypto", default-features = false, features = [ "alloc" ] }
+starknet-crypto = { version = "0.6.0", path = "../starknet-crypto", default-features = false, features = ["alloc"] }
 starknet-ff = { version = "0.3.4", path = "../starknet-ff", default-features = false, features = ["serde"] }
 base64 = { version = "0.21.0", default-features = false, features = ["alloc"] }
 flate2 = { version = "1.0.25", optional = true }


### PR DESCRIPTION
Enables the default features of `starknet-crypto` when using through the `starknet` wrapper crate to make it easier to use.