### PR TITLE
fix(sequencer): missing err codes

### DIFF
--- a/starknet-providers/src/sequencer/mod.rs
+++ b/starknet-providers/src/sequencer/mod.rs
@@ -82,6 +82,10 @@ pub enum ErrorCode {
     ClassAlreadyDeclared,
     #[serde(rename = "StarknetErrorCode.COMPILATION_FAILED")]
     CompilationFailed,
+    #[serde(rename = "StarknetErrorCode.INVALID_COMPILED_CLASS_HASH")]
+    InvalidCompiledClassHash,
+    #[serde(rename = "StarknetErrorCode.DUPLICATED_TRANSACTION")]
+    DuplicatedTransaction,
 }
 
 impl SequencerGatewayProvider {
@@ -722,6 +726,8 @@ impl TryFrom<ErrorCode> for StarknetError {
             ErrorCode::InvalidTransactionNonce => Err(()),
             ErrorCode::ClassAlreadyDeclared => Ok(Self::ClassAlreadyDeclared),
             ErrorCode::CompilationFailed => Err(()),
+            ErrorCode::InvalidCompiledClassHash => Err(()),
+            ErrorCode::DuplicatedTransaction => Err(()),
         }
     }
 }


### PR DESCRIPTION
2 missing error codes found:

- `INVALID_COMPILED_CLASS_HASH`: this happens when the sequencer disagrees with the CASM hash provided.
- `DUPLICATED_TRANSACTION`: starting from Starknet v0.12.0, the sequencer no longer accepts duplicate transaction submissions and rejects them with this new error code.