### PR TITLE
test: fix starknet 0.12.0 test failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,6 +1659,7 @@ name = "starknet-accounts"
 version = "0.3.0"
 dependencies = [
  "async-trait",
+ "rand",
  "serde",
  "serde_json",
  "starknet-core",

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -20,6 +20,7 @@ async-trait = "0.1.68"
 thiserror = "1.0.40"
 
 [dev-dependencies]
+rand = { version = "0.8.5", features=["std_rng"] }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
 tokio = { version = "1.27.0", features = ["full"] }

--- a/starknet-contract/tests/contract_deployment.rs
+++ b/starknet-contract/tests/contract_deployment.rs
@@ -12,7 +12,8 @@ use url::Url;
 #[tokio::test]
 async fn can_deploy_contract_to_alpha_goerli() {
     let provider = JsonRpcClient::new(HttpTransport::new(
-        Url::parse("https://rpc-goerli-1.starknet.rs/rpc/v0.3").unwrap(),
+        Url::parse("https://starknet-goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161")
+            .unwrap(),
     ));
     let signer = LocalWallet::from(SigningKey::from_secret_scalar(
         FieldElement::from_hex_be(

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -16,7 +16,8 @@ use url::Url;
 
 fn create_jsonrpc_client() -> JsonRpcClient<HttpTransport> {
     JsonRpcClient::new(HttpTransport::new(
-        Url::parse("https://rpc-goerli-1.starknet.rs/rpc/v0.3").unwrap(),
+        Url::parse("https://starknet-goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161")
+            .unwrap(),
     ))
 }
 
@@ -391,7 +392,7 @@ async fn jsonrpc_get_events() {
         .get_events(
             EventFilter {
                 from_block: Some(BlockId::Number(234500)),
-                to_block: None,
+                to_block: Some(BlockId::Number(235000)),
                 address: None,
                 keys: None,
             },


### PR DESCRIPTION
Starknet v0.12.0 was deployed to testnet and it has caused some tests to failed. This PR changes the following to make tests pass again:

- Forces all transactions sent out to be unique, as the sequencer no longer accepts duplicate transaction submissions;
- Switches to Infura for JSON-RPC, as it seems the sequencer has imposed a stricter rate limit on transaction submission, and using our own node results in failures;
- Updates the event query to be a narrow range as Infura doesn't seem to allow wide range event query.