### PR TITLE
release: bump starknet-providers to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ all-features = true
 starknet-ff = { version = "0.3.4", path = "./starknet-ff", default-features = false }
 starknet-crypto = { version = "0.6.0", path = "./starknet-crypto" }
 starknet-core = { version = "0.4.0", path = "./starknet-core", default-features = false }
-starknet-providers = { version = "0.4.0", path = "./starknet-providers" }
+starknet-providers = { version = "0.4.1", path = "./starknet-providers" }
 starknet-contract = { version = "0.3.0", path = "./starknet-contract" }
 starknet-signers = { version = "0.2.2", path = "./starknet-signers" }
 starknet-accounts = { version = "0.3.0", path = "./starknet-accounts" }

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
 starknet-core = { version = "0.4.0", path = "../starknet-core" }
-starknet-providers = { version = "0.4.0", path = "../starknet-providers" }
+starknet-providers = { version = "0.4.1", path = "../starknet-providers" }
 starknet-signers = { version = "0.2.2", path = "../starknet-signers" }
 async-trait = "0.1.68"
 thiserror = "1.0.40"

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
 starknet-core = { version = "0.4.0", path = "../starknet-core" }
-starknet-providers = { version = "0.4.0", path = "../starknet-providers" }
+starknet-providers = { version = "0.4.1", path = "../starknet-providers" }
 starknet-accounts = { version = "0.3.0", path = "../starknet-accounts" }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-providers"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
This is technically a breaking change as we're adding new enum variants. However, this only breaks code that's exhausting all options of `ErrorCode`, which is very unlikely.

Therefore, let's just ignore semver and bump `starknet-providers` to `0.4.1` instead :)