### PR TITLE
Remove last digit in sha2 version, allowing users to bump version, or use the one they need

### DIFF
--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -22,7 +22,7 @@ num-bigint = { version = "0.4.3", default-features = false }
 num-integer = { version = "0.1.45", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 rfc6979 = { version = "0.4.0", default-features = false }
-sha2 = { version = "0.10.6", default-features = false }
+sha2 = { version = "0.10", default-features = false }
 zeroize = { version = "1.6.0", default-features = false }
 hex = { version = "0.4.3", default-features = false, optional = true }
 


### PR DESCRIPTION
Pinning last digit in version forces the users of the library to use that version. Else unsolved conflicts may appear.

This also makes dependencies outdated. Right now for example there's a new version of sha2.

By omitting the last digit, it uses the last one by default, or the one specified by the user of the library.

For the record, this is the latest version of sha2 right now: https://github.com/RustCrypto/hashes/commit/d8b088aece5659cecdce397ce48d6129b6c4c440