### PR TITLE
feat: support query tx version

### DIFF
--- a/starknet-accounts/src/account/declaration.rs
+++ b/starknet-accounts/src/account/declaration.rs
@@ -393,6 +393,8 @@ where
             contract_class: self.inner.contract_class.clone(),
             compiled_class_hash: self.inner.compiled_class_hash,
             sender_address: self.account.address(),
+            // TODO: make use of query version tx for estimating fees
+            is_query: false,
         })
     }
 }
@@ -447,6 +449,8 @@ where
             nonce: self.inner.nonce,
             contract_class: Arc::new(compressed_class),
             sender_address: self.account.address(),
+            // TODO: make use of query version tx for estimating fees
+            is_query: false,
         })
     }
 }

--- a/starknet-accounts/src/account/execution.rs
+++ b/starknet-accounts/src/account/execution.rs
@@ -248,6 +248,8 @@ where
             nonce: self.inner.nonce,
             sender_address: self.account.address(),
             calldata: self.raw_calldata(),
+            // TODO: make use of query version tx for estimating fees
+            is_query: false,
         })
     }
 }

--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -339,6 +339,8 @@ where
             contract_address_salt: self.inner.salt,
             constructor_calldata: self.factory.calldata(),
             class_hash: self.factory.class_hash(),
+            // TODO: make use of query version tx for estimating fees
+            is_query: false,
         })
     }
 }

--- a/starknet-core/test-data/serde/broadcasted_invoke_v1_non_query.json
+++ b/starknet-core/test-data/serde/broadcasted_invoke_v1_non_query.json
@@ -1,0 +1,15 @@
+{
+  "max_fee": "0x1",
+  "version": "0x1",
+  "signature": [
+    "0x2"
+  ],
+  "nonce": "0x1",
+  "type": "INVOKE",
+  "sender_address": "0x3",
+  "calldata": [
+    "0x1",
+    "0x2",
+    "0x3"
+  ]
+}

--- a/starknet-core/test-data/serde/broadcasted_invoke_v1_query.json
+++ b/starknet-core/test-data/serde/broadcasted_invoke_v1_query.json
@@ -1,0 +1,15 @@
+{
+  "max_fee": "0x1",
+  "version": "0x100000000000000000000000000000001",
+  "signature": [
+    "0x2"
+  ],
+  "nonce": "0x1",
+  "type": "INVOKE",
+  "sender_address": "0x3",
+  "calldata": [
+    "0x1",
+    "0x2",
+    "0x3"
+  ]
+}

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -329,6 +329,8 @@ async fn jsonrpc_estimate_fee() {
                         FieldElement::from_hex_be("3635c9adc5dea00000").unwrap(),
                         FieldElement::from_hex_be("0").unwrap(),
                     ],
+                    // TODO: make use of query version tx for estimating fees
+                    is_query: false,
                 },
             )),
             BlockId::Tag(BlockTag::Latest),


### PR DESCRIPTION
Query tx version support is only applied for `BroadcastXxx` types, as the query version would never exist in a block.

This PR enables applications using `starknet-core` on the server side to accept query version tx requests. However, `starknet-rs` itself does not make use of it yet. This will be addressed in a future version.