### PR TITLE
feat(providers): provider traffic trace logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,12 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "memchr"
@@ -1785,6 +1782,7 @@ dependencies = [
  "auto_impl",
  "ethereum-types",
  "flate2",
+ "log",
  "reqwest",
  "serde",
  "serde_json",

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -18,8 +18,9 @@ async-trait = "0.1.68"
 auto_impl = "1.0.1"
 ethereum-types = "0.14.1"
 flate2 = "1.0.25"
+log = "0.4.19"
 url = "2.3.1"
-reqwest = { version = "0.11.16", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.11.16", default-features = false, features = ["rustls-tls"] }
 thiserror = "1.0.40"
 serde = "1.0.160"
 serde_json = "1.0.96"

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -17,7 +17,7 @@ use starknet_core::{
 use crate::{Provider, ProviderError};
 
 mod transports;
-pub use transports::{HttpTransport, JsonRpcTransport};
+pub use transports::{HttpTransport, HttpTransportError, JsonRpcTransport};
 
 #[derive(Debug)]
 pub struct JsonRpcClient<T> {

--- a/starknet-providers/src/jsonrpc/transports/mod.rs
+++ b/starknet-providers/src/jsonrpc/transports/mod.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 use crate::jsonrpc::{JsonRpcMethod, JsonRpcResponse};
 
 mod http;
-pub use http::HttpTransport;
+pub use http::{HttpTransport, HttpTransportError};
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]


### PR DESCRIPTION
Downstream applications often find it difficult to debug provider- related issues since there's currently no way to inspect the traffic. The integration with `log` makes debugging easier.