### PR TITLE
feat: include error message in provider error

### DIFF
--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -8,7 +8,9 @@ use starknet_core::{
         DeployAccountTransactionResult, FeeEstimate, FieldElement, StarknetError,
     },
 };
-use starknet_providers::{Provider, ProviderError};
+use starknet_providers::{
+    MaybeUnknownErrorCode, Provider, ProviderError, StarknetErrorWithMessage,
+};
 use std::error::Error;
 
 pub mod argent;
@@ -177,9 +179,10 @@ where
             .await
         {
             Ok(nonce) => Ok(nonce),
-            Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => {
-                Ok(FieldElement::ZERO)
-            }
+            Err(ProviderError::StarknetError(StarknetErrorWithMessage {
+                code: MaybeUnknownErrorCode::Known(StarknetError::ContractNotFound),
+                ..
+            })) => Ok(FieldElement::ZERO),
             Err(err) => Err(err),
         }
     }

--- a/starknet-core/src/types/codegen.rs
+++ b/starknet-core/src/types/codegen.rs
@@ -3,7 +3,7 @@
 //     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen
 
 // Code generated with version:
-//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen#2bf67752dd3200c4d46077e3d2838c9563d2dfa7
+//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen#b956776898ca9f9c92ccc9b8523ff7d82af5c3ad
 
 // Code generation requested but not implemented for these types:
 // - `BLOCK_ID`
@@ -1044,21 +1044,19 @@ impl std::error::Error for StarknetError {}
 impl core::fmt::Display for StarknetError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::FailedToReceiveTransaction => write!(f, "Failed to write transaction"),
-            Self::ContractNotFound => write!(f, "Contract not found"),
-            Self::BlockNotFound => write!(f, "Block not found"),
-            Self::TransactionHashNotFound => write!(f, "Transaction hash not found"),
-            Self::InvalidTransactionIndex => write!(f, "Invalid transaction index in a block"),
-            Self::ClassHashNotFound => write!(f, "Class hash not found"),
-            Self::PageSizeTooBig => write!(f, "Requested page size is too big"),
-            Self::NoBlocks => write!(f, "There are no blocks"),
-            Self::InvalidContinuationToken => {
-                write!(f, "The supplied continuation token is invalid or unknown")
-            }
-            Self::TooManyKeysInFilter => write!(f, "Too many keys provided in a filter"),
-            Self::ContractError => write!(f, "Contract error"),
-            Self::InvalidContractClass => write!(f, "Invalid contract class"),
-            Self::ClassAlreadyDeclared => write!(f, "Class already declared"),
+            Self::FailedToReceiveTransaction => write!(f, "FailedToReceiveTransaction"),
+            Self::ContractNotFound => write!(f, "ContractNotFound"),
+            Self::BlockNotFound => write!(f, "BlockNotFound"),
+            Self::TransactionHashNotFound => write!(f, "TransactionHashNotFound"),
+            Self::InvalidTransactionIndex => write!(f, "InvalidTransactionIndex"),
+            Self::ClassHashNotFound => write!(f, "ClassHashNotFound"),
+            Self::PageSizeTooBig => write!(f, "PageSizeTooBig"),
+            Self::NoBlocks => write!(f, "NoBlocks"),
+            Self::InvalidContinuationToken => write!(f, "InvalidContinuationToken"),
+            Self::TooManyKeysInFilter => write!(f, "TooManyKeysInFilter"),
+            Self::ContractError => write!(f, "ContractError"),
+            Self::InvalidContractClass => write!(f, "InvalidContractClass"),
+            Self::ClassAlreadyDeclared => write!(f, "ClassAlreadyDeclared"),
         }
     }
 }

--- a/starknet-providers/src/lib.rs
+++ b/starknet-providers/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 mod provider;
-pub use provider::{Provider, ProviderError};
+pub use provider::{MaybeUnknownErrorCode, Provider, ProviderError, StarknetErrorWithMessage};
 
 pub mod sequencer;
 pub use sequencer::{

--- a/starknet-providers/src/provider.rs
+++ b/starknet-providers/src/provider.rs
@@ -219,11 +219,33 @@ pub trait Provider {
 #[derive(Debug, thiserror::Error)]
 pub enum ProviderError<E> {
     #[error(transparent)]
-    StarknetError(StarknetError),
+    StarknetError(StarknetErrorWithMessage),
     #[error("Request rate limited")]
     RateLimited,
     #[error("Array length mismatch")]
     ArrayLengthMismatch,
     #[error(transparent)]
     Other(E),
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("code={code}, message=\"{message}\"")]
+pub struct StarknetErrorWithMessage {
+    pub code: MaybeUnknownErrorCode,
+    pub message: String,
+}
+
+#[derive(Debug)]
+pub enum MaybeUnknownErrorCode {
+    Known(StarknetError),
+    Unknown(i64),
+}
+
+impl core::fmt::Display for MaybeUnknownErrorCode {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            MaybeUnknownErrorCode::Known(code) => write!(f, "{}", code),
+            MaybeUnknownErrorCode::Unknown(code) => write!(f, "{}", code),
+        }
+    }
 }

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -11,6 +11,7 @@ use starknet_core::types::{
 };
 
 use crate::{
+    provider::{MaybeUnknownErrorCode, StarknetErrorWithMessage},
     sequencer::{
         models::conversions::{ConversionError, TransactionWithReceipt},
         GatewayClientError,
@@ -111,7 +112,10 @@ impl Provider for SequencerGatewayProvider {
             Ok(block.transactions.remove(index).try_into()?)
         } else {
             Err(ProviderError::<Self::Error>::StarknetError(
-                StarknetError::InvalidTransactionIndex,
+                StarknetErrorWithMessage {
+                    code: MaybeUnknownErrorCode::Known(StarknetError::InvalidTransactionIndex),
+                    message: "Invalid transaction index in a block".into(),
+                },
             ))
         }
     }
@@ -132,7 +136,10 @@ impl Provider for SequencerGatewayProvider {
             || receipt.status == super::models::TransactionStatus::Received
         {
             Err(ProviderError::<Self::Error>::StarknetError(
-                StarknetError::TransactionHashNotFound,
+                StarknetErrorWithMessage {
+                    code: MaybeUnknownErrorCode::Known(StarknetError::TransactionHashNotFound),
+                    message: "Transaction hash not found".into(),
+                },
             ))
         } else {
             // JSON-RPC also sends tx type, which is not available in our receipt type

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -10,7 +10,7 @@ use starknet_core::{
 };
 use starknet_providers::{
     jsonrpc::{HttpTransport, JsonRpcClient},
-    Provider, ProviderError,
+    MaybeUnknownErrorCode, Provider, ProviderError, StarknetErrorWithMessage,
 };
 use url::Url;
 
@@ -148,7 +148,10 @@ async fn jsonrpc_get_transaction_by_hash_non_existent_tx() {
         .unwrap_err();
 
     match err {
-        ProviderError::StarknetError(StarknetError::TransactionHashNotFound) => {
+        ProviderError::StarknetError(StarknetErrorWithMessage {
+            code: MaybeUnknownErrorCode::Known(StarknetError::TransactionHashNotFound),
+            ..
+        }) => {
             // TXN_HASH_NOT_FOUND
         }
         _ => panic!("Unexpected error"),


### PR DESCRIPTION
Currently when a matching error code is found, the `message` context is lost in the conversion process. This PR makes the message available again.

This might not be very useful in practice though, due to how JSON-RPC node implementations seem to simply always hard-code the fixed error message derived from the error code itself.