### PR TITLE
ci: fix cargo-udeps installation failure

### DIFF
--- a/.github/workflows/udeps.yml
+++ b/.github/workflows/udeps.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: cargo-udeps
+          args: cargo-udeps --locked
 
       - name: Run udeps
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
`cargo-udeps` now fails to install without having dependencies locked.