### PR TITLE
test: use distinct accounts for test cases

### DIFF
--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -7,7 +7,7 @@ use starknet_core::{
             legacy::{LegacyContractClass, RawLegacyAbiEntry, RawLegacyFunction},
             SierraClass,
         },
-        FieldElement,
+        BlockId, BlockTag, FieldElement,
     },
     utils::get_selector_from_name,
 };
@@ -31,22 +31,38 @@ fn create_jsonrpc_client() -> JsonRpcClient<HttpTransport> {
 
 #[tokio::test]
 async fn can_get_nonce_with_sequencer() {
-    can_get_nonce_inner(create_sequencer_client()).await
+    can_get_nonce_inner(
+        create_sequencer_client(),
+        "0x4edd59099fb8f462021abe43a6660c1f0a4b3ffcdaf5483a0846c5bce0ca563",
+    )
+    .await
 }
 
 #[tokio::test]
 async fn can_get_nonce_with_jsonrpc() {
-    can_get_nonce_inner(create_jsonrpc_client()).await
+    can_get_nonce_inner(
+        create_jsonrpc_client(),
+        "0x69194dcf3379d2b1747487b6aa0d22d50993c1e2955a74342fcee39ae38c89d",
+    )
+    .await
 }
 
 #[tokio::test]
 async fn can_estimate_fee_with_sequencer() {
-    can_estimate_fee_inner(create_sequencer_client()).await
+    can_estimate_fee_inner(
+        create_sequencer_client(),
+        "0x6509cb370e06f4c5acc42c7269ac4cf0bfc9afc6c83eca9c040de8b3e24f92e",
+    )
+    .await
 }
 
 #[tokio::test]
 async fn can_estimate_fee_with_jsonrpc() {
-    can_estimate_fee_inner(create_jsonrpc_client()).await
+    can_estimate_fee_inner(
+        create_jsonrpc_client(),
+        "0x44c3c30803ea9c4e063ae052e6b7ef537284fca6b93849dae9a093e42aa1574",
+    )
+    .await
 }
 
 // The `simulate`-related test cases are temporarily removed until it's supported in [Provider]
@@ -54,68 +70,88 @@ async fn can_estimate_fee_with_jsonrpc() {
 
 #[tokio::test]
 async fn can_execute_tst_mint_with_sequencer() {
-    can_execute_tst_mint_inner(create_sequencer_client()).await
+    can_execute_tst_mint_inner(
+        create_sequencer_client(),
+        "0x1377e5cc40f099c23ef670f0d4979304b8bf975404fe44f4bd78f76eb5014e0",
+    )
+    .await
 }
 
 #[tokio::test]
 async fn can_execute_tst_mint_with_jsonrpc() {
-    can_execute_tst_mint_inner(create_jsonrpc_client()).await
+    can_execute_tst_mint_inner(
+        create_jsonrpc_client(),
+        "0x32e340cf84c5e80102031e555ca8b2688855895000d7ad2f2c1fd29e3503ef7",
+    )
+    .await
 }
 
 #[tokio::test]
 async fn can_declare_cairo1_contract_with_sequencer() {
-    can_declare_cairo1_contract_inner(create_sequencer_client()).await
+    can_declare_cairo1_contract_inner(
+        create_sequencer_client(),
+        "0x5d56c86af91e6732f71ceb0fd12d29a86928799f8767a8447d73c9c9a8c1bb4",
+    )
+    .await
 }
 
 #[tokio::test]
 async fn can_declare_cairo1_contract_with_jsonrpc() {
-    can_declare_cairo1_contract_inner(create_jsonrpc_client()).await
+    can_declare_cairo1_contract_inner(
+        create_jsonrpc_client(),
+        "0x2a27190134a9b2f3af972782233764ad22defde1e6ea69608a0820a537e8e1f",
+    )
+    .await
 }
 
 #[tokio::test]
 async fn can_declare_cairo0_contract_with_sequencer() {
-    can_declare_cairo0_contract_inner(create_sequencer_client()).await
+    can_declare_cairo0_contract_inner(
+        create_sequencer_client(),
+        "0x45dba6ce6a4dc3d2f31aa6da5f51007f1e43e84a1e62c4481bac5454dea4e6d",
+    )
+    .await
 }
 
 #[tokio::test]
 async fn can_declare_cairo0_contract_with_jsonrpc() {
-    can_declare_cairo0_contract_inner(create_jsonrpc_client()).await
+    can_declare_cairo0_contract_inner(
+        create_jsonrpc_client(),
+        "0x2a6bb48ab184f8e5fa5b3050523b2891519308e3a7200f933ab4a5598bed9da",
+    )
+    .await
 }
 
-async fn can_get_nonce_inner<P: Provider + Send + Sync>(provider: P) {
+async fn can_get_nonce_inner<P: Provider + Send + Sync>(provider: P, address: &str) {
     let signer = LocalWallet::from(SigningKey::from_secret_scalar(
         FieldElement::from_hex_be(
             "00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
         )
         .unwrap(),
     ));
-    let address = FieldElement::from_hex_be(
-        "02da37a17affbd2df4ede7120dae305ec36dfe94ec96a8c3f49bbf59f4e9a9fa",
-    )
-    .unwrap();
+    let address = FieldElement::from_hex_be(address).unwrap();
 
-    let account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     assert_ne!(account.get_nonce().await.unwrap(), FieldElement::ZERO);
 }
 
-async fn can_estimate_fee_inner<P: Provider + Send + Sync>(provider: P) {
+async fn can_estimate_fee_inner<P: Provider + Send + Sync>(provider: P, address: &str) {
     let signer = LocalWallet::from(SigningKey::from_secret_scalar(
         FieldElement::from_hex_be(
             "00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
         )
         .unwrap(),
     ));
-    let address = FieldElement::from_hex_be(
-        "02da37a17affbd2df4ede7120dae305ec36dfe94ec96a8c3f49bbf59f4e9a9fa",
-    )
-    .unwrap();
+    let address = FieldElement::from_hex_be(address).unwrap();
     let tst_token_address = FieldElement::from_hex_be(
         "07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10",
     )
     .unwrap();
 
-    let account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let fee_estimate = account
         .execute(vec![
@@ -145,7 +181,7 @@ async fn can_estimate_fee_inner<P: Provider + Send + Sync>(provider: P) {
     assert!(fee_estimate.overall_fee > 0);
 }
 
-async fn can_execute_tst_mint_inner<P: Provider + Send + Sync>(provider: P) {
+async fn can_execute_tst_mint_inner<P: Provider + Send + Sync>(provider: P, address: &str) {
     // This test case is not very useful as the sequencer will always respond with
     // `TransactionReceived` even if the transaction will eventually fail, just like how
     // `eth_sendRawTransaction` always responds with success except for insufficient balance. So it
@@ -159,16 +195,14 @@ async fn can_execute_tst_mint_inner<P: Provider + Send + Sync>(provider: P) {
         )
         .unwrap(),
     ));
-    let address = FieldElement::from_hex_be(
-        "02da37a17affbd2df4ede7120dae305ec36dfe94ec96a8c3f49bbf59f4e9a9fa",
-    )
-    .unwrap();
+    let address = FieldElement::from_hex_be(address).unwrap();
     let tst_token_address = FieldElement::from_hex_be(
         "07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10",
     )
     .unwrap();
 
-    let account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let mut rng = rand::thread_rng();
     let random_amount = rng.next_u64().into();
@@ -197,7 +231,7 @@ async fn can_execute_tst_mint_inner<P: Provider + Send + Sync>(provider: P) {
     assert!(result.transaction_hash > FieldElement::ZERO);
 }
 
-async fn can_declare_cairo1_contract_inner<P: Provider + Send + Sync>(provider: P) {
+async fn can_declare_cairo1_contract_inner<P: Provider + Send + Sync>(provider: P, address: &str) {
     // This test case is not very useful, same as `can_execute_tst_mint` above.
 
     #[derive(serde::Deserialize)]
@@ -211,11 +245,9 @@ async fn can_declare_cairo1_contract_inner<P: Provider + Send + Sync>(provider: 
         )
         .unwrap(),
     ));
-    let address = FieldElement::from_hex_be(
-        "02da37a17affbd2df4ede7120dae305ec36dfe94ec96a8c3f49bbf59f4e9a9fa",
-    )
-    .unwrap();
-    let account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let address = FieldElement::from_hex_be(address).unwrap();
+    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let contract_artifact = serde_json::from_str::<SierraClass>(include_str!(
         "../test-data/cairo1/artifacts/abi_types_sierra.txt"
@@ -251,7 +283,7 @@ async fn can_declare_cairo1_contract_inner<P: Provider + Send + Sync>(provider: 
     assert!(result.transaction_hash > FieldElement::ZERO);
 }
 
-async fn can_declare_cairo0_contract_inner<P: Provider + Send + Sync>(provider: P) {
+async fn can_declare_cairo0_contract_inner<P: Provider + Send + Sync>(provider: P, address: &str) {
     // This test case is not very useful, same as `can_execute_tst_mint` above.
 
     let signer = LocalWallet::from(SigningKey::from_secret_scalar(
@@ -260,11 +292,9 @@ async fn can_declare_cairo0_contract_inner<P: Provider + Send + Sync>(provider: 
         )
         .unwrap(),
     ));
-    let address = FieldElement::from_hex_be(
-        "02da37a17affbd2df4ede7120dae305ec36dfe94ec96a8c3f49bbf59f4e9a9fa",
-    )
-    .unwrap();
-    let account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let address = FieldElement::from_hex_be(address).unwrap();
+    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let mut contract_artifact: LegacyContractClass =
         serde_json::from_str(include_str!("../test-data/cairo0/artifacts/oz_account.txt")).unwrap();

--- a/starknet-contract/tests/contract_deployment.rs
+++ b/starknet-contract/tests/contract_deployment.rs
@@ -3,7 +3,7 @@ use starknet_accounts::SingleOwnerAccount;
 use starknet_contract::ContractFactory;
 use starknet_core::{
     chain_id,
-    types::{contract::legacy::LegacyContractClass, FieldElement},
+    types::{contract::legacy::LegacyContractClass, BlockId, BlockTag, FieldElement},
 };
 use starknet_providers::{jsonrpc::HttpTransport, JsonRpcClient};
 use starknet_signers::{LocalWallet, SigningKey};
@@ -25,7 +25,8 @@ async fn can_deploy_contract_to_alpha_goerli() {
         "02da37a17affbd2df4ede7120dae305ec36dfe94ec96a8c3f49bbf59f4e9a9fa",
     )
     .unwrap();
-    let account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let artifact = serde_json::from_str::<LegacyContractClass>(include_str!(
         "../test-data/cairo0/artifacts/oz_account.txt"


### PR DESCRIPTION
The network now validates transaction nonces. Using different accounts for different test cases helps reduce the chance of clashing.