### PR TITLE
chore: exclude test data from published crates

### DIFF
--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -11,6 +11,7 @@ description = """
 Types for handling Starknet account abstraction
 """
 keywords = ["ethereum", "starknet", "web3"]
+exclude = ["test-data/**"]
 
 [dependencies]
 starknet-core = { version = "0.5.1", path = "../starknet-core" }

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -11,6 +11,7 @@ description = """
 Types and utilities for Starknet smart contract deployment and interaction
 """
 keywords = ["ethereum", "starknet", "web3"]
+exclude = ["test-data/**"]
 
 [dependencies]
 starknet-core = { version = "0.5.1", path = "../starknet-core" }

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -11,6 +11,7 @@ description = """
 Core structures for the starknet crate
 """
 keywords = ["ethereum", "starknet", "web3"]
+exclude = ["test-data/**"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -11,6 +11,7 @@ description = """
 Low-level cryptography utilities for Starknet
 """
 keywords = ["ethereum", "starknet", "web3", "no_std"]
+exclude = ["test-data/**"]
 
 [dependencies]
 starknet-crypto-codegen = { version = "0.3.2", path = "../starknet-crypto-codegen" }

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -11,6 +11,7 @@ description = """
 Provider implementations for the starknet crate
 """
 keywords = ["ethereum", "starknet", "web3"]
+exclude = ["test-data/**"]
 
 [dependencies]
 starknet-core = { version = "0.5.1", path = "../starknet-core" }


### PR DESCRIPTION
Just realized that the published crates unnecessarily bundle the `test-data` directory, causing crate sizes to be rather large.

For example, the latest version of `starknet-core` is now 658 kB _compressed_. After this change it will become 29.9 kB instead.