### PR TITLE
fix: no_unknown_fields feature not propagated

### DIFF
--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -33,4 +33,6 @@ tokio = { version = "1.27.0", features = ["full"] }
 
 [features]
 default = []
-no_unknown_fields = []
+no_unknown_fields = [
+    "starknet-core/no_unknown_fields"
+]


### PR DESCRIPTION
When using the `starknet-providers` crate directly, the `no_unknown_fields` feature is incorrectly not propagated into `starknet-core`.