### PR TITLE
feat: support Cairo 1 account `execute` encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,6 +1656,7 @@ name = "starknet-accounts"
 version = "0.4.0"
 dependencies = [
  "async-trait",
+ "auto_impl",
  "rand",
  "serde",
  "serde_json",

--- a/examples/declare_cairo0_contract.rs
+++ b/examples/declare_cairo0_contract.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use starknet::{
-    accounts::{Account, SingleOwnerAccount},
+    accounts::{Account, ExecutionEncoding, SingleOwnerAccount},
     core::{
         chain_id,
         types::{contract::legacy::LegacyContractClass, BlockId, BlockTag, FieldElement},
@@ -21,7 +21,13 @@ async fn main() {
     ));
     let address = FieldElement::from_hex_be("YOUR_ACCOUNT_CONTRACT_ADDRESS_IN_HEX_HERE").unwrap();
 
-    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(
+        provider,
+        signer,
+        address,
+        chain_id::TESTNET,
+        ExecutionEncoding::Legacy,
+    );
 
     // `SingleOwnerAccount` defaults to checking nonce and estimating fees against the latest
     // block. Optionally change the target block to pending with the following line:

--- a/examples/declare_cairo1_contract.rs
+++ b/examples/declare_cairo1_contract.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use starknet::{
-    accounts::{Account, SingleOwnerAccount},
+    accounts::{Account, ExecutionEncoding, SingleOwnerAccount},
     core::{
         chain_id,
         types::{contract::SierraClass, BlockId, BlockTag, FieldElement},
@@ -27,7 +27,13 @@ async fn main() {
     ));
     let address = FieldElement::from_hex_be("YOUR_ACCOUNT_CONTRACT_ADDRESS_IN_HEX_HERE").unwrap();
 
-    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(
+        provider,
+        signer,
+        address,
+        chain_id::TESTNET,
+        ExecutionEncoding::Legacy,
+    );
 
     // `SingleOwnerAccount` defaults to checking nonce and estimating fees against the latest
     // block. Optionally change the target block to pending with the following line:

--- a/examples/deploy_contract.rs
+++ b/examples/deploy_contract.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use starknet::{
-    accounts::SingleOwnerAccount,
+    accounts::{ExecutionEncoding, SingleOwnerAccount},
     contract::ContractFactory,
     core::{
         chain_id,
@@ -25,7 +25,13 @@ async fn main() {
         FieldElement::from_hex_be("YOUR_PRIVATE_KEY_IN_HEX_HERE").unwrap(),
     ));
     let address = FieldElement::from_hex_be("YOUR_ACCOUNT_CONTRACT_ADDRESS_IN_HEX_HERE").unwrap();
-    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(
+        provider,
+        signer,
+        address,
+        chain_id::TESTNET,
+        ExecutionEncoding::Legacy,
+    );
 
     // `SingleOwnerAccount` defaults to checking nonce and estimating fees against the latest
     // block. Optionally change the target block to pending with the following line:

--- a/examples/mint_tokens.rs
+++ b/examples/mint_tokens.rs
@@ -1,5 +1,5 @@
 use starknet::{
-    accounts::{Account, Call, SingleOwnerAccount},
+    accounts::{Account, Call, ExecutionEncoding, SingleOwnerAccount},
     core::{
         chain_id,
         types::{BlockId, BlockTag, FieldElement},
@@ -21,7 +21,13 @@ async fn main() {
     )
     .unwrap();
 
-    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(
+        provider,
+        signer,
+        address,
+        chain_id::TESTNET,
+        ExecutionEncoding::Legacy,
+    );
 
     // `SingleOwnerAccount` defaults to checking nonce and estimating fees against the latest
     // block. Optionally change the target block to pending with the following line:

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -18,6 +18,7 @@ starknet-core = { version = "0.5.1", path = "../starknet-core" }
 starknet-providers = { version = "0.5.0", path = "../starknet-providers" }
 starknet-signers = { version = "0.3.0", path = "../starknet-signers" }
 async-trait = "0.1.68"
+auto_impl = "1.0.1"
 thiserror = "1.0.40"
 
 [dev-dependencies]

--- a/starknet-accounts/src/account/mod.rs
+++ b/starknet-accounts/src/account/mod.rs
@@ -1,6 +1,7 @@
 use crate::Call;
 
 use async_trait::async_trait;
+use auto_impl::auto_impl;
 use starknet_core::types::{
     contract::{legacy::LegacyContractClass, CompressProgramError, ComputeClassHashError},
     BlockId, BlockTag, FieldElement, FlattenedSierraClass,
@@ -17,7 +18,7 @@ mod execution;
 /// sending transactions.
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-pub trait Account: Sized {
+pub trait Account: ExecutionEncoder + Sized {
     type SignError: Error + Send + Sync;
 
     fn address(&self) -> FieldElement;
@@ -54,6 +55,11 @@ pub trait Account: Sized {
     fn declare_legacy(&self, contract_class: Arc<LegacyContractClass>) -> LegacyDeclaration<Self> {
         LegacyDeclaration::new(contract_class, self)
     }
+}
+
+#[auto_impl(&, Box, Arc)]
+pub trait ExecutionEncoder {
+    fn encode_calls(&self, calls: &[Call]) -> Vec<FieldElement>;
 }
 
 /// An [Account] implementation that also comes with a [Provider]. Functionalities that require a

--- a/starknet-accounts/src/lib.rs
+++ b/starknet-accounts/src/lib.rs
@@ -1,8 +1,8 @@
 mod account;
 pub use account::{
-    Account, AccountError, ConnectedAccount, Declaration, Execution, LegacyDeclaration,
-    PreparedDeclaration, PreparedExecution, PreparedLegacyDeclaration, RawDeclaration,
-    RawExecution, RawLegacyDeclaration,
+    Account, AccountError, ConnectedAccount, Declaration, Execution, ExecutionEncoder,
+    LegacyDeclaration, PreparedDeclaration, PreparedExecution, PreparedLegacyDeclaration,
+    RawDeclaration, RawExecution, RawLegacyDeclaration,
 };
 
 mod call;
@@ -15,7 +15,7 @@ pub use factory::{
 };
 
 pub mod single_owner;
-pub use single_owner::SingleOwnerAccount;
+pub use single_owner::{ExecutionEncoding, SingleOwnerAccount};
 
 #[derive(Debug, thiserror::Error)]
 #[error("Not all fields are prepared")]

--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -1,5 +1,5 @@
 use rand::RngCore;
-use starknet_accounts::{Account, Call, ConnectedAccount, SingleOwnerAccount};
+use starknet_accounts::{Account, Call, ConnectedAccount, ExecutionEncoding, SingleOwnerAccount};
 use starknet_core::{
     chain_id,
     types::{
@@ -130,7 +130,13 @@ async fn can_get_nonce_inner<P: Provider + Send + Sync>(provider: P, address: &s
     ));
     let address = FieldElement::from_hex_be(address).unwrap();
 
-    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(
+        provider,
+        signer,
+        address,
+        chain_id::TESTNET,
+        ExecutionEncoding::Legacy,
+    );
     account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     assert_ne!(account.get_nonce().await.unwrap(), FieldElement::ZERO);
@@ -149,7 +155,13 @@ async fn can_estimate_fee_inner<P: Provider + Send + Sync>(provider: P, address:
     )
     .unwrap();
 
-    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(
+        provider,
+        signer,
+        address,
+        chain_id::TESTNET,
+        ExecutionEncoding::Legacy,
+    );
     account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let fee_estimate = account
@@ -200,7 +212,13 @@ async fn can_execute_tst_mint_inner<P: Provider + Send + Sync>(provider: P, addr
     )
     .unwrap();
 
-    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(
+        provider,
+        signer,
+        address,
+        chain_id::TESTNET,
+        ExecutionEncoding::Legacy,
+    );
     account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let mut rng = rand::thread_rng();
@@ -245,7 +263,13 @@ async fn can_declare_cairo1_contract_inner<P: Provider + Send + Sync>(provider: 
         .unwrap(),
     ));
     let address = FieldElement::from_hex_be(address).unwrap();
-    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(
+        provider,
+        signer,
+        address,
+        chain_id::TESTNET,
+        ExecutionEncoding::Legacy,
+    );
     account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let contract_artifact = serde_json::from_str::<SierraClass>(include_str!(
@@ -292,7 +316,13 @@ async fn can_declare_cairo0_contract_inner<P: Provider + Send + Sync>(provider: 
         .unwrap(),
     ));
     let address = FieldElement::from_hex_be(address).unwrap();
-    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(
+        provider,
+        signer,
+        address,
+        chain_id::TESTNET,
+        ExecutionEncoding::Legacy,
+    );
     account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let mut contract_artifact: LegacyContractClass =

--- a/starknet-contract/tests/contract_deployment.rs
+++ b/starknet-contract/tests/contract_deployment.rs
@@ -1,5 +1,5 @@
 use rand::{rngs::StdRng, RngCore, SeedableRng};
-use starknet_accounts::SingleOwnerAccount;
+use starknet_accounts::{ExecutionEncoding, SingleOwnerAccount};
 use starknet_contract::ContractFactory;
 use starknet_core::{
     chain_id,
@@ -24,7 +24,13 @@ async fn can_deploy_contract_to_alpha_goerli() {
         "02da37a17affbd2df4ede7120dae305ec36dfe94ec96a8c3f49bbf59f4e9a9fa",
     )
     .unwrap();
-    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+    let mut account = SingleOwnerAccount::new(
+        provider,
+        signer,
+        address,
+        chain_id::TESTNET,
+        ExecutionEncoding::Legacy,
+    );
     account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let artifact = serde_json::from_str::<LegacyContractClass>(include_str!(


### PR DESCRIPTION
Cairo 1 account contracts expect calldata to be formatted differently from Cairo 0 accounts. The library previously assumed that such encoding is universal, which is clearly incorrect. In fact, account contracts should always be free to interpret calldata however they like, regardless of what Cairo version they're written in.

This commit introduces a breaking changes on the `new()` method of `SingleOwnerAccount` on purpose. This commit could have kept the method unchanged and instead uses a default value for `encoding`. However, adding the breaking change helps raise awareness that such difference exists.