### PR TITLE
feat: compute address for contract deployment

### DIFF
--- a/examples/deploy_contract.rs
+++ b/examples/deploy_contract.rs
@@ -43,7 +43,7 @@ async fn main() {
 
     let contract_factory = ContractFactory::new(class_hash, account);
     contract_factory
-        .deploy(&vec![felt!("123456")], felt!("1122"), false)
+        .deploy(vec![felt!("123456")], felt!("1122"), false)
         .send()
         .await
         .expect("Unable to deploy contract");

--- a/starknet-contract/src/factory.rs
+++ b/starknet-contract/src/factory.rs
@@ -1,5 +1,9 @@
-use starknet_accounts::{Account, Call, Execution};
-use starknet_core::types::FieldElement;
+use starknet_accounts::{Account, AccountError, Call, ConnectedAccount, Execution};
+use starknet_core::{
+    types::{FeeEstimate, FieldElement, InvokeTransactionResult},
+    utils::{get_udc_deployed_address, UdcUniqueSettings, UdcUniqueness},
+};
+use starknet_providers::Provider;
 
 /// The default UDC address: 0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf.
 const UDC_ADDRESS: FieldElement = FieldElement::from_mont([
@@ -23,6 +27,17 @@ pub struct ContractFactory<A> {
     account: A,
 }
 
+pub struct Deployment<'f, A> {
+    factory: &'f ContractFactory<A>,
+    constructor_calldata: Vec<FieldElement>,
+    salt: FieldElement,
+    unique: bool,
+    // The following fields allow us to mimic an `Execution` API.
+    nonce: Option<FieldElement>,
+    max_fee: Option<FieldElement>,
+    fee_estimate_multiplier: f64,
+}
+
 impl<A> ContractFactory<A> {
     pub fn new(class_hash: FieldElement, account: A) -> Self {
         Self::new_with_udc(class_hash, account, UDC_ADDRESS)
@@ -41,38 +56,187 @@ impl<A> ContractFactory<A>
 where
     A: Account,
 {
-    pub fn deploy<C>(
+    pub fn deploy(
         &self,
-        constructor_calldata: C,
+        constructor_calldata: Vec<FieldElement>,
         salt: FieldElement,
         unique: bool,
-    ) -> Execution<A>
-    where
-        C: AsRef<[FieldElement]>,
-    {
-        let constructor_calldata = constructor_calldata.as_ref();
-
-        let mut calldata = vec![
-            self.class_hash,
+    ) -> Deployment<A> {
+        Deployment {
+            factory: self,
+            constructor_calldata,
             salt,
-            if unique {
+            unique,
+            nonce: None,
+            max_fee: None,
+            fee_estimate_multiplier: 1.1,
+        }
+    }
+}
+
+impl<'f, A> Deployment<'f, A> {
+    pub fn nonce(self, nonce: FieldElement) -> Self {
+        Self {
+            nonce: Some(nonce),
+            ..self
+        }
+    }
+
+    pub fn max_fee(self, max_fee: FieldElement) -> Self {
+        Self {
+            max_fee: Some(max_fee),
+            ..self
+        }
+    }
+
+    pub fn fee_estimate_multiplier(self, fee_estimate_multiplier: f64) -> Self {
+        Self {
+            fee_estimate_multiplier,
+            ..self
+        }
+    }
+}
+
+impl<'f, A> Deployment<'f, A>
+where
+    A: Account,
+{
+    /// Calculate the resulting contract address without sending a transaction.
+    pub fn deployed_address(&self) -> FieldElement {
+        get_udc_deployed_address(
+            self.salt,
+            self.factory.class_hash,
+            &if self.unique {
+                UdcUniqueness::Unique(UdcUniqueSettings {
+                    deployer_address: self.factory.account.address(),
+                    udc_contract_address: self.factory.udc_address,
+                })
+            } else {
+                UdcUniqueness::NotUnique
+            },
+            &self.constructor_calldata,
+        )
+    }
+}
+
+impl<'f, A> Deployment<'f, A>
+where
+    A: ConnectedAccount + Sync,
+{
+    pub async fn estimate_fee(
+        &self,
+    ) -> Result<FeeEstimate, AccountError<A::SignError, <A::Provider as Provider>::Error>> {
+        let execution: Execution<A> = self.into();
+        execution.estimate_fee().await
+    }
+
+    pub async fn send(
+        &self,
+    ) -> Result<InvokeTransactionResult, AccountError<A::SignError, <A::Provider as Provider>::Error>>
+    {
+        let execution: Execution<A> = self.into();
+        execution.send().await
+    }
+}
+
+impl<'f, A> From<&Deployment<'f, A>> for Execution<'f, A> {
+    fn from(value: &Deployment<'f, A>) -> Self {
+        let mut calldata = vec![
+            value.factory.class_hash,
+            value.salt,
+            if value.unique {
                 FieldElement::ONE
             } else {
                 FieldElement::ZERO
             },
-            constructor_calldata.len().into(),
+            value.constructor_calldata.len().into(),
         ];
-        constructor_calldata
-            .iter()
-            .for_each(|item| calldata.push(*item));
+        calldata.extend_from_slice(&value.constructor_calldata);
 
-        Execution::new(
+        let execution = Self::new(
             vec![Call {
-                to: self.udc_address,
+                to: value.factory.udc_address,
                 selector: SELECTOR_DEPLOYCONTRACT,
                 calldata,
             }],
-            &self.account,
-        )
+            &value.factory.account,
+        );
+
+        let execution = if let Some(nonce) = value.nonce {
+            execution.nonce(nonce)
+        } else {
+            execution
+        };
+
+        let execution = if let Some(max_fee) = value.max_fee {
+            execution.max_fee(max_fee)
+        } else {
+            execution
+        };
+
+        execution.fee_estimate_multiplier(value.fee_estimate_multiplier)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use starknet_accounts::{ExecutionEncoding, SingleOwnerAccount};
+    use starknet_core::chain_id;
+    use starknet_providers::SequencerGatewayProvider;
+    use starknet_signers::{LocalWallet, SigningKey};
+
+    use super::*;
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    fn test_deployed_address_unique() {
+        let factory = ContractFactory::new(
+            FieldElement::from_hex_be(
+                "0x2bfd9564754d9b4a326da62b2f22b8fea7bbeffd62da4fcaea986c323b7aeb",
+            )
+            .unwrap(),
+            SingleOwnerAccount::new(
+                SequencerGatewayProvider::starknet_alpha_goerli(),
+                LocalWallet::from_signing_key(SigningKey::from_random()),
+                FieldElement::from_hex_be(
+                    "0xb1461de04c6a1aa3375bdf9b7723a8779c082ffe21311d683a0b15c078b5dc",
+                )
+                .unwrap(),
+                chain_id::TESTNET,
+                ExecutionEncoding::Legacy,
+            ),
+        );
+
+        let unique_address = factory
+            .deploy(
+                vec![FieldElement::from_hex_be("0x1234").unwrap()],
+                FieldElement::from_hex_be("0x3456").unwrap(),
+                true,
+            )
+            .deployed_address();
+
+        let not_unique_address = factory
+            .deploy(
+                vec![FieldElement::from_hex_be("0x1234").unwrap()],
+                FieldElement::from_hex_be("0x3456").unwrap(),
+                false,
+            )
+            .deployed_address();
+
+        assert_eq!(
+            unique_address,
+            FieldElement::from_hex_be(
+                "0x36e05bcd41191387bc2f04ed9cad4776a75df3b748b0246a5d217a988474181"
+            )
+            .unwrap()
+        );
+
+        assert_eq!(
+            not_unique_address,
+            FieldElement::from_hex_be(
+                "0x3a320b6aa0b451b22fba90b5d75b943932649137c09a86a5cf4853031be70c1"
+            )
+            .unwrap()
+        );
     }
 }


### PR DESCRIPTION
Resolves #447.

Changes the return type of `deploy()` from `Execution` to a new type `Deployment`, which exposes a method `deployed_address()` for calculating the target contract address. This new type exposes an API similar to `Execution`, so it's still easy to use.

This is a breaking change but most consuming code shouldn't be affected given the how `Deployment` closely resembles `Execution`.