### PR TITLE
release: bump starknet to 0.6.0 (and deps)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,7 +1636,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "starknet"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde_json",
  "starknet-accounts",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "rand",
  "serde",
@@ -1687,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "base64 0.21.0",
  "criterion",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-macros"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "starknet-core",
  "syn 2.0.15",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -36,12 +36,12 @@ all-features = true
 [dependencies]
 starknet-ff = { version = "0.3.4", path = "./starknet-ff", default-features = false }
 starknet-crypto = { version = "0.6.0", path = "./starknet-crypto" }
-starknet-core = { version = "0.5.1", path = "./starknet-core", default-features = false }
-starknet-providers = { version = "0.5.0", path = "./starknet-providers" }
-starknet-contract = { version = "0.4.0", path = "./starknet-contract" }
-starknet-signers = { version = "0.3.0", path = "./starknet-signers" }
-starknet-accounts = { version = "0.4.0", path = "./starknet-accounts" }
-starknet-macros = { version = "0.1.2", path = "./starknet-macros" }
+starknet-core = { version = "0.6.0", path = "./starknet-core", default-features = false }
+starknet-providers = { version = "0.6.0", path = "./starknet-providers" }
+starknet-contract = { version = "0.5.0", path = "./starknet-contract" }
+starknet-signers = { version = "0.4.0", path = "./starknet-signers" }
+starknet-accounts = { version = "0.5.0", path = "./starknet-accounts" }
+starknet-macros = { version = "0.1.3", path = "./starknet-macros" }
 
 [dev-dependencies]
 serde_json = "1.0.74"

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-accounts"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,9 +14,9 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.5.1", path = "../starknet-core" }
-starknet-providers = { version = "0.5.0", path = "../starknet-providers" }
-starknet-signers = { version = "0.3.0", path = "../starknet-signers" }
+starknet-core = { version = "0.6.0", path = "../starknet-core" }
+starknet-providers = { version = "0.6.0", path = "../starknet-providers" }
+starknet-signers = { version = "0.4.0", path = "../starknet-signers" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 thiserror = "1.0.40"

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-contract"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,9 +14,9 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.5.1", path = "../starknet-core" }
-starknet-providers = { version = "0.5.0", path = "../starknet-providers" }
-starknet-accounts = { version = "0.4.0", path = "../starknet-accounts" }
+starknet-core = { version = "0.6.0", path = "../starknet-core" }
+starknet-providers = { version = "0.6.0", path = "../starknet-providers" }
+starknet-accounts = { version = "0.5.0", path = "../starknet-accounts" }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
 serde_with = "2.3.2"
@@ -24,6 +24,6 @@ thiserror = "1.0.40"
 
 [dev-dependencies]
 rand = { version = "0.8.5", features=["std_rng"] }
-starknet-signers = { version = "0.3.0", path = "../starknet-signers" }
+starknet-signers = { version = "0.4.0", path = "../starknet-signers" }
 tokio = { version = "1.27.0", features = ["full"] }
 url = "2.3.1"

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-core"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/starknet-macros/Cargo.toml
+++ b/starknet-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-macros"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -16,7 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 proc-macro = true
 
 [dependencies]
-starknet-core = { version = "0.5.1", path = "../starknet-core" }
+starknet-core = { version = "0.6.0", path = "../starknet-core" }
 syn = "2.0.15"
 
 [features]

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-providers"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.5.1", path = "../starknet-core" }
+starknet-core = { version = "0.6.0", path = "../starknet-core" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 ethereum-types = "0.14.1"

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-signers"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,7 +13,7 @@ Starknet signer implementations
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.5.1", path = "../starknet-core" }
+starknet-core = { version = "0.6.0", path = "../starknet-core" }
 starknet-crypto = { version = "0.6.0", path = "../starknet-crypto" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"


### PR DESCRIPTION
New versions:

- `starknet-core`: v0.6.0
- `starknet-signers`: v0.4.0
- `starknet-providers`: v0.6.0
- `starknet-accounts`: v0.5.0
- `starknet-contract`: v0.5.0
- `starknet-macros`: v0.1.3
- `starknet`: v0.6.0