### PR TITLE
feat: use query tx version for fee estimation

### DIFF
--- a/starknet-accounts/src/account/mod.rs
+++ b/starknet-accounts/src/account/mod.rs
@@ -28,16 +28,19 @@ pub trait Account: ExecutionEncoder + Sized {
     async fn sign_execution(
         &self,
         execution: &RawExecution,
+        query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError>;
 
     async fn sign_declaration(
         &self,
         declaration: &RawDeclaration,
+        query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError>;
 
     async fn sign_legacy_declaration(
         &self,
         legacy_declaration: &RawLegacyDeclaration,
+        query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError>;
 
     fn execute(&self, calls: Vec<Call>) -> Execution<Self> {
@@ -197,22 +200,27 @@ where
     async fn sign_execution(
         &self,
         execution: &RawExecution,
+        query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError> {
-        (*self).sign_execution(execution).await
+        (*self).sign_execution(execution, query_only).await
     }
 
     async fn sign_declaration(
         &self,
         declaration: &RawDeclaration,
+        query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError> {
-        (*self).sign_declaration(declaration).await
+        (*self).sign_declaration(declaration, query_only).await
     }
 
     async fn sign_legacy_declaration(
         &self,
         legacy_declaration: &RawLegacyDeclaration,
+        query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError> {
-        (*self).sign_legacy_declaration(legacy_declaration).await
+        (*self)
+            .sign_legacy_declaration(legacy_declaration, query_only)
+            .await
     }
 }
 
@@ -235,23 +243,28 @@ where
     async fn sign_execution(
         &self,
         execution: &RawExecution,
+        query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError> {
-        self.as_ref().sign_execution(execution).await
+        self.as_ref().sign_execution(execution, query_only).await
     }
 
     async fn sign_declaration(
         &self,
         declaration: &RawDeclaration,
+        query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError> {
-        self.as_ref().sign_declaration(declaration).await
+        self.as_ref()
+            .sign_declaration(declaration, query_only)
+            .await
     }
 
     async fn sign_legacy_declaration(
         &self,
         legacy_declaration: &RawLegacyDeclaration,
+        query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError> {
         self.as_ref()
-            .sign_legacy_declaration(legacy_declaration)
+            .sign_legacy_declaration(legacy_declaration, query_only)
             .await
     }
 }
@@ -275,23 +288,28 @@ where
     async fn sign_execution(
         &self,
         execution: &RawExecution,
+        query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError> {
-        self.as_ref().sign_execution(execution).await
+        self.as_ref().sign_execution(execution, query_only).await
     }
 
     async fn sign_declaration(
         &self,
         declaration: &RawDeclaration,
+        query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError> {
-        self.as_ref().sign_declaration(declaration).await
+        self.as_ref()
+            .sign_declaration(declaration, query_only)
+            .await
     }
 
     async fn sign_legacy_declaration(
         &self,
         legacy_declaration: &RawLegacyDeclaration,
+        query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError> {
         self.as_ref()
-            .sign_legacy_declaration(legacy_declaration)
+            .sign_legacy_declaration(legacy_declaration, query_only)
             .await
     }
 }

--- a/starknet-accounts/src/single_owner.rs
+++ b/starknet-accounts/src/single_owner.rs
@@ -97,8 +97,9 @@ where
     async fn sign_execution(
         &self,
         execution: &RawExecution,
+        query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError> {
-        let tx_hash = execution.transaction_hash(self.chain_id, self.address, self);
+        let tx_hash = execution.transaction_hash(self.chain_id, self.address, query_only, self);
         let signature = self
             .signer
             .sign_hash(&tx_hash)
@@ -111,8 +112,9 @@ where
     async fn sign_declaration(
         &self,
         declaration: &RawDeclaration,
+        query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError> {
-        let tx_hash = declaration.transaction_hash(self.chain_id, self.address);
+        let tx_hash = declaration.transaction_hash(self.chain_id, self.address, query_only);
         let signature = self
             .signer
             .sign_hash(&tx_hash)
@@ -125,9 +127,10 @@ where
     async fn sign_legacy_declaration(
         &self,
         legacy_declaration: &RawLegacyDeclaration,
+        query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError> {
         let tx_hash = legacy_declaration
-            .transaction_hash(self.chain_id, self.address)
+            .transaction_hash(self.chain_id, self.address, query_only)
             .map_err(SignError::ClassHash)?;
         let signature = self
             .signer

--- a/starknet-contract/tests/contract_deployment.rs
+++ b/starknet-contract/tests/contract_deployment.rs
@@ -21,7 +21,7 @@ async fn can_deploy_contract_to_alpha_goerli() {
         .unwrap(),
     ));
     let address = FieldElement::from_hex_be(
-        "02da37a17affbd2df4ede7120dae305ec36dfe94ec96a8c3f49bbf59f4e9a9fa",
+        "04284d0741ee00d8e4d6a02d21c0be58665f0e6e187cf48c509b1ac39cdeca65",
     )
     .unwrap();
     let mut account = SingleOwnerAccount::new(

--- a/starknet-providers/src/sequencer/models/conversions.rs
+++ b/starknet-providers/src/sequencer/models/conversions.rs
@@ -767,6 +767,7 @@ impl From<core::BroadcastedInvokeTransaction> for InvokeFunctionTransactionReque
             signature: value.signature,
             max_fee: value.max_fee,
             nonce: value.nonce,
+            is_query: value.is_query,
         }
     }
 }
@@ -790,6 +791,7 @@ impl From<core::BroadcastedDeclareTransactionV1> for DeclareV1TransactionRequest
             max_fee: value.max_fee,
             signature: value.signature,
             nonce: value.nonce,
+            is_query: value.is_query,
         }
     }
 }
@@ -808,6 +810,7 @@ impl TryFrom<core::BroadcastedDeclareTransactionV2> for DeclareV2TransactionRequ
             max_fee: value.max_fee,
             signature: value.signature,
             nonce: value.nonce,
+            is_query: value.is_query,
         })
     }
 }
@@ -821,6 +824,7 @@ impl From<core::BroadcastedDeployAccountTransaction> for DeployAccountTransactio
             max_fee: value.max_fee,
             signature: value.signature,
             nonce: value.nonce,
+            is_query: value.is_query,
         }
     }
 }

--- a/starknet-providers/src/sequencer/models/transaction_request.rs
+++ b/starknet-providers/src/sequencer/models/transaction_request.rs
@@ -11,6 +11,22 @@ use super::{
     L1Address,
 };
 
+/// 2 ^ 128 + 1
+const QUERY_VERSION_ONE: FieldElement = FieldElement::from_mont([
+    18446744073700081633,
+    17407,
+    18446744073709551584,
+    576460752142433776,
+]);
+
+/// 2 ^ 128 + 2
+const QUERY_VERSION_TWO: FieldElement = FieldElement::from_mont([
+    18446744073700081601,
+    17407,
+    18446744073709551584,
+    576460752142433232,
+]);
+
 #[serde_as]
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
@@ -95,6 +111,7 @@ pub struct DeclareV1Transaction {
     pub signature: Vec<FieldElement>,
     /// A sequential integer used to distinguish between transactions and order them.
     pub nonce: FieldElement,
+    pub is_query: bool,
 }
 
 #[derive(Debug)]
@@ -113,6 +130,7 @@ pub struct DeclareV2Transaction {
     pub signature: Vec<FieldElement>,
     /// A sequential integer used to distinguish between transactions and order them.
     pub nonce: FieldElement,
+    pub is_query: bool,
 }
 
 #[derive(Debug)]
@@ -122,6 +140,7 @@ pub struct InvokeFunctionTransaction {
     pub signature: Vec<FieldElement>,
     pub max_fee: FieldElement,
     pub nonce: FieldElement,
+    pub is_query: bool,
 }
 
 #[derive(Debug)]
@@ -135,6 +154,7 @@ pub struct DeployAccountTransaction {
     pub signature: Vec<FieldElement>,
     // The nonce of the transaction.
     pub nonce: FieldElement,
+    pub is_query: bool,
 }
 
 impl Serialize for DeclareV1Transaction {
@@ -158,7 +178,11 @@ impl Serialize for DeclareV1Transaction {
         }
 
         let versioned = Versioned {
-            version: FieldElement::ONE,
+            version: if self.is_query {
+                QUERY_VERSION_ONE
+            } else {
+                FieldElement::ONE
+            },
             contract_class: &self.contract_class,
             sender_address: &self.sender_address,
             max_fee: &self.max_fee,
@@ -193,7 +217,11 @@ impl Serialize for DeclareV2Transaction {
         }
 
         let versioned = Versioned {
-            version: FieldElement::TWO,
+            version: if self.is_query {
+                QUERY_VERSION_TWO
+            } else {
+                FieldElement::TWO
+            },
             contract_class: &self.contract_class,
             compiled_class_hash: &self.compiled_class_hash,
             sender_address: &self.sender_address,
@@ -227,7 +255,11 @@ impl Serialize for InvokeFunctionTransaction {
         }
 
         let versioned = Versioned {
-            version: FieldElement::ONE,
+            version: if self.is_query {
+                QUERY_VERSION_ONE
+            } else {
+                FieldElement::ONE
+            },
             sender_address: &self.sender_address,
             calldata: &self.calldata,
             signature: &self.signature,
@@ -262,7 +294,11 @@ impl Serialize for DeployAccountTransaction {
         }
 
         let versioned = Versioned {
-            version: FieldElement::ONE,
+            version: if self.is_query {
+                QUERY_VERSION_ONE
+            } else {
+                FieldElement::ONE
+            },
             class_hash: &self.class_hash,
             contract_address_salt: &self.contract_address_salt,
             constructor_calldata: &self.constructor_calldata,

--- a/starknet-providers/tests/sequencer_goerli.rs
+++ b/starknet-providers/tests/sequencer_goerli.rs
@@ -129,6 +129,7 @@ async fn sequencer_goerli_can_simulate_transaction() {
                     "0x0000000000000000000000000000000000000000000000000000000000000000",
                 )
                 .unwrap(),
+                is_query: false,
             }),
             BlockId::Latest,
             false,
@@ -204,6 +205,7 @@ async fn sequencer_goerli_can_bulk_estimate_fee() {
                     ],
                     max_fee: felt_dec("0"),
                     nonce: felt_dec("0"),
+                    is_query: false,
                 }),
                 AccountTransaction::InvokeFunction(InvokeFunctionTransactionRequest {
                     sender_address: felt_hex(
@@ -236,6 +238,7 @@ async fn sequencer_goerli_can_bulk_estimate_fee() {
                     ],
                     max_fee: felt_dec("0"),
                     nonce: felt_dec("1"),
+                    is_query: false,
                 }),
             ],
             BlockId::Latest,


### PR DESCRIPTION
Changes to add `2 ^ 128` to `version` for sending fee estimation requests.