### PR TITLE
feat: generate models for trace methods

### DIFF
--- a/starknet-core/src/types/requests.rs
+++ b/starknet-core/src/types/requests.rs
@@ -12,5 +12,7 @@ pub use super::codegen::{
     GetStateUpdateRequestRef, GetStorageAtRequest, GetStorageAtRequestRef,
     GetTransactionByBlockIdAndIndexRequest, GetTransactionByBlockIdAndIndexRequestRef,
     GetTransactionByHashRequest, GetTransactionByHashRequestRef, GetTransactionReceiptRequest,
-    GetTransactionReceiptRequestRef, PendingTransactionsRequest, SyncingRequest,
+    GetTransactionReceiptRequestRef, PendingTransactionsRequest, SimulateTransactionsRequest,
+    SimulateTransactionsRequestRef, SyncingRequest, TraceBlockTransactionsRequest,
+    TraceBlockTransactionsRequestRef, TraceTransactionRequest, TraceTransactionRequestRef,
 };

--- a/starknet-core/src/types/serde_impls.rs
+++ b/starknet-core/src/types/serde_impls.rs
@@ -207,6 +207,26 @@ mod enum_ser_impls {
             }
         }
     }
+
+    impl Serialize for TransactionTrace {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            match self {
+                Self::Invoke(variant) => variant.serialize(serializer),
+                Self::DeployAccount(variant) => variant.serialize(serializer),
+                Self::L1Handler(variant) => variant.serialize(serializer),
+                Self::Declare(variant) => variant.serialize(serializer),
+            }
+        }
+    }
+
+    impl Serialize for ExecuteInvocation {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            match self {
+                Self::Success(variant) => variant.serialize(serializer),
+                Self::Reverted(variant) => variant.serialize(serializer),
+            }
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Regenerates core types from `starknet-jsonrpc-codegen` using the latest version which supports trace methods and schemas.