### PR TITLE
feat: add contract error data into the rpc error message

### DIFF
--- a/starknet-providers/src/jsonrpc/transports/http.rs
+++ b/starknet-providers/src/jsonrpc/transports/http.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use log::trace;
 use reqwest::{Client, Url};
 use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Value;
 
 use crate::jsonrpc::{transports::JsonRpcTransport, JsonRpcMethod, JsonRpcResponse};
 
@@ -75,7 +76,26 @@ impl JsonRpcTransport for HttpTransport {
         let response_body = response.text().await.map_err(Self::Error::Reqwest)?;
         trace!("Response from JSON-RPC: {}", response_body);
 
-        let parsed_response = serde_json::from_str(&response_body).map_err(Self::Error::Json)?;
+        let mut parsed_response =
+            serde_json::from_str(&response_body).map_err(Self::Error::Json)?;
+
+        if let JsonRpcResponse::Error { ref mut error, .. } = parsed_response {
+            if error.code == 40 {
+                trace!("Extracting `data` from ContractError (40)");
+                let json_raw: Value =
+                    serde_json::from_str(&response_body).map_err(Self::Error::Json)?;
+                // "error" key is safe to unwrap here as we parsed the response correctly with
+                // the field "error".
+                if let Some(data) = json_raw.get("error").unwrap().get("data") {
+                    if let Some(revert_error) = data.get("revert_error") {
+                        error.message += &format!(
+                            "\nrevert_error: {}",
+                            revert_error.as_str().unwrap_or("Not available")
+                        );
+                    }
+                }
+            }
+        }
 
         Ok(parsed_response)
     }


### PR DESCRIPTION
Currently, when the JSON RPC error is `ContractError(40)`, we loose the `data` field that is only present for the `CONTRACT_ERROR` error type from the [spec](https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json#L3376C14-L3376C28).

This PR aims at adding the `revert_error` that is present in `data` to the error message.
I've tried to modified the structure, but due to the current state of the spec, @xJonathanLEI do you think that is enough, or we should prepare a struct that can be forward compatible with other possible error coming in the future?

In anyway, it's useful to have a more explicit error message in the case of contract error. We may add a `revert_reason` field?

Any comment feedback very welcomed!