### PR TITLE
feat: erase implementation-specific provider error

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Examples can be found in the [examples folder](./examples):
 
 9. [Parsing a JSON-RPC request on the server side](./examples/parse_jsonrpc_request.rs)
 
+10. [Inspecting a erased provider-specific error type](./examples/downcast_provider_error.rs)
+
 ## License
 
 Licensed under either of

--- a/examples/downcast_provider_error.rs
+++ b/examples/downcast_provider_error.rs
@@ -1,0 +1,26 @@
+use starknet_providers::{
+    jsonrpc::{HttpTransport, HttpTransportError, JsonRpcClient, JsonRpcClientError},
+    Provider, ProviderError,
+};
+use url::Url;
+
+#[tokio::main]
+async fn main() {
+    let rpc_client =
+        JsonRpcClient::new(HttpTransport::new(Url::parse("https://fake.url/").unwrap()));
+
+    let error = match rpc_client.block_number().await.unwrap_err() {
+        ProviderError::Other(inner) => inner,
+        _ => panic!("unexpected error variant"),
+    };
+
+    // The implementation-specific error type is erased to make the `ProviderError` type easier to
+    // work with. Here, we showcase how to recover the inner type.
+    let impl_specific_error: &JsonRpcClientError<HttpTransportError> =
+        match error.as_any().downcast_ref() {
+            Some(inner) => inner,
+            None => panic!("unexpected downcast failure"),
+        };
+
+    dbg!(impl_specific_error);
+}

--- a/starknet-accounts/src/account/declaration.rs
+++ b/starknet-accounts/src/account/declaration.rs
@@ -99,9 +99,7 @@ impl<'a, A> Declaration<'a, A>
 where
     A: ConnectedAccount + Sync,
 {
-    pub async fn estimate_fee(
-        &self,
-    ) -> Result<FeeEstimate, AccountError<A::SignError, <A::Provider as Provider>::Error>> {
+    pub async fn estimate_fee(&self) -> Result<FeeEstimate, AccountError<A::SignError>> {
         // Resolves nonce
         let nonce = match self.nonce {
             Some(value) => value,
@@ -119,8 +117,7 @@ where
         &self,
         skip_validate: bool,
         skip_fee_charge: bool,
-    ) -> Result<SimulatedTransaction, AccountError<A::SignError, <A::Provider as Provider>::Error>>
-    {
+    ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
         // Resolves nonce
         let nonce = match self.nonce {
             Some(value) => value,
@@ -135,21 +132,11 @@ where
             .await
     }
 
-    pub async fn send(
-        &self,
-    ) -> Result<
-        DeclareTransactionResult,
-        AccountError<A::SignError, <A::Provider as Provider>::Error>,
-    > {
+    pub async fn send(&self) -> Result<DeclareTransactionResult, AccountError<A::SignError>> {
         self.prepare().await?.send().await
     }
 
-    async fn prepare(
-        &self,
-    ) -> Result<
-        PreparedDeclaration<'a, A>,
-        AccountError<A::SignError, <A::Provider as Provider>::Error>,
-    > {
+    async fn prepare(&self) -> Result<PreparedDeclaration<'a, A>, AccountError<A::SignError>> {
         // Resolves nonce
         let nonce = match self.nonce {
             Some(value) => value,
@@ -183,7 +170,7 @@ where
     async fn estimate_fee_with_nonce(
         &self,
         nonce: FieldElement,
-    ) -> Result<FeeEstimate, AccountError<A::SignError, <A::Provider as Provider>::Error>> {
+    ) -> Result<FeeEstimate, AccountError<A::SignError>> {
         let prepared = PreparedDeclaration {
             account: self.account,
             inner: RawDeclaration {
@@ -210,8 +197,7 @@ where
         nonce: FieldElement,
         skip_validate: bool,
         skip_fee_charge: bool,
-    ) -> Result<SimulatedTransaction, AccountError<A::SignError, <A::Provider as Provider>::Error>>
-    {
+    ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
         let prepared = PreparedDeclaration {
             account: self.account,
             inner: RawDeclaration {
@@ -298,9 +284,7 @@ impl<'a, A> LegacyDeclaration<'a, A>
 where
     A: ConnectedAccount + Sync,
 {
-    pub async fn estimate_fee(
-        &self,
-    ) -> Result<FeeEstimate, AccountError<A::SignError, <A::Provider as Provider>::Error>> {
+    pub async fn estimate_fee(&self) -> Result<FeeEstimate, AccountError<A::SignError>> {
         // Resolves nonce
         let nonce = match self.nonce {
             Some(value) => value,
@@ -318,8 +302,7 @@ where
         &self,
         skip_validate: bool,
         skip_fee_charge: bool,
-    ) -> Result<SimulatedTransaction, AccountError<A::SignError, <A::Provider as Provider>::Error>>
-    {
+    ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
         // Resolves nonce
         let nonce = match self.nonce {
             Some(value) => value,
@@ -334,21 +317,13 @@ where
             .await
     }
 
-    pub async fn send(
-        &self,
-    ) -> Result<
-        DeclareTransactionResult,
-        AccountError<A::SignError, <A::Provider as Provider>::Error>,
-    > {
+    pub async fn send(&self) -> Result<DeclareTransactionResult, AccountError<A::SignError>> {
         self.prepare().await?.send().await
     }
 
     async fn prepare(
         &self,
-    ) -> Result<
-        PreparedLegacyDeclaration<'a, A>,
-        AccountError<A::SignError, <A::Provider as Provider>::Error>,
-    > {
+    ) -> Result<PreparedLegacyDeclaration<'a, A>, AccountError<A::SignError>> {
         // Resolves nonce
         let nonce = match self.nonce {
             Some(value) => value,
@@ -381,7 +356,7 @@ where
     async fn estimate_fee_with_nonce(
         &self,
         nonce: FieldElement,
-    ) -> Result<FeeEstimate, AccountError<A::SignError, <A::Provider as Provider>::Error>> {
+    ) -> Result<FeeEstimate, AccountError<A::SignError>> {
         let prepared = PreparedLegacyDeclaration {
             account: self.account,
             inner: RawLegacyDeclaration {
@@ -407,8 +382,7 @@ where
         nonce: FieldElement,
         skip_validate: bool,
         skip_fee_charge: bool,
-    ) -> Result<SimulatedTransaction, AccountError<A::SignError, <A::Provider as Provider>::Error>>
-    {
+    ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
         let prepared = PreparedLegacyDeclaration {
             account: self.account,
             inner: RawLegacyDeclaration {
@@ -505,12 +479,7 @@ impl<'a, A> PreparedDeclaration<'a, A>
 where
     A: ConnectedAccount,
 {
-    pub async fn send(
-        &self,
-    ) -> Result<
-        DeclareTransactionResult,
-        AccountError<A::SignError, <A::Provider as Provider>::Error>,
-    > {
+    pub async fn send(&self) -> Result<DeclareTransactionResult, AccountError<A::SignError>> {
         let tx_request = self.get_declare_request(false).await?;
         self.account
             .provider()
@@ -522,10 +491,7 @@ where
     pub async fn get_declare_request(
         &self,
         query_only: bool,
-    ) -> Result<
-        BroadcastedDeclareTransactionV2,
-        AccountError<A::SignError, <A::Provider as Provider>::Error>,
-    > {
+    ) -> Result<BroadcastedDeclareTransactionV2, AccountError<A::SignError>> {
         let signature = self
             .account
             .sign_declaration(&self.inner, query_only)
@@ -563,12 +529,7 @@ impl<'a, A> PreparedLegacyDeclaration<'a, A>
 where
     A: ConnectedAccount,
 {
-    pub async fn send(
-        &self,
-    ) -> Result<
-        DeclareTransactionResult,
-        AccountError<A::SignError, <A::Provider as Provider>::Error>,
-    > {
+    pub async fn send(&self) -> Result<DeclareTransactionResult, AccountError<A::SignError>> {
         let tx_request = self.get_declare_request(false).await?;
         self.account
             .provider()
@@ -580,10 +541,7 @@ where
     pub async fn get_declare_request(
         &self,
         query_only: bool,
-    ) -> Result<
-        BroadcastedDeclareTransactionV1,
-        AccountError<A::SignError, <A::Provider as Provider>::Error>,
-    > {
+    ) -> Result<BroadcastedDeclareTransactionV1, AccountError<A::SignError>> {
         let signature = self
             .account
             .sign_legacy_declaration(&self.inner, query_only)

--- a/starknet-accounts/src/account/execution.rs
+++ b/starknet-accounts/src/account/execution.rs
@@ -82,9 +82,7 @@ impl<'a, A> Execution<'a, A>
 where
     A: ConnectedAccount + Sync,
 {
-    pub async fn estimate_fee(
-        &self,
-    ) -> Result<FeeEstimate, AccountError<A::SignError, <A::Provider as Provider>::Error>> {
+    pub async fn estimate_fee(&self) -> Result<FeeEstimate, AccountError<A::SignError>> {
         // Resolves nonce
         let nonce = match self.nonce {
             Some(value) => value,
@@ -102,8 +100,7 @@ where
         &self,
         skip_validate: bool,
         skip_fee_charge: bool,
-    ) -> Result<SimulatedTransaction, AccountError<A::SignError, <A::Provider as Provider>::Error>>
-    {
+    ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
         // Resolves nonce
         let nonce = match self.nonce {
             Some(value) => value,
@@ -118,19 +115,11 @@ where
             .await
     }
 
-    pub async fn send(
-        &self,
-    ) -> Result<InvokeTransactionResult, AccountError<A::SignError, <A::Provider as Provider>::Error>>
-    {
+    pub async fn send(&self) -> Result<InvokeTransactionResult, AccountError<A::SignError>> {
         self.prepare().await?.send().await
     }
 
-    async fn prepare(
-        &self,
-    ) -> Result<
-        PreparedExecution<'a, A>,
-        AccountError<A::SignError, <A::Provider as Provider>::Error>,
-    > {
+    async fn prepare(&self) -> Result<PreparedExecution<'a, A>, AccountError<A::SignError>> {
         // Resolves nonce
         let nonce = match self.nonce {
             Some(value) => value,
@@ -163,7 +152,7 @@ where
     async fn estimate_fee_with_nonce(
         &self,
         nonce: FieldElement,
-    ) -> Result<FeeEstimate, AccountError<A::SignError, <A::Provider as Provider>::Error>> {
+    ) -> Result<FeeEstimate, AccountError<A::SignError>> {
         let prepared = PreparedExecution {
             account: self.account,
             inner: RawExecution {
@@ -192,8 +181,7 @@ where
         nonce: FieldElement,
         skip_validate: bool,
         skip_fee_charge: bool,
-    ) -> Result<SimulatedTransaction, AccountError<A::SignError, <A::Provider as Provider>::Error>>
-    {
+    ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
         let prepared = PreparedExecution {
             account: self.account,
             inner: RawExecution {
@@ -276,10 +264,7 @@ impl<'a, A> PreparedExecution<'a, A>
 where
     A: ConnectedAccount,
 {
-    pub async fn send(
-        &self,
-    ) -> Result<InvokeTransactionResult, AccountError<A::SignError, <A::Provider as Provider>::Error>>
-    {
+    pub async fn send(&self) -> Result<InvokeTransactionResult, AccountError<A::SignError>> {
         let tx_request = self
             .get_invoke_request(false)
             .await

--- a/starknet-accounts/src/account/mod.rs
+++ b/starknet-accounts/src/account/mod.rs
@@ -80,9 +80,7 @@ pub trait ConnectedAccount: Account {
         BlockId::Tag(BlockTag::Latest)
     }
 
-    async fn get_nonce(
-        &self,
-    ) -> Result<FieldElement, ProviderError<<Self::Provider as Provider>::Error>> {
+    async fn get_nonce(&self) -> Result<FieldElement, ProviderError> {
         self.provider()
             .get_nonce(self.block_id(), self.address())
             .await
@@ -170,11 +168,11 @@ pub struct PreparedLegacyDeclaration<'a, A> {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum AccountError<S, P> {
+pub enum AccountError<S> {
     #[error(transparent)]
     Signing(S),
     #[error(transparent)]
-    Provider(ProviderError<P>),
+    Provider(ProviderError),
     #[error(transparent)]
     ClassHashCalculation(ComputeClassHashError),
     #[error(transparent)]

--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -100,11 +100,11 @@ pub struct PreparedAccountDeployment<'f, F> {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum AccountFactoryError<S, P> {
+pub enum AccountFactoryError<S> {
     #[error(transparent)]
     Signing(S),
     #[error(transparent)]
-    Provider(ProviderError<P>),
+    Provider(ProviderError),
 }
 
 impl<'f, F> AccountDeployment<'f, F> {
@@ -170,9 +170,7 @@ where
         )
     }
 
-    pub async fn fetch_nonce(
-        &self,
-    ) -> Result<FieldElement, ProviderError<<F::Provider as Provider>::Error>> {
+    pub async fn fetch_nonce(&self) -> Result<FieldElement, ProviderError> {
         match self
             .factory
             .provider()
@@ -188,10 +186,7 @@ where
         }
     }
 
-    pub async fn estimate_fee(
-        &self,
-    ) -> Result<FeeEstimate, AccountFactoryError<F::SignError, <F::Provider as Provider>::Error>>
-    {
+    pub async fn estimate_fee(&self) -> Result<FeeEstimate, AccountFactoryError<F::SignError>> {
         // Resolves nonce
         let nonce = match self.nonce {
             Some(value) => value,
@@ -208,10 +203,7 @@ where
         &self,
         skip_validate: bool,
         skip_fee_charge: bool,
-    ) -> Result<
-        SimulatedTransaction,
-        AccountFactoryError<F::SignError, <F::Provider as Provider>::Error>,
-    > {
+    ) -> Result<SimulatedTransaction, AccountFactoryError<F::SignError>> {
         // Resolves nonce
         let nonce = match self.nonce {
             Some(value) => value,
@@ -227,19 +219,13 @@ where
 
     pub async fn send(
         &self,
-    ) -> Result<
-        DeployAccountTransactionResult,
-        AccountFactoryError<F::SignError, <F::Provider as Provider>::Error>,
-    > {
+    ) -> Result<DeployAccountTransactionResult, AccountFactoryError<F::SignError>> {
         self.prepare().await?.send().await
     }
 
     async fn prepare(
         &self,
-    ) -> Result<
-        PreparedAccountDeployment<'f, F>,
-        AccountFactoryError<F::SignError, <F::Provider as Provider>::Error>,
-    > {
+    ) -> Result<PreparedAccountDeployment<'f, F>, AccountFactoryError<F::SignError>> {
         // Resolves nonce
         let nonce = match self.nonce {
             Some(value) => value,
@@ -271,8 +257,7 @@ where
     async fn estimate_fee_with_nonce(
         &self,
         nonce: FieldElement,
-    ) -> Result<FeeEstimate, AccountFactoryError<F::SignError, <F::Provider as Provider>::Error>>
-    {
+    ) -> Result<FeeEstimate, AccountFactoryError<F::SignError>> {
         let prepared = PreparedAccountDeployment {
             factory: self.factory,
             inner: RawAccountDeployment {
@@ -301,10 +286,7 @@ where
         nonce: FieldElement,
         skip_validate: bool,
         skip_fee_charge: bool,
-    ) -> Result<
-        SimulatedTransaction,
-        AccountFactoryError<F::SignError, <F::Provider as Provider>::Error>,
-    > {
+    ) -> Result<SimulatedTransaction, AccountFactoryError<F::SignError>> {
         let prepared = PreparedAccountDeployment {
             factory: self.factory,
             inner: RawAccountDeployment {
@@ -379,10 +361,7 @@ where
 
     pub async fn send(
         &self,
-    ) -> Result<
-        DeployAccountTransactionResult,
-        AccountFactoryError<F::SignError, <F::Provider as Provider>::Error>,
-    > {
+    ) -> Result<DeployAccountTransactionResult, AccountFactoryError<F::SignError>> {
         let tx_request = self
             .get_deploy_request()
             .await

--- a/starknet-contract/src/factory.rs
+++ b/starknet-contract/src/factory.rs
@@ -3,7 +3,6 @@ use starknet_core::{
     types::{FeeEstimate, FieldElement, InvokeTransactionResult, SimulatedTransaction},
     utils::{get_udc_deployed_address, UdcUniqueSettings, UdcUniqueness},
 };
-use starknet_providers::Provider;
 
 /// The default UDC address: 0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf.
 const UDC_ADDRESS: FieldElement = FieldElement::from_mont([
@@ -123,9 +122,7 @@ impl<'f, A> Deployment<'f, A>
 where
     A: ConnectedAccount + Sync,
 {
-    pub async fn estimate_fee(
-        &self,
-    ) -> Result<FeeEstimate, AccountError<A::SignError, <A::Provider as Provider>::Error>> {
+    pub async fn estimate_fee(&self) -> Result<FeeEstimate, AccountError<A::SignError>> {
         let execution: Execution<A> = self.into();
         execution.estimate_fee().await
     }
@@ -134,16 +131,12 @@ where
         &self,
         skip_validate: bool,
         skip_fee_charge: bool,
-    ) -> Result<SimulatedTransaction, AccountError<A::SignError, <A::Provider as Provider>::Error>>
-    {
+    ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
         let execution: Execution<A> = self.into();
         execution.simulate(skip_validate, skip_fee_charge).await
     }
 
-    pub async fn send(
-        &self,
-    ) -> Result<InvokeTransactionResult, AccountError<A::SignError, <A::Provider as Provider>::Error>>
-    {
+    pub async fn send(&self) -> Result<InvokeTransactionResult, AccountError<A::SignError>> {
         let execution: Execution<A> = self.into();
         execution.send().await
     }

--- a/starknet-providers/src/any.rs
+++ b/starknet-providers/src/any.rs
@@ -20,78 +20,71 @@ use crate::{
 ///
 /// A recommended pattern is to make your business logic code (e.g. functions) generic over the
 /// [Provider] trait, while using this [AnyProvider] type for bootstrapping your application.
+///
+/// NOTE: This type was introduced when [Provider] was not Box-able. It should be reviewed whether
+///       it's still needed anymore.
 #[derive(Debug)]
 pub enum AnyProvider {
     JsonRpcHttp(JsonRpcClient<HttpTransport>),
     SequencerGateway(SequencerGatewayProvider),
 }
 
-#[derive(Debug, thiserror::Error)]
-#[error(transparent)]
-pub enum AnyProviderError {
-    JsonRpcHttp(<JsonRpcClient<HttpTransport> as Provider>::Error),
-    SequencerGateway(<SequencerGatewayProvider as Provider>::Error),
-}
-
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Provider for AnyProvider {
-    type Error = AnyProviderError;
-
     async fn get_block_with_tx_hashes<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithTxHashes, ProviderError<Self::Error>>
+    ) -> Result<MaybePendingBlockWithTxHashes, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(
+            Self::JsonRpcHttp(inner) => {
                 <JsonRpcClient<HttpTransport> as Provider>::get_block_with_tx_hashes(
                     inner, block_id,
                 )
-                .await?,
-            ),
-            Self::SequencerGateway(inner) => Ok(
+                .await
+            }
+            Self::SequencerGateway(inner) => {
                 <SequencerGatewayProvider as Provider>::get_block_with_tx_hashes(inner, block_id)
-                    .await?,
-            ),
+                    .await
+            }
         }
     }
 
     async fn get_block_with_txs<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithTxs, ProviderError<Self::Error>>
+    ) -> Result<MaybePendingBlockWithTxs, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(
+            Self::JsonRpcHttp(inner) => {
                 <JsonRpcClient<HttpTransport> as Provider>::get_block_with_txs(inner, block_id)
-                    .await?,
-            ),
-            Self::SequencerGateway(inner) => Ok(
-                <SequencerGatewayProvider as Provider>::get_block_with_txs(inner, block_id).await?,
-            ),
+                    .await
+            }
+            Self::SequencerGateway(inner) => {
+                <SequencerGatewayProvider as Provider>::get_block_with_txs(inner, block_id).await
+            }
         }
     }
 
     async fn get_state_update<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingStateUpdate, ProviderError<Self::Error>>
+    ) -> Result<MaybePendingStateUpdate, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(
-                <JsonRpcClient<HttpTransport> as Provider>::get_state_update(inner, block_id)
-                    .await?,
-            ),
-            Self::SequencerGateway(inner) => Ok(
-                <SequencerGatewayProvider as Provider>::get_state_update(inner, block_id).await?,
-            ),
+            Self::JsonRpcHttp(inner) => {
+                <JsonRpcClient<HttpTransport> as Provider>::get_state_update(inner, block_id).await
+            }
+            Self::SequencerGateway(inner) => {
+                <SequencerGatewayProvider as Provider>::get_state_update(inner, block_id).await
+            }
         }
     }
 
@@ -100,7 +93,7 @@ impl Provider for AnyProvider {
         contract_address: A,
         key: K,
         block_id: B,
-    ) -> Result<FieldElement, ProviderError<Self::Error>>
+    ) -> Result<FieldElement, ProviderError>
     where
         A: AsRef<FieldElement> + Send + Sync,
         K: AsRef<FieldElement> + Send + Sync,
@@ -108,22 +101,22 @@ impl Provider for AnyProvider {
     {
         match self {
             Self::JsonRpcHttp(inner) => {
-                Ok(<JsonRpcClient<HttpTransport> as Provider>::get_storage_at(
+                <JsonRpcClient<HttpTransport> as Provider>::get_storage_at(
                     inner,
                     contract_address,
                     key,
                     block_id,
                 )
-                .await?)
+                .await
             }
             Self::SequencerGateway(inner) => {
-                Ok(<SequencerGatewayProvider as Provider>::get_storage_at(
+                <SequencerGatewayProvider as Provider>::get_storage_at(
                     inner,
                     contract_address,
                     key,
                     block_id,
                 )
-                .await?)
+                .await
             }
         }
     }
@@ -131,25 +124,25 @@ impl Provider for AnyProvider {
     async fn get_transaction_by_hash<H>(
         &self,
         transaction_hash: H,
-    ) -> Result<Transaction, ProviderError<Self::Error>>
+    ) -> Result<Transaction, ProviderError>
     where
         H: AsRef<FieldElement> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(
+            Self::JsonRpcHttp(inner) => {
                 <JsonRpcClient<HttpTransport> as Provider>::get_transaction_by_hash(
                     inner,
                     transaction_hash,
                 )
-                .await?,
-            ),
-            Self::SequencerGateway(inner) => Ok(
+                .await
+            }
+            Self::SequencerGateway(inner) => {
                 <SequencerGatewayProvider as Provider>::get_transaction_by_hash(
                     inner,
                     transaction_hash,
                 )
-                .await?,
-            ),
+                .await
+            }
         }
     }
 
@@ -157,48 +150,48 @@ impl Provider for AnyProvider {
         &self,
         block_id: B,
         index: u64,
-    ) -> Result<Transaction, ProviderError<Self::Error>>
+    ) -> Result<Transaction, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(
+            Self::JsonRpcHttp(inner) => {
                 <JsonRpcClient<HttpTransport> as Provider>::get_transaction_by_block_id_and_index(
                     inner, block_id, index,
                 )
-                .await?,
-            ),
-            Self::SequencerGateway(inner) => Ok(
+                .await
+            }
+            Self::SequencerGateway(inner) => {
                 <SequencerGatewayProvider as Provider>::get_transaction_by_block_id_and_index(
                     inner, block_id, index,
                 )
-                .await?,
-            ),
+                .await
+            }
         }
     }
 
     async fn get_transaction_receipt<H>(
         &self,
         transaction_hash: H,
-    ) -> Result<MaybePendingTransactionReceipt, ProviderError<Self::Error>>
+    ) -> Result<MaybePendingTransactionReceipt, ProviderError>
     where
         H: AsRef<FieldElement> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(
+            Self::JsonRpcHttp(inner) => {
                 <JsonRpcClient<HttpTransport> as Provider>::get_transaction_receipt(
                     inner,
                     transaction_hash,
                 )
-                .await?,
-            ),
-            Self::SequencerGateway(inner) => Ok(
+                .await
+            }
+            Self::SequencerGateway(inner) => {
                 <SequencerGatewayProvider as Provider>::get_transaction_receipt(
                     inner,
                     transaction_hash,
                 )
-                .await?,
-            ),
+                .await
+            }
         }
     }
 
@@ -206,20 +199,19 @@ impl Provider for AnyProvider {
         &self,
         block_id: B,
         class_hash: H,
-    ) -> Result<ContractClass, ProviderError<Self::Error>>
+    ) -> Result<ContractClass, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
         H: AsRef<FieldElement> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(<JsonRpcClient<HttpTransport> as Provider>::get_class(
-                inner, block_id, class_hash,
-            )
-            .await?),
-            Self::SequencerGateway(inner) => Ok(<SequencerGatewayProvider as Provider>::get_class(
-                inner, block_id, class_hash,
-            )
-            .await?),
+            Self::JsonRpcHttp(inner) => {
+                <JsonRpcClient<HttpTransport> as Provider>::get_class(inner, block_id, class_hash)
+                    .await
+            }
+            Self::SequencerGateway(inner) => {
+                <SequencerGatewayProvider as Provider>::get_class(inner, block_id, class_hash).await
+            }
         }
     }
 
@@ -227,27 +219,27 @@ impl Provider for AnyProvider {
         &self,
         block_id: B,
         contract_address: A,
-    ) -> Result<FieldElement, ProviderError<Self::Error>>
+    ) -> Result<FieldElement, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
         A: AsRef<FieldElement> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(
+            Self::JsonRpcHttp(inner) => {
                 <JsonRpcClient<HttpTransport> as Provider>::get_class_hash_at(
                     inner,
                     block_id,
                     contract_address,
                 )
-                .await?,
-            ),
+                .await
+            }
             Self::SequencerGateway(inner) => {
-                Ok(<SequencerGatewayProvider as Provider>::get_class_hash_at(
+                <SequencerGatewayProvider as Provider>::get_class_hash_at(
                     inner,
                     block_id,
                     contract_address,
                 )
-                .await?)
+                .await
             }
         }
     }
@@ -256,70 +248,60 @@ impl Provider for AnyProvider {
         &self,
         block_id: B,
         contract_address: A,
-    ) -> Result<ContractClass, ProviderError<Self::Error>>
+    ) -> Result<ContractClass, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
         A: AsRef<FieldElement> + Send + Sync,
     {
         match self {
             Self::JsonRpcHttp(inner) => {
-                Ok(<JsonRpcClient<HttpTransport> as Provider>::get_class_at(
+                <JsonRpcClient<HttpTransport> as Provider>::get_class_at(
                     inner,
                     block_id,
                     contract_address,
                 )
-                .await?)
+                .await
             }
             Self::SequencerGateway(inner) => {
-                Ok(<SequencerGatewayProvider as Provider>::get_class_at(
+                <SequencerGatewayProvider as Provider>::get_class_at(
                     inner,
                     block_id,
                     contract_address,
                 )
-                .await?)
+                .await
             }
         }
     }
 
-    async fn get_block_transaction_count<B>(
-        &self,
-        block_id: B,
-    ) -> Result<u64, ProviderError<Self::Error>>
+    async fn get_block_transaction_count<B>(&self, block_id: B) -> Result<u64, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(
+            Self::JsonRpcHttp(inner) => {
                 <JsonRpcClient<HttpTransport> as Provider>::get_block_transaction_count(
                     inner, block_id,
                 )
-                .await?,
-            ),
-            Self::SequencerGateway(inner) => Ok(
-                <SequencerGatewayProvider as Provider>::get_block_transaction_count(
-                    inner, block_id,
-                )
-                .await?,
-            ),
+                .await
+            }
+            Self::SequencerGateway(inner) => {
+                <SequencerGatewayProvider as Provider>::get_block_transaction_count(inner, block_id)
+                    .await
+            }
         }
     }
 
-    async fn call<R, B>(
-        &self,
-        request: R,
-        block_id: B,
-    ) -> Result<Vec<FieldElement>, ProviderError<Self::Error>>
+    async fn call<R, B>(&self, request: R, block_id: B) -> Result<Vec<FieldElement>, ProviderError>
     where
         R: AsRef<FunctionCall> + Send + Sync,
         B: AsRef<BlockId> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(<JsonRpcClient<HttpTransport> as Provider>::call(
-                inner, request, block_id,
-            )
-            .await?),
+            Self::JsonRpcHttp(inner) => {
+                <JsonRpcClient<HttpTransport> as Provider>::call(inner, request, block_id).await
+            }
             Self::SequencerGateway(inner) => {
-                Ok(<SequencerGatewayProvider as Provider>::call(inner, request, block_id).await?)
+                <SequencerGatewayProvider as Provider>::call(inner, request, block_id).await
             }
         }
     }
@@ -328,20 +310,19 @@ impl Provider for AnyProvider {
         &self,
         request: R,
         block_id: B,
-    ) -> Result<Vec<FeeEstimate>, ProviderError<Self::Error>>
+    ) -> Result<Vec<FeeEstimate>, ProviderError>
     where
         R: AsRef<[BroadcastedTransaction]> + Send + Sync,
         B: AsRef<BlockId> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(
+            Self::JsonRpcHttp(inner) => {
                 <JsonRpcClient<HttpTransport> as Provider>::estimate_fee(inner, request, block_id)
-                    .await?,
-            ),
-            Self::SequencerGateway(inner) => Ok(
-                <SequencerGatewayProvider as Provider>::estimate_fee(inner, request, block_id)
-                    .await?,
-            ),
+                    .await
+            }
+            Self::SequencerGateway(inner) => {
+                <SequencerGatewayProvider as Provider>::estimate_fee(inner, request, block_id).await
+            }
         }
     }
 
@@ -349,80 +330,78 @@ impl Provider for AnyProvider {
         &self,
         message: M,
         block_id: B,
-    ) -> Result<FeeEstimate, ProviderError<Self::Error>>
+    ) -> Result<FeeEstimate, ProviderError>
     where
         M: AsRef<MsgFromL1> + Send + Sync,
         B: AsRef<BlockId> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(
+            Self::JsonRpcHttp(inner) => {
                 <JsonRpcClient<HttpTransport> as Provider>::estimate_message_fee(
                     inner, message, block_id,
                 )
-                .await?,
-            ),
-            Self::SequencerGateway(inner) => Ok(
+                .await
+            }
+            Self::SequencerGateway(inner) => {
                 <SequencerGatewayProvider as Provider>::estimate_message_fee(
                     inner, message, block_id,
                 )
-                .await?,
-            ),
+                .await
+            }
         }
     }
 
-    async fn block_number(&self) -> Result<u64, ProviderError<Self::Error>> {
+    async fn block_number(&self) -> Result<u64, ProviderError> {
         match self {
             Self::JsonRpcHttp(inner) => {
-                Ok(<JsonRpcClient<HttpTransport> as Provider>::block_number(inner).await?)
+                <JsonRpcClient<HttpTransport> as Provider>::block_number(inner).await
             }
             Self::SequencerGateway(inner) => {
-                Ok(<SequencerGatewayProvider as Provider>::block_number(inner).await?)
+                <SequencerGatewayProvider as Provider>::block_number(inner).await
             }
         }
     }
 
-    async fn block_hash_and_number(
-        &self,
-    ) -> Result<BlockHashAndNumber, ProviderError<Self::Error>> {
-        match self {
-            Self::JsonRpcHttp(inner) => Ok(
-                <JsonRpcClient<HttpTransport> as Provider>::block_hash_and_number(inner).await?,
-            ),
-            Self::SequencerGateway(inner) => {
-                Ok(<SequencerGatewayProvider as Provider>::block_hash_and_number(inner).await?)
-            }
-        }
-    }
-
-    async fn chain_id(&self) -> Result<FieldElement, ProviderError<Self::Error>> {
+    async fn block_hash_and_number(&self) -> Result<BlockHashAndNumber, ProviderError> {
         match self {
             Self::JsonRpcHttp(inner) => {
-                Ok(<JsonRpcClient<HttpTransport> as Provider>::chain_id(inner).await?)
+                <JsonRpcClient<HttpTransport> as Provider>::block_hash_and_number(inner).await
             }
             Self::SequencerGateway(inner) => {
-                Ok(<SequencerGatewayProvider as Provider>::chain_id(inner).await?)
+                <SequencerGatewayProvider as Provider>::block_hash_and_number(inner).await
             }
         }
     }
 
-    async fn pending_transactions(&self) -> Result<Vec<Transaction>, ProviderError<Self::Error>> {
+    async fn chain_id(&self) -> Result<FieldElement, ProviderError> {
         match self {
             Self::JsonRpcHttp(inner) => {
-                Ok(<JsonRpcClient<HttpTransport> as Provider>::pending_transactions(inner).await?)
+                <JsonRpcClient<HttpTransport> as Provider>::chain_id(inner).await
             }
             Self::SequencerGateway(inner) => {
-                Ok(<SequencerGatewayProvider as Provider>::pending_transactions(inner).await?)
+                <SequencerGatewayProvider as Provider>::chain_id(inner).await
             }
         }
     }
 
-    async fn syncing(&self) -> Result<SyncStatusType, ProviderError<Self::Error>> {
+    async fn pending_transactions(&self) -> Result<Vec<Transaction>, ProviderError> {
         match self {
             Self::JsonRpcHttp(inner) => {
-                Ok(<JsonRpcClient<HttpTransport> as Provider>::syncing(inner).await?)
+                <JsonRpcClient<HttpTransport> as Provider>::pending_transactions(inner).await
             }
             Self::SequencerGateway(inner) => {
-                Ok(<SequencerGatewayProvider as Provider>::syncing(inner).await?)
+                <SequencerGatewayProvider as Provider>::pending_transactions(inner).await
+            }
+        }
+    }
+
+    async fn syncing(&self) -> Result<SyncStatusType, ProviderError> {
+        match self {
+            Self::JsonRpcHttp(inner) => {
+                <JsonRpcClient<HttpTransport> as Provider>::syncing(inner).await
+            }
+            Self::SequencerGateway(inner) => {
+                <SequencerGatewayProvider as Provider>::syncing(inner).await
             }
         }
     }
@@ -432,23 +411,25 @@ impl Provider for AnyProvider {
         filter: EventFilter,
         continuation_token: Option<String>,
         chunk_size: u64,
-    ) -> Result<EventsPage, ProviderError<Self::Error>> {
+    ) -> Result<EventsPage, ProviderError> {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(<JsonRpcClient<HttpTransport> as Provider>::get_events(
-                inner,
-                filter,
-                continuation_token,
-                chunk_size,
-            )
-            .await?),
-            Self::SequencerGateway(inner) => {
-                Ok(<SequencerGatewayProvider as Provider>::get_events(
+            Self::JsonRpcHttp(inner) => {
+                <JsonRpcClient<HttpTransport> as Provider>::get_events(
                     inner,
                     filter,
                     continuation_token,
                     chunk_size,
                 )
-                .await?)
+                .await
+            }
+            Self::SequencerGateway(inner) => {
+                <SequencerGatewayProvider as Provider>::get_events(
+                    inner,
+                    filter,
+                    continuation_token,
+                    chunk_size,
+                )
+                .await
             }
         }
     }
@@ -457,121 +438,121 @@ impl Provider for AnyProvider {
         &self,
         block_id: B,
         contract_address: A,
-    ) -> Result<FieldElement, ProviderError<Self::Error>>
+    ) -> Result<FieldElement, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
         A: AsRef<FieldElement> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(<JsonRpcClient<HttpTransport> as Provider>::get_nonce(
-                inner,
-                block_id,
-                contract_address,
-            )
-            .await?),
-            Self::SequencerGateway(inner) => Ok(<SequencerGatewayProvider as Provider>::get_nonce(
-                inner,
-                block_id,
-                contract_address,
-            )
-            .await?),
+            Self::JsonRpcHttp(inner) => {
+                <JsonRpcClient<HttpTransport> as Provider>::get_nonce(
+                    inner,
+                    block_id,
+                    contract_address,
+                )
+                .await
+            }
+            Self::SequencerGateway(inner) => {
+                <SequencerGatewayProvider as Provider>::get_nonce(inner, block_id, contract_address)
+                    .await
+            }
         }
     }
 
     async fn add_invoke_transaction<I>(
         &self,
         invoke_transaction: I,
-    ) -> Result<InvokeTransactionResult, ProviderError<Self::Error>>
+    ) -> Result<InvokeTransactionResult, ProviderError>
     where
         I: AsRef<BroadcastedInvokeTransaction> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(
+            Self::JsonRpcHttp(inner) => {
                 <JsonRpcClient<HttpTransport> as Provider>::add_invoke_transaction(
                     inner,
                     invoke_transaction,
                 )
-                .await?,
-            ),
-            Self::SequencerGateway(inner) => Ok(
+                .await
+            }
+            Self::SequencerGateway(inner) => {
                 <SequencerGatewayProvider as Provider>::add_invoke_transaction(
                     inner,
                     invoke_transaction,
                 )
-                .await?,
-            ),
+                .await
+            }
         }
     }
 
     async fn add_declare_transaction<D>(
         &self,
         declare_transaction: D,
-    ) -> Result<DeclareTransactionResult, ProviderError<Self::Error>>
+    ) -> Result<DeclareTransactionResult, ProviderError>
     where
         D: AsRef<BroadcastedDeclareTransaction> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(
+            Self::JsonRpcHttp(inner) => {
                 <JsonRpcClient<HttpTransport> as Provider>::add_declare_transaction(
                     inner,
                     declare_transaction,
                 )
-                .await?,
-            ),
-            Self::SequencerGateway(inner) => Ok(
+                .await
+            }
+            Self::SequencerGateway(inner) => {
                 <SequencerGatewayProvider as Provider>::add_declare_transaction(
                     inner,
                     declare_transaction,
                 )
-                .await?,
-            ),
+                .await
+            }
         }
     }
 
     async fn add_deploy_account_transaction<D>(
         &self,
         deploy_account_transaction: D,
-    ) -> Result<DeployAccountTransactionResult, ProviderError<Self::Error>>
+    ) -> Result<DeployAccountTransactionResult, ProviderError>
     where
         D: AsRef<BroadcastedDeployAccountTransaction> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(
+            Self::JsonRpcHttp(inner) => {
                 <JsonRpcClient<HttpTransport> as Provider>::add_deploy_account_transaction(
                     inner,
                     deploy_account_transaction,
                 )
-                .await?,
-            ),
-            Self::SequencerGateway(inner) => Ok(
+                .await
+            }
+            Self::SequencerGateway(inner) => {
                 <SequencerGatewayProvider as Provider>::add_deploy_account_transaction(
                     inner,
                     deploy_account_transaction,
                 )
-                .await?,
-            ),
+                .await
+            }
         }
     }
 
     async fn trace_transaction<H>(
         &self,
         transaction_hash: H,
-    ) -> Result<TransactionTrace, ProviderError<Self::Error>>
+    ) -> Result<TransactionTrace, ProviderError>
     where
         H: AsRef<FieldElement> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(
+            Self::JsonRpcHttp(inner) => {
                 <JsonRpcClient<HttpTransport> as Provider>::trace_transaction(
                     inner,
                     transaction_hash,
                 )
-                .await?,
-            ),
-            Self::SequencerGateway(inner) => Ok(
+                .await
+            }
+            Self::SequencerGateway(inner) => {
                 <SequencerGatewayProvider as Provider>::trace_transaction(inner, transaction_hash)
-                    .await?,
-            ),
+                    .await
+            }
         }
     }
 
@@ -580,78 +561,52 @@ impl Provider for AnyProvider {
         block_id: B,
         transactions: T,
         simulation_flags: S,
-    ) -> Result<Vec<SimulatedTransaction>, ProviderError<Self::Error>>
+    ) -> Result<Vec<SimulatedTransaction>, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
         T: AsRef<[BroadcastedTransaction]> + Send + Sync,
         S: AsRef<[SimulationFlag]> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(
+            Self::JsonRpcHttp(inner) => {
                 <JsonRpcClient<HttpTransport> as Provider>::simulate_transactions(
                     inner,
                     block_id,
                     transactions,
                     simulation_flags,
                 )
-                .await?,
-            ),
-            Self::SequencerGateway(inner) => Ok(
+                .await
+            }
+            Self::SequencerGateway(inner) => {
                 <SequencerGatewayProvider as Provider>::simulate_transactions(
                     inner,
                     block_id,
                     transactions,
                     simulation_flags,
                 )
-                .await?,
-            ),
+                .await
+            }
         }
     }
 
     async fn trace_block_transactions<H>(
         &self,
         block_hash: H,
-    ) -> Result<Vec<TransactionTraceWithHash>, ProviderError<Self::Error>>
+    ) -> Result<Vec<TransactionTraceWithHash>, ProviderError>
     where
         H: AsRef<FieldElement> + Send + Sync,
     {
         match self {
-            Self::JsonRpcHttp(inner) => Ok(
+            Self::JsonRpcHttp(inner) => {
                 <JsonRpcClient<HttpTransport> as Provider>::trace_block_transactions(
                     inner, block_hash,
                 )
-                .await?,
-            ),
-            Self::SequencerGateway(inner) => Ok(
+                .await
+            }
+            Self::SequencerGateway(inner) => {
                 <SequencerGatewayProvider as Provider>::trace_block_transactions(inner, block_hash)
-                    .await?,
-            ),
-        }
-    }
-}
-
-impl From<ProviderError<<JsonRpcClient<HttpTransport> as Provider>::Error>>
-    for ProviderError<AnyProviderError>
-{
-    fn from(value: ProviderError<<JsonRpcClient<HttpTransport> as Provider>::Error>) -> Self {
-        match value {
-            ProviderError::StarknetError(inner) => Self::StarknetError(inner),
-            ProviderError::RateLimited => Self::RateLimited,
-            ProviderError::ArrayLengthMismatch => Self::ArrayLengthMismatch,
-            ProviderError::Other(inner) => Self::Other(AnyProviderError::JsonRpcHttp(inner)),
-        }
-    }
-}
-
-impl From<ProviderError<<SequencerGatewayProvider as Provider>::Error>>
-    for ProviderError<AnyProviderError>
-{
-    fn from(value: ProviderError<<SequencerGatewayProvider as Provider>::Error>) -> Self {
-        match value {
-            ProviderError::StarknetError(inner) => Self::StarknetError(inner),
-            ProviderError::RateLimited => Self::RateLimited,
-            ProviderError::ArrayLengthMismatch => Self::ArrayLengthMismatch,
-            ProviderError::Other(inner) => Self::Other(AnyProviderError::SequencerGateway(inner)),
+                    .await
+            }
         }
     }
 }

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -1,3 +1,5 @@
+use std::{any::Any, error::Error};
+
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::serde_as;
@@ -16,7 +18,7 @@ use starknet_core::{
 };
 
 use crate::{
-    provider::{MaybeUnknownErrorCode, StarknetErrorWithMessage},
+    provider::{MaybeUnknownErrorCode, ProviderImplError, StarknetErrorWithMessage},
     Provider, ProviderError,
 };
 
@@ -171,13 +173,9 @@ impl<T> JsonRpcClient<T> {
 
 impl<T> JsonRpcClient<T>
 where
-    T: JsonRpcTransport,
+    T: 'static + JsonRpcTransport + Send + Sync,
 {
-    async fn send_request<P, R>(
-        &self,
-        method: JsonRpcMethod,
-        params: P,
-    ) -> Result<R, ProviderError<JsonRpcClientError<T::Error>>>
+    async fn send_request<P, R>(&self, method: JsonRpcMethod, params: P) -> Result<R, ProviderError>
     where
         P: Serialize + Send,
         R: DeserializeOwned,
@@ -186,7 +184,7 @@ where
             .transport
             .send_request(method, params)
             .await
-            .map_err(|err| ProviderError::Other(JsonRpcClientError::TransportError(err)))?
+            .map_err(JsonRpcClientError::TransportError)?
         {
             JsonRpcResponse::Success { result, .. } => Ok(result),
             JsonRpcResponse::Error { error, .. } => {
@@ -206,15 +204,13 @@ where
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<T> Provider for JsonRpcClient<T>
 where
-    T: JsonRpcTransport + Sync + Send,
+    T: 'static + JsonRpcTransport + Sync + Send,
 {
-    type Error = JsonRpcClientError<T::Error>;
-
     /// Get block information with transaction hashes given the block id
     async fn get_block_with_tx_hashes<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithTxHashes, ProviderError<Self::Error>>
+    ) -> Result<MaybePendingBlockWithTxHashes, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -231,7 +227,7 @@ where
     async fn get_block_with_txs<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithTxs, ProviderError<Self::Error>>
+    ) -> Result<MaybePendingBlockWithTxs, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -248,7 +244,7 @@ where
     async fn get_state_update<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingStateUpdate, ProviderError<Self::Error>>
+    ) -> Result<MaybePendingStateUpdate, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -267,7 +263,7 @@ where
         contract_address: A,
         key: K,
         block_id: B,
-    ) -> Result<FieldElement, ProviderError<Self::Error>>
+    ) -> Result<FieldElement, ProviderError>
     where
         A: AsRef<FieldElement> + Send + Sync,
         K: AsRef<FieldElement> + Send + Sync,
@@ -290,7 +286,7 @@ where
     async fn get_transaction_by_hash<H>(
         &self,
         transaction_hash: H,
-    ) -> Result<Transaction, ProviderError<Self::Error>>
+    ) -> Result<Transaction, ProviderError>
     where
         H: AsRef<FieldElement> + Send + Sync,
     {
@@ -308,7 +304,7 @@ where
         &self,
         block_id: B,
         index: u64,
-    ) -> Result<Transaction, ProviderError<Self::Error>>
+    ) -> Result<Transaction, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -326,7 +322,7 @@ where
     async fn get_transaction_receipt<H>(
         &self,
         transaction_hash: H,
-    ) -> Result<MaybePendingTransactionReceipt, ProviderError<Self::Error>>
+    ) -> Result<MaybePendingTransactionReceipt, ProviderError>
     where
         H: AsRef<FieldElement> + Send + Sync,
     {
@@ -344,7 +340,7 @@ where
         &self,
         block_id: B,
         class_hash: H,
-    ) -> Result<ContractClass, ProviderError<Self::Error>>
+    ) -> Result<ContractClass, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
         H: AsRef<FieldElement> + Send + Sync,
@@ -364,7 +360,7 @@ where
         &self,
         block_id: B,
         contract_address: A,
-    ) -> Result<FieldElement, ProviderError<Self::Error>>
+    ) -> Result<FieldElement, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
         A: AsRef<FieldElement> + Send + Sync,
@@ -386,7 +382,7 @@ where
         &self,
         block_id: B,
         contract_address: A,
-    ) -> Result<ContractClass, ProviderError<Self::Error>>
+    ) -> Result<ContractClass, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
         A: AsRef<FieldElement> + Send + Sync,
@@ -402,10 +398,7 @@ where
     }
 
     /// Get the number of transactions in a block given a block id
-    async fn get_block_transaction_count<B>(
-        &self,
-        block_id: B,
-    ) -> Result<u64, ProviderError<Self::Error>>
+    async fn get_block_transaction_count<B>(&self, block_id: B) -> Result<u64, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -419,11 +412,7 @@ where
     }
 
     /// Call a starknet function without creating a Starknet transaction
-    async fn call<R, B>(
-        &self,
-        request: R,
-        block_id: B,
-    ) -> Result<Vec<FieldElement>, ProviderError<Self::Error>>
+    async fn call<R, B>(&self, request: R, block_id: B) -> Result<Vec<FieldElement>, ProviderError>
     where
         R: AsRef<FunctionCall> + Send + Sync,
         B: AsRef<BlockId> + Send + Sync,
@@ -445,7 +434,7 @@ where
         &self,
         request: R,
         block_id: B,
-    ) -> Result<Vec<FeeEstimate>, ProviderError<Self::Error>>
+    ) -> Result<Vec<FeeEstimate>, ProviderError>
     where
         R: AsRef<[BroadcastedTransaction]> + Send + Sync,
         B: AsRef<BlockId> + Send + Sync,
@@ -465,7 +454,7 @@ where
         &self,
         message: M,
         block_id: B,
-    ) -> Result<FeeEstimate, ProviderError<Self::Error>>
+    ) -> Result<FeeEstimate, ProviderError>
     where
         M: AsRef<MsgFromL1> + Send + Sync,
         B: AsRef<BlockId> + Send + Sync,
@@ -481,21 +470,19 @@ where
     }
 
     /// Get the most recent accepted block number
-    async fn block_number(&self) -> Result<u64, ProviderError<Self::Error>> {
+    async fn block_number(&self) -> Result<u64, ProviderError> {
         self.send_request(JsonRpcMethod::BlockNumber, BlockNumberRequest)
             .await
     }
 
     /// Get the most recent accepted block hash and number
-    async fn block_hash_and_number(
-        &self,
-    ) -> Result<BlockHashAndNumber, ProviderError<Self::Error>> {
+    async fn block_hash_and_number(&self) -> Result<BlockHashAndNumber, ProviderError> {
         self.send_request(JsonRpcMethod::BlockHashAndNumber, BlockHashAndNumberRequest)
             .await
     }
 
     /// Return the currently configured Starknet chain id
-    async fn chain_id(&self) -> Result<FieldElement, ProviderError<Self::Error>> {
+    async fn chain_id(&self) -> Result<FieldElement, ProviderError> {
         Ok(self
             .send_request::<_, Felt>(JsonRpcMethod::ChainId, ChainIdRequest)
             .await?
@@ -503,7 +490,7 @@ where
     }
 
     /// Returns the transactions in the transaction pool, recognized by this sequencer
-    async fn pending_transactions(&self) -> Result<Vec<Transaction>, ProviderError<Self::Error>> {
+    async fn pending_transactions(&self) -> Result<Vec<Transaction>, ProviderError> {
         self.send_request(
             JsonRpcMethod::PendingTransactions,
             PendingTransactionsRequest,
@@ -512,7 +499,7 @@ where
     }
 
     /// Returns an object about the sync status, or false if the node is not synching
-    async fn syncing(&self) -> Result<SyncStatusType, ProviderError<Self::Error>> {
+    async fn syncing(&self) -> Result<SyncStatusType, ProviderError> {
         self.send_request(JsonRpcMethod::Syncing, SyncingRequest)
             .await
     }
@@ -523,7 +510,7 @@ where
         filter: EventFilter,
         continuation_token: Option<String>,
         chunk_size: u64,
-    ) -> Result<EventsPage, ProviderError<Self::Error>> {
+    ) -> Result<EventsPage, ProviderError> {
         self.send_request(
             JsonRpcMethod::GetEvents,
             GetEventsRequestRef {
@@ -544,7 +531,7 @@ where
         &self,
         block_id: B,
         contract_address: A,
-    ) -> Result<FieldElement, ProviderError<Self::Error>>
+    ) -> Result<FieldElement, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
         A: AsRef<FieldElement> + Send + Sync,
@@ -565,7 +552,7 @@ where
     async fn add_invoke_transaction<I>(
         &self,
         invoke_transaction: I,
-    ) -> Result<InvokeTransactionResult, ProviderError<Self::Error>>
+    ) -> Result<InvokeTransactionResult, ProviderError>
     where
         I: AsRef<BroadcastedInvokeTransaction> + Send + Sync,
     {
@@ -582,7 +569,7 @@ where
     async fn add_declare_transaction<D>(
         &self,
         declare_transaction: D,
-    ) -> Result<DeclareTransactionResult, ProviderError<Self::Error>>
+    ) -> Result<DeclareTransactionResult, ProviderError>
     where
         D: AsRef<BroadcastedDeclareTransaction> + Send + Sync,
     {
@@ -599,7 +586,7 @@ where
     async fn add_deploy_account_transaction<D>(
         &self,
         deploy_account_transaction: D,
-    ) -> Result<DeployAccountTransactionResult, ProviderError<Self::Error>>
+    ) -> Result<DeployAccountTransactionResult, ProviderError>
     where
         D: AsRef<BroadcastedDeployAccountTransaction> + Send + Sync,
     {
@@ -617,7 +604,7 @@ where
     async fn trace_transaction<H>(
         &self,
         transaction_hash: H,
-    ) -> Result<TransactionTrace, ProviderError<Self::Error>>
+    ) -> Result<TransactionTrace, ProviderError>
     where
         H: AsRef<FieldElement> + Send + Sync,
     {
@@ -637,7 +624,7 @@ where
         block_id: B,
         transactions: TX,
         simulation_flags: S,
-    ) -> Result<Vec<SimulatedTransaction>, ProviderError<Self::Error>>
+    ) -> Result<Vec<SimulatedTransaction>, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
         TX: AsRef<[BroadcastedTransaction]> + Send + Sync,
@@ -658,7 +645,7 @@ where
     async fn trace_block_transactions<H>(
         &self,
         block_hash: H,
-    ) -> Result<Vec<TransactionTraceWithHash>, ProviderError<Self::Error>>
+    ) -> Result<Vec<TransactionTraceWithHash>, ProviderError>
     where
         H: AsRef<FieldElement> + Send + Sync,
     {
@@ -812,6 +799,24 @@ impl<'de> Deserialize<'de> for JsonRpcRequest {
             id: raw_request.id,
             data: request_data,
         })
+    }
+}
+
+impl<T> ProviderImplError for JsonRpcClientError<T>
+where
+    T: 'static + Error + Send + Sync,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl<T> From<JsonRpcClientError<T>> for ProviderError
+where
+    T: 'static + Error + Send + Sync,
+{
+    fn from(value: JsonRpcClientError<T>) -> Self {
+        Self::Other(Box::new(value))
     }
 }
 

--- a/starknet-providers/src/lib.rs
+++ b/starknet-providers/src/lib.rs
@@ -12,4 +12,4 @@ pub mod jsonrpc;
 pub use jsonrpc::JsonRpcClient;
 
 mod any;
-pub use any::{AnyProvider, AnyProviderError};
+pub use any::AnyProvider;


### PR DESCRIPTION
Changes the `Other` variant of `ProviderError` to use a trait object instead of a generic parameter. This makes the `ProviderError` type much easier to work with, as errors from different `Provider` types are now compatible, and any type that wraps `ProviderError` will have one fewer generic parameter to deal with.

At the same time, it's still possible, though harder, to access the erased error type by downcasting, which requires the caller to know the concrete type at compile time, as showcased in the new example.

This is a breaking change, but it shouldn't affect downstream applications which already erase the whole `ProviderError` type with something like `anyhow`.