### PR TITLE
fix: incorrect upper bound for `s`

### DIFF
--- a/starknet-crypto/src/ecdsa.rs
+++ b/starknet-crypto/src/ecdsa.rs
@@ -138,7 +138,7 @@ pub fn verify(
     if r == &FieldElement::ZERO || r >= &ELEMENT_UPPER_BOUND {
         return Err(VerifyError::InvalidR);
     }
-    if s == &FieldElement::ZERO || s >= &EC_ORDER {
+    if s == &FieldElement::ZERO || s >= &ELEMENT_UPPER_BOUND {
         return Err(VerifyError::InvalidS);
     }
 


### PR DESCRIPTION
Thanks to Michael from @eqlabs for spotting this. This PR changes the `s` upper bound to match the [implementation from `crypto-cpp`](https://github.com/starkware-libs/crypto-cpp/blob/78e3ed8dc7a0901fe6d62f4e99becc6e7936adfd/src/starkware/crypto/ecdsa.cc#L65).