### PR TITLE
fix: incorrect upper bound for `s` in `sign`

### DIFF
--- a/starknet-crypto/src/ecdsa.rs
+++ b/starknet-crypto/src/ecdsa.rs
@@ -108,7 +108,7 @@ pub fn sign(
     let s = mul_mod_floor(&r, private_key, &EC_ORDER);
     let s = add_unbounded(&s, message);
     let s = bigint_mul_mod_floor(s, &k_inv, &EC_ORDER);
-    if s == FieldElement::ZERO || s >= EC_ORDER {
+    if s == FieldElement::ZERO || s >= ELEMENT_UPPER_BOUND {
         return Err(SignError::InvalidK);
     }
 


### PR DESCRIPTION
Same as #485 but for `sign`, as we need to keep `sign` and `verify` consistent.