### PR TITLE
test: disable reverted invoke trace test

### DIFF
--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -788,6 +788,7 @@ async fn jsonrpc_trace_invoke() {
 }
 
 #[tokio::test]
+#[ignore = "disabled until pathfinder PR #1457 is released"]
 async fn jsonrpc_trace_invoke_reverted() {
     let rpc_client = create_jsonrpc_client();
 


### PR DESCRIPTION
Test disabled until https://github.com/eqlabs/pathfinder/pull/1457 is released.