### PR TITLE
release: bump starknet-crypto to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "criterion",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 
 [dependencies]
 starknet-ff = { version = "0.3.4", path = "./starknet-ff", default-features = false }
-starknet-crypto = { version = "0.6.0", path = "./starknet-crypto" }
+starknet-crypto = { version = "0.6.1", path = "./starknet-crypto" }
 starknet-core = { version = "0.6.1", path = "./starknet-core", default-features = false }
 starknet-providers = { version = "0.6.0", path = "./starknet-providers" }
 starknet-contract = { version = "0.5.0", path = "./starknet-contract" }

--- a/examples/starknet-wasm/Cargo.toml
+++ b/examples/starknet-wasm/Cargo.toml
@@ -20,6 +20,6 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 starknet-ff = { version = "0.3.4", path = "../../starknet-ff" }
-starknet-crypto = { version = "0.6.0", path = "../../starknet-crypto" }
+starknet-crypto = { version = "0.6.1", path = "../../starknet-crypto" }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 wasm-bindgen = "0.2.84"

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["test-data/**"]
 all-features = true
 
 [dependencies]
-starknet-crypto = { version = "0.6.0", path = "../starknet-crypto", default-features = false, features = ["alloc"] }
+starknet-crypto = { version = "0.6.1", path = "../starknet-crypto", default-features = false, features = ["alloc"] }
 starknet-ff = { version = "0.3.4", path = "../starknet-ff", default-features = false, features = ["serde"] }
 base64 = { version = "0.21.0", default-features = false, features = ["alloc"] }
 flate2 = { version = "1.0.25", optional = true }

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-crypto"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
 starknet-core = { version = "0.6.1", path = "../starknet-core" }
-starknet-crypto = { version = "0.6.0", path = "../starknet-crypto" }
+starknet-crypto = { version = "0.6.1", path = "../starknet-crypto" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 thiserror = "1.0.40"


### PR DESCRIPTION
To make #485 and #486 available.