### PR TITLE
test: re-enable ignored tests

### DIFF
--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -788,7 +788,6 @@ async fn jsonrpc_trace_invoke() {
 }
 
 #[tokio::test]
-#[ignore = "disabled until pathfinder PR #1457 is released"]
 async fn jsonrpc_trace_invoke_reverted() {
     let rpc_client = create_jsonrpc_client();
 


### PR DESCRIPTION
The `pathfinder` fix has been released with v0.9.4. We no longer need to ignore this test case.