### PR TITLE
release: bump starknet-core to 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "base64 0.21.0",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ all-features = true
 [dependencies]
 starknet-ff = { version = "0.3.5", path = "./starknet-ff", default-features = false }
 starknet-crypto = { version = "0.6.1", path = "./starknet-crypto" }
-starknet-core = { version = "0.7.1", path = "./starknet-core", default-features = false }
+starknet-core = { version = "0.7.2", path = "./starknet-core", default-features = false }
 starknet-providers = { version = "0.7.0", path = "./starknet-providers" }
 starknet-contract = { version = "0.6.0", path = "./starknet-contract" }
 starknet-signers = { version = "0.5.0", path = "./starknet-signers" }

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.7.1", path = "../starknet-core" }
+starknet-core = { version = "0.7.2", path = "../starknet-core" }
 starknet-providers = { version = "0.7.0", path = "../starknet-providers" }
 starknet-signers = { version = "0.5.0", path = "../starknet-signers" }
 async-trait = "0.1.68"

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.7.1", path = "../starknet-core" }
+starknet-core = { version = "0.7.2", path = "../starknet-core" }
 starknet-providers = { version = "0.7.0", path = "../starknet-providers" }
 starknet-accounts = { version = "0.6.0", path = "../starknet-accounts" }
 serde = { version = "1.0.160", features = ["derive"] }

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-core"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/starknet-macros/Cargo.toml
+++ b/starknet-macros/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 proc-macro = true
 
 [dependencies]
-starknet-core = { version = "0.7.1", path = "../starknet-core" }
+starknet-core = { version = "0.7.2", path = "../starknet-core" }
 syn = "2.0.15"
 
 [features]

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.7.1", path = "../starknet-core" }
+starknet-core = { version = "0.7.2", path = "../starknet-core" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 ethereum-types = "0.14.1"

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -13,7 +13,7 @@ Starknet signer implementations
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.7.1", path = "../starknet-core" }
+starknet-core = { version = "0.7.2", path = "../starknet-core" }
 starknet-crypto = { version = "0.6.1", path = "../starknet-crypto" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"


### PR DESCRIPTION
Mainly to make #494 available on crates.io.