### PR TITLE
feat: revamp provider error handling

### DIFF
--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -9,9 +9,7 @@ use starknet_core::{
         SimulationFlag, StarknetError,
     },
 };
-use starknet_providers::{
-    MaybeUnknownErrorCode, Provider, ProviderError, StarknetErrorWithMessage,
-};
+use starknet_providers::{Provider, ProviderError};
 use std::error::Error;
 
 pub mod argent;
@@ -178,10 +176,9 @@ where
             .await
         {
             Ok(nonce) => Ok(nonce),
-            Err(ProviderError::StarknetError(StarknetErrorWithMessage {
-                code: MaybeUnknownErrorCode::Known(StarknetError::ContractNotFound),
-                ..
-            })) => Ok(FieldElement::ZERO),
+            Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => {
+                Ok(FieldElement::ZERO)
+            }
             Err(err) => Err(err),
         }
     }

--- a/starknet-core/src/types/codegen.rs
+++ b/starknet-core/src/types/codegen.rs
@@ -3,7 +3,7 @@
 //     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen
 
 // Code generated with version:
-//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen#3215ab04aee89aafa48973cdcf027219f662f49d
+//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen#51260963a0723fdbc715598efb7198ce5a1d49b9
 
 // Code generation requested but not implemented for these types:
 // - `BLOCK_ID`
@@ -1393,6 +1393,39 @@ impl core::fmt::Display for StarknetError {
             Self::UnexpectedError => write!(f, "UnexpectedError"),
             Self::NoTraceAvailable => write!(f, "NoTraceAvailable"),
             Self::InvalidTransactionHash => write!(f, "InvalidTransactionHash"),
+        }
+    }
+}
+
+impl StarknetError {
+    pub fn message(&self) -> &'static str {
+        match self {
+            Self::FailedToReceiveTransaction => "Failed to write transaction",
+            Self::ContractNotFound => "Contract not found",
+            Self::BlockNotFound => "Block not found",
+            Self::InvalidTransactionIndex => "Invalid transaction index in a block",
+            Self::ClassHashNotFound => "Class hash not found",
+            Self::TransactionHashNotFound => "Transaction hash not found",
+            Self::PageSizeTooBig => "Requested page size is too big",
+            Self::NoBlocks => "There are no blocks",
+            Self::InvalidContinuationToken => "The supplied continuation token is invalid or unknown",
+            Self::TooManyKeysInFilter => "Too many keys provided in a filter",
+            Self::ContractError => "Contract error",
+            Self::ClassAlreadyDeclared => "Class already declared",
+            Self::InvalidTransactionNonce => "Invalid transaction nonce",
+            Self::InsufficientMaxFee => "Max fee is smaller than the minimal transaction cost (validation plus fee transfer)",
+            Self::InsufficientAccountBalance => "Account balance is smaller than the transaction's max_fee",
+            Self::ValidationFailure => "Account validation failed",
+            Self::CompilationFailed => "Compilation failed",
+            Self::ContractClassSizeIsTooLarge => "Contract class size it too large",
+            Self::NonAccount => "Sender address in not an account contract",
+            Self::DuplicateTx => "A transaction with the same hash already exists in the mempool",
+            Self::CompiledClassHashMismatch => "the compiled class hash did not match the one supplied in the transaction",
+            Self::UnsupportedTxVersion => "the transaction version is not supported",
+            Self::UnsupportedContractClassVersion => "the contract class version is not supported",
+            Self::UnexpectedError => "An unexpected error occurred",
+            Self::NoTraceAvailable => "No trace available for transaction",
+            Self::InvalidTransactionHash => "Invalid transaction hash",
         }
     }
 }

--- a/starknet-providers/src/lib.rs
+++ b/starknet-providers/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 mod provider;
-pub use provider::{MaybeUnknownErrorCode, Provider, ProviderError, StarknetErrorWithMessage};
+pub use provider::{Provider, ProviderError};
 
 pub mod sequencer;
 pub use sequencer::{

--- a/starknet-providers/src/provider.rs
+++ b/starknet-providers/src/provider.rs
@@ -297,33 +297,11 @@ pub trait ProviderImplError: Error + Debug + Send + Sync {
 #[derive(Debug, thiserror::Error)]
 pub enum ProviderError {
     #[error(transparent)]
-    StarknetError(StarknetErrorWithMessage),
+    StarknetError(StarknetError),
     #[error("Request rate limited")]
     RateLimited,
     #[error("Array length mismatch")]
     ArrayLengthMismatch,
     #[error("{0}")]
     Other(Box<dyn ProviderImplError>),
-}
-
-#[derive(Debug, thiserror::Error)]
-#[error("code={code}, message=\"{message}\"")]
-pub struct StarknetErrorWithMessage {
-    pub code: MaybeUnknownErrorCode,
-    pub message: String,
-}
-
-#[derive(Debug)]
-pub enum MaybeUnknownErrorCode {
-    Known(StarknetError),
-    Unknown(i64),
-}
-
-impl core::fmt::Display for MaybeUnknownErrorCode {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            MaybeUnknownErrorCode::Known(code) => write!(f, "{}", code),
-            MaybeUnknownErrorCode::Unknown(code) => write!(f, "{}", code),
-        }
-    }
 }

--- a/starknet-providers/src/sequencer/mod.rs
+++ b/starknet-providers/src/sequencer/mod.rs
@@ -1,4 +1,4 @@
-use crate::provider::{MaybeUnknownErrorCode, ProviderError, StarknetErrorWithMessage};
+use crate::provider::ProviderError;
 
 use log::trace;
 use reqwest::{Client, Error as ReqwestError, StatusCode};
@@ -730,10 +730,7 @@ impl From<SequencerError> for ProviderError {
         };
 
         match matching_code {
-            Some(code) => ProviderError::StarknetError(StarknetErrorWithMessage {
-                code: MaybeUnknownErrorCode::Known(code),
-                message: value.message,
-            }),
+            Some(code) => ProviderError::StarknetError(code),
             None => GatewayClientError::SequencerError(value).into(),
         }
     }

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -14,7 +14,7 @@ use starknet_core::types::{
 };
 
 use crate::{
-    provider::{MaybeUnknownErrorCode, ProviderImplError, StarknetErrorWithMessage},
+    provider::ProviderImplError,
     sequencer::{
         models::conversions::{ConversionError, TransactionWithReceipt},
         GatewayClientError,
@@ -106,10 +106,9 @@ impl Provider for SequencerGatewayProvider {
 
         // `NotReceived` is not a valid status for JSON-RPC. It's an error.
         if let Some(TransactionFinalityStatus::NotReceived) = &status.finality_status {
-            return Err(ProviderError::StarknetError(StarknetErrorWithMessage {
-                code: MaybeUnknownErrorCode::Known(StarknetError::TransactionHashNotFound),
-                message: "Transaction hash not found".into(),
-            }));
+            return Err(ProviderError::StarknetError(
+                StarknetError::TransactionHashNotFound,
+            ));
         }
 
         Ok(status.try_into()?)
@@ -142,10 +141,9 @@ impl Provider for SequencerGatewayProvider {
         if index < block.transactions.len() {
             Ok(block.transactions.remove(index).try_into()?)
         } else {
-            Err(ProviderError::StarknetError(StarknetErrorWithMessage {
-                code: MaybeUnknownErrorCode::Known(StarknetError::InvalidTransactionIndex),
-                message: "Invalid transaction index in a block".into(),
-            }))
+            Err(ProviderError::StarknetError(
+                StarknetError::InvalidTransactionIndex,
+            ))
         }
     }
 
@@ -164,10 +162,9 @@ impl Provider for SequencerGatewayProvider {
         if receipt.status == super::models::TransactionStatus::NotReceived
             || receipt.status == super::models::TransactionStatus::Received
         {
-            Err(ProviderError::StarknetError(StarknetErrorWithMessage {
-                code: MaybeUnknownErrorCode::Known(StarknetError::TransactionHashNotFound),
-                message: "Transaction hash not found".into(),
-            }))
+            Err(ProviderError::StarknetError(
+                StarknetError::TransactionHashNotFound,
+            ))
         } else {
             // JSON-RPC also sends tx type, which is not available in our receipt type
             let tx = self.get_transaction(*transaction_hash.as_ref()).await?;

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -11,7 +11,7 @@ use starknet_core::{
 };
 use starknet_providers::{
     jsonrpc::{HttpTransport, JsonRpcClient},
-    MaybeUnknownErrorCode, Provider, ProviderError, StarknetErrorWithMessage,
+    Provider, ProviderError,
 };
 use url::Url;
 
@@ -371,10 +371,7 @@ async fn jsonrpc_get_transaction_by_hash_non_existent_tx() {
         .unwrap_err();
 
     match err {
-        ProviderError::StarknetError(StarknetErrorWithMessage {
-            code: MaybeUnknownErrorCode::Known(StarknetError::TransactionHashNotFound),
-            ..
-        }) => {
+        ProviderError::StarknetError(StarknetError::TransactionHashNotFound) => {
             // TXN_HASH_NOT_FOUND
         }
         _ => panic!("Unexpected error"),


### PR DESCRIPTION
Greatly simplify provider error code matching. Previously, the error code returned from the RPC is an enum with 2 variants for known and unknown codes to accommodate the fact that JSON-RPC nodes sometimes return codes that are part of the JSON-RPC standard, but are not from the Starknet specifications. This commit changes to move the unknown codes to be handled by the implementation-specific error type instead, making it much easier to match against specification error codes, at the cost of being harder to match the unknown codes.