### PR TITLE
test: ignore sequencer tests for deprecation

### DIFF
--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -29,6 +29,7 @@ fn create_jsonrpc_client() -> JsonRpcClient<HttpTransport> {
 }
 
 #[tokio::test]
+#[ignore = "endpoint deprecated since Starknet v0.12.3"]
 async fn can_get_nonce_with_sequencer() {
     can_get_nonce_inner(
         create_sequencer_client(),
@@ -47,6 +48,7 @@ async fn can_get_nonce_with_jsonrpc() {
 }
 
 #[tokio::test]
+#[ignore = "endpoint deprecated since Starknet v0.12.3"]
 async fn can_estimate_fee_with_sequencer() {
     can_estimate_fee_inner(
         create_sequencer_client(),
@@ -68,6 +70,7 @@ async fn can_estimate_fee_with_jsonrpc() {
 // TODO: add `simulate` test cases back once transaction simulation in supported
 
 #[tokio::test]
+#[ignore = "endpoint deprecated since Starknet v0.12.3"]
 async fn can_execute_tst_mint_with_sequencer() {
     can_execute_tst_mint_inner(
         create_sequencer_client(),
@@ -86,6 +89,7 @@ async fn can_execute_tst_mint_with_jsonrpc() {
 }
 
 #[tokio::test]
+#[ignore = "endpoint deprecated since Starknet v0.12.3"]
 async fn can_declare_cairo1_contract_with_sequencer() {
     can_declare_cairo1_contract_inner(
         create_sequencer_client(),
@@ -104,6 +108,7 @@ async fn can_declare_cairo1_contract_with_jsonrpc() {
 }
 
 #[tokio::test]
+#[ignore = "endpoint deprecated since Starknet v0.12.3"]
 async fn can_declare_cairo0_contract_with_sequencer() {
     can_declare_cairo0_contract_inner(
         create_sequencer_client(),

--- a/starknet-providers/tests/sequencer_goerli.rs
+++ b/starknet-providers/tests/sequencer_goerli.rs
@@ -23,6 +23,7 @@ fn felt_dec(dec: &str) -> FieldElement {
 }
 
 #[tokio::test]
+#[ignore = "endpoint deprecated since Starknet v0.12.3"]
 async fn sequencer_goerli_can_estimate_message_fee() {
     let client = create_sequencer_client();
 
@@ -63,6 +64,7 @@ async fn sequencer_goerli_can_estimate_message_fee() {
 }
 
 #[tokio::test]
+#[ignore = "endpoint deprecated since Starknet v0.12.3"]
 async fn sequencer_goerli_can_simulate_transaction() {
     let client = create_sequencer_client();
 
@@ -149,6 +151,7 @@ async fn sequencer_goerli_can_simulate_transaction() {
 }
 
 #[tokio::test]
+#[ignore = "endpoint deprecated since Starknet v0.12.3"]
 async fn sequencer_goerli_can_get_nonce() {
     let client = create_sequencer_client();
 
@@ -167,6 +170,7 @@ async fn sequencer_goerli_can_get_nonce() {
 }
 
 #[tokio::test]
+#[ignore = "endpoint deprecated since Starknet v0.12.3"]
 async fn sequencer_goerli_can_bulk_estimate_fee() {
     let client = create_sequencer_client();
 


### PR DESCRIPTION
Can no longer run these due to the upgrade to v0.12.3.