### PR TITLE
feat: parse data field for provider errors

### DIFF
--- a/starknet-core/src/types/codegen.rs
+++ b/starknet-core/src/types/codegen.rs
@@ -3,7 +3,7 @@
 //     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen
 
 // Code generated with version:
-//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen#51260963a0723fdbc715598efb7198ce5a1d49b9
+//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen#bddc1b829c33b14440d22a85bc937e3d16e32ed1
 
 // Code generation requested but not implemented for these types:
 // - `BLOCK_ID`
@@ -239,6 +239,14 @@ pub struct CompressedLegacyContractClass {
     /// Contract abi
     #[serde(skip_serializing_if = "Option::is_none")]
     pub abi: Option<Vec<LegacyContractAbiEntry>>,
+}
+
+/// More data about the execution failure.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
+pub struct ContractErrorData {
+    /// A string encoding the execution trace up to the point of failure
+    pub revert_error: String,
 }
 
 /// Contract storage diff item.
@@ -1007,6 +1015,14 @@ pub struct MsgToL1 {
     pub payload: Vec<FieldElement>,
 }
 
+/// Extra information on why trace is not available. Either it wasn't executed yet (received), or
+/// the transaction failed (rejected).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
+pub struct NoTraceAvailableErrorData {
+    pub status: SequencerTransactionStatus,
+}
+
 /// Nonce update.
 ///
 /// The updated nonce per contract address.
@@ -1305,7 +1321,7 @@ pub enum SimulationFlag {
 }
 
 /// JSON-RPC error codes
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StarknetError {
     /// Failed to write transaction
     FailedToReceiveTransaction,
@@ -1328,7 +1344,7 @@ pub enum StarknetError {
     /// Too many keys provided in a filter
     TooManyKeysInFilter,
     /// Contract error
-    ContractError,
+    ContractError(ContractErrorData),
     /// Class already declared
     ClassAlreadyDeclared,
     /// Invalid transaction nonce
@@ -1354,9 +1370,9 @@ pub enum StarknetError {
     /// the contract class version is not supported
     UnsupportedContractClassVersion,
     /// An unexpected error occurred
-    UnexpectedError,
+    UnexpectedError(String),
     /// No trace available for transaction
-    NoTraceAvailable,
+    NoTraceAvailable(NoTraceAvailableErrorData),
     /// Invalid transaction hash
     InvalidTransactionHash,
 }
@@ -1377,7 +1393,7 @@ impl core::fmt::Display for StarknetError {
             Self::NoBlocks => write!(f, "NoBlocks"),
             Self::InvalidContinuationToken => write!(f, "InvalidContinuationToken"),
             Self::TooManyKeysInFilter => write!(f, "TooManyKeysInFilter"),
-            Self::ContractError => write!(f, "ContractError"),
+            Self::ContractError(_) => write!(f, "ContractError"),
             Self::ClassAlreadyDeclared => write!(f, "ClassAlreadyDeclared"),
             Self::InvalidTransactionNonce => write!(f, "InvalidTransactionNonce"),
             Self::InsufficientMaxFee => write!(f, "InsufficientMaxFee"),
@@ -1390,8 +1406,8 @@ impl core::fmt::Display for StarknetError {
             Self::CompiledClassHashMismatch => write!(f, "CompiledClassHashMismatch"),
             Self::UnsupportedTxVersion => write!(f, "UnsupportedTxVersion"),
             Self::UnsupportedContractClassVersion => write!(f, "UnsupportedContractClassVersion"),
-            Self::UnexpectedError => write!(f, "UnexpectedError"),
-            Self::NoTraceAvailable => write!(f, "NoTraceAvailable"),
+            Self::UnexpectedError(_) => write!(f, "UnexpectedError"),
+            Self::NoTraceAvailable(_) => write!(f, "NoTraceAvailable"),
             Self::InvalidTransactionHash => write!(f, "InvalidTransactionHash"),
         }
     }
@@ -1410,7 +1426,7 @@ impl StarknetError {
             Self::NoBlocks => "There are no blocks",
             Self::InvalidContinuationToken => "The supplied continuation token is invalid or unknown",
             Self::TooManyKeysInFilter => "Too many keys provided in a filter",
-            Self::ContractError => "Contract error",
+            Self::ContractError(_) => "Contract error",
             Self::ClassAlreadyDeclared => "Class already declared",
             Self::InvalidTransactionNonce => "Invalid transaction nonce",
             Self::InsufficientMaxFee => "Max fee is smaller than the minimal transaction cost (validation plus fee transfer)",
@@ -1423,8 +1439,8 @@ impl StarknetError {
             Self::CompiledClassHashMismatch => "the compiled class hash did not match the one supplied in the transaction",
             Self::UnsupportedTxVersion => "the transaction version is not supported",
             Self::UnsupportedContractClassVersion => "the contract class version is not supported",
-            Self::UnexpectedError => "An unexpected error occurred",
-            Self::NoTraceAvailable => "No trace available for transaction",
+            Self::UnexpectedError(_) => "An unexpected error occurred",
+            Self::NoTraceAvailable(_) => "No trace available for transaction",
             Self::InvalidTransactionHash => "Invalid transaction hash",
         }
     }

--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -16,18 +16,19 @@ mod codegen;
 pub use codegen::{
     BlockStatus, BlockTag, BlockWithTxHashes, BlockWithTxs, BroadcastedDeclareTransactionV1,
     BroadcastedDeclareTransactionV2, BroadcastedDeployAccountTransaction,
-    BroadcastedInvokeTransaction, CallType, CompressedLegacyContractClass, ContractStorageDiffItem,
-    DataAvailabilityMode, DeclareTransactionReceipt, DeclareTransactionTrace, DeclareTransactionV0,
-    DeclareTransactionV1, DeclareTransactionV2, DeclaredClassItem, DeployAccountTransaction,
-    DeployAccountTransactionReceipt, DeployAccountTransactionTrace, DeployTransaction,
-    DeployTransactionReceipt, DeployedContractItem, EmittedEvent, EntryPointType,
-    EntryPointsByType, Event, EventFilter, EventFilterWithPage, EventsChunk, ExecutionResources,
-    FeeEstimate, FlattenedSierraClass, FunctionCall, FunctionInvocation, FunctionStateMutability,
-    InvokeTransactionReceipt, InvokeTransactionTrace, InvokeTransactionV0, InvokeTransactionV1,
-    L1HandlerTransaction, L1HandlerTransactionReceipt, L1HandlerTransactionTrace,
-    LegacyContractEntryPoint, LegacyEntryPointsByType, LegacyEventAbiEntry, LegacyEventAbiType,
-    LegacyFunctionAbiEntry, LegacyFunctionAbiType, LegacyStructAbiEntry, LegacyStructAbiType,
-    LegacyStructMember, LegacyTypedParameter, MsgFromL1, MsgToL1, NonceUpdate, OrderedEvent,
+    BroadcastedInvokeTransaction, CallType, CompressedLegacyContractClass, ContractErrorData,
+    ContractStorageDiffItem, DataAvailabilityMode, DeclareTransactionReceipt,
+    DeclareTransactionTrace, DeclareTransactionV0, DeclareTransactionV1, DeclareTransactionV2,
+    DeclaredClassItem, DeployAccountTransaction, DeployAccountTransactionReceipt,
+    DeployAccountTransactionTrace, DeployTransaction, DeployTransactionReceipt,
+    DeployedContractItem, EmittedEvent, EntryPointType, EntryPointsByType, Event, EventFilter,
+    EventFilterWithPage, EventsChunk, ExecutionResources, FeeEstimate, FlattenedSierraClass,
+    FunctionCall, FunctionInvocation, FunctionStateMutability, InvokeTransactionReceipt,
+    InvokeTransactionTrace, InvokeTransactionV0, InvokeTransactionV1, L1HandlerTransaction,
+    L1HandlerTransactionReceipt, L1HandlerTransactionTrace, LegacyContractEntryPoint,
+    LegacyEntryPointsByType, LegacyEventAbiEntry, LegacyEventAbiType, LegacyFunctionAbiEntry,
+    LegacyFunctionAbiType, LegacyStructAbiEntry, LegacyStructAbiType, LegacyStructMember,
+    LegacyTypedParameter, MsgFromL1, MsgToL1, NoTraceAvailableErrorData, NonceUpdate, OrderedEvent,
     OrderedMessage, PendingBlockWithTxHashes, PendingBlockWithTxs,
     PendingDeclareTransactionReceipt, PendingDeployAccountTransactionReceipt,
     PendingInvokeTransactionReceipt, PendingL1HandlerTransactionReceipt, PendingStateUpdate,
@@ -513,42 +514,6 @@ impl TryFrom<&L1HandlerTransaction> for MsgToL2 {
 
     fn try_from(value: &L1HandlerTransaction) -> Result<Self, Self::Error> {
         value.parse_msg_to_l2()
-    }
-}
-
-impl TryFrom<i64> for StarknetError {
-    type Error = ();
-
-    fn try_from(value: i64) -> Result<Self, Self::Error> {
-        Ok(match value {
-            1 => StarknetError::FailedToReceiveTransaction,
-            20 => StarknetError::ContractNotFound,
-            24 => StarknetError::BlockNotFound,
-            27 => StarknetError::InvalidTransactionIndex,
-            28 => StarknetError::ClassHashNotFound,
-            29 => StarknetError::TransactionHashNotFound,
-            31 => StarknetError::PageSizeTooBig,
-            32 => StarknetError::NoBlocks,
-            33 => StarknetError::InvalidContinuationToken,
-            34 => StarknetError::TooManyKeysInFilter,
-            40 => StarknetError::ContractError,
-            51 => StarknetError::ClassAlreadyDeclared,
-            52 => StarknetError::InvalidTransactionNonce,
-            53 => StarknetError::InsufficientMaxFee,
-            54 => StarknetError::InsufficientAccountBalance,
-            55 => StarknetError::ValidationFailure,
-            56 => StarknetError::CompilationFailed,
-            57 => StarknetError::ContractClassSizeIsTooLarge,
-            58 => StarknetError::NonAccount,
-            59 => StarknetError::DuplicateTx,
-            60 => StarknetError::CompiledClassHashMismatch,
-            61 => StarknetError::UnsupportedTxVersion,
-            62 => StarknetError::UnsupportedContractClassVersion,
-            63 => StarknetError::UnexpectedError,
-            10 => StarknetError::NoTraceAvailable,
-            25 => StarknetError::InvalidTransactionHash,
-            _ => return Err(()),
-        })
     }
 }
 

--- a/starknet-providers/src/sequencer/mod.rs
+++ b/starknet-providers/src/sequencer/mod.rs
@@ -715,7 +715,7 @@ impl From<SequencerError> for ProviderError {
         let matching_code = match value.code {
             ErrorCode::BlockNotFound => Some(StarknetError::BlockNotFound),
             ErrorCode::EntryPointNotFoundInContract => None,
-            ErrorCode::InvalidProgram => Some(StarknetError::ContractError),
+            ErrorCode::InvalidProgram => None,
             ErrorCode::TransactionFailed => Some(StarknetError::ValidationFailure),
             ErrorCode::TransactionNotFound => Some(StarknetError::ContractNotFound),
             ErrorCode::UninitializedContract => Some(StarknetError::ContractNotFound),
@@ -726,7 +726,7 @@ impl From<SequencerError> for ProviderError {
             ErrorCode::CompilationFailed => Some(StarknetError::CompilationFailed),
             ErrorCode::InvalidCompiledClassHash => Some(StarknetError::CompiledClassHashMismatch),
             ErrorCode::DuplicatedTransaction => Some(StarknetError::DuplicateTx),
-            ErrorCode::InvalidContractClass => Some(StarknetError::ContractError),
+            ErrorCode::InvalidContractClass => None,
         };
 
         match matching_code {


### PR DESCRIPTION
Supersedes #483.

Certain `StarknetError` variants now wrap an inner type, allowing access to the `data` field from JSON-RPC error responses. These variants are:

- `ContractError`
- `UnexpectedError`
- `NoTraceAvailable`

among which `data` for `ContractError` would be the most useful for inspecting error details.