### PR TITLE
feat: re-export `Url` in `starknet-providers`

### DIFF
--- a/starknet-providers/src/lib.rs
+++ b/starknet-providers/src/lib.rs
@@ -13,3 +13,6 @@ pub use jsonrpc::JsonRpcClient;
 
 mod any;
 pub use any::AnyProvider;
+
+// Re-export
+pub use url::Url;


### PR DESCRIPTION
This type is needed to initialize a JSON-RPC client. Having this type re-exported makes it eaiser to use, as applications would not have to import the `url` crate themselves nor worry about the version.