### PR TITLE
refactor: remove unused `AccountTransaction` type

### DIFF
--- a/starknet-providers/src/sequencer/models/conversions.rs
+++ b/starknet-providers/src/sequencer/models/conversions.rs
@@ -455,20 +455,6 @@ impl TryFrom<TransactionFinalityStatus> for core::TransactionFinalityStatus {
     }
 }
 
-impl TryFrom<core::BroadcastedTransaction> for AccountTransaction {
-    type Error = ConversionError;
-
-    fn try_from(value: core::BroadcastedTransaction) -> Result<Self, Self::Error> {
-        match value {
-            core::BroadcastedTransaction::Invoke(inner) => Ok(Self::InvokeFunction(inner.into())),
-            core::BroadcastedTransaction::Declare(inner) => Ok(Self::Declare(inner.try_into()?)),
-            core::BroadcastedTransaction::DeployAccount(inner) => {
-                Ok(Self::DeployAccount(inner.into()))
-            }
-        }
-    }
-}
-
 impl From<core::BroadcastedInvokeTransaction> for InvokeFunctionTransactionRequest {
     fn from(value: core::BroadcastedInvokeTransaction) -> Self {
         Self {

--- a/starknet-providers/src/sequencer/models/mod.rs
+++ b/starknet-providers/src/sequencer/models/mod.rs
@@ -29,7 +29,7 @@ pub use contract_addresses::ContractAddresses;
 
 mod transaction_request;
 pub use transaction_request::{
-    AccountTransaction, AddTransactionResult, AddTransactionResultCode,
+    AddTransactionResult, AddTransactionResultCode,
     DeclareTransaction as DeclareTransactionRequest,
     DeclareV1Transaction as DeclareV1TransactionRequest,
     DeclareV2Transaction as DeclareV2TransactionRequest,

--- a/starknet-providers/src/sequencer/models/transaction_request.rs
+++ b/starknet-providers/src/sequencer/models/transaction_request.rs
@@ -27,6 +27,14 @@ const QUERY_VERSION_TWO: FieldElement = FieldElement::from_mont([
     576460752142433232,
 ]);
 
+/// 2 ^ 128 + 3
+const QUERY_VERSION_THREE: FieldElement = FieldElement::from_mont([
+    18446744073700081569,
+    17407,
+    18446744073709551584,
+    576460752142432688,
+]);
+
 #[serde_as]
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
@@ -52,16 +60,6 @@ pub enum AddTransactionResultCode {
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum TransactionRequest {
-    Declare(DeclareTransaction),
-    InvokeFunction(InvokeFunctionTransaction),
-    DeployAccount(DeployAccountTransaction),
-}
-
-/// Represents a transaction in the Starknet network that is originated from an action of an
-/// account.
-#[derive(Debug, Serialize)]
-#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum AccountTransaction {
     Declare(DeclareTransaction),
     InvokeFunction(InvokeFunctionTransaction),
     DeployAccount(DeployAccountTransaction),


### PR DESCRIPTION
This type has been made useless by #516. Forgot to remove it in that PR.