### PR TITLE
test: undo ignoring spec_version test

### DIFF
--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -22,7 +22,6 @@ fn create_jsonrpc_client() -> JsonRpcClient<HttpTransport> {
     JsonRpcClient::new(HttpTransport::new(Url::parse(&rpc_url).unwrap()))
 }
 
-#[ignore = "nodes are incorrectly returning `0.6.0-rc5`"]
 #[tokio::test]
 async fn jsonrpc_spec_version() {
     let rpc_client = create_jsonrpc_client();


### PR DESCRIPTION
Juno v0.8.1 now correctly serves `0.6.0`.