### PR TITLE
fix: skip serialization of continuation token if `None`

### DIFF
--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -106,7 +106,8 @@ pub struct EventsPage {
     /// Matching events
     pub events: Vec<EmittedEvent>,
     /// A pointer to the last element of the delivered page, use this token in a subsequent query to
-    /// obtain the next page
+    /// obtain the next page. If the value is `None`, don't add it to the response as clients might
+    /// use `contains_key` as a check for the last page.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub continuation_token: Option<String>,
 }

--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -107,6 +107,7 @@ pub struct EventsPage {
     pub events: Vec<EmittedEvent>,
     /// A pointer to the last element of the delivered page, use this token in a subsequent query to
     /// obtain the next page
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub continuation_token: Option<String>,
 }
 


### PR DESCRIPTION
In the Starknet Spec, the `continuation_token` is not a required field. So in the last event page, the `continuation_token` must be absent from the response instead of being null. I also tried this with the infura RPC (which uses pathfinder?) and works in the same way. We are integrating Madara with the explorer and that's breaking because of this.