### PR TITLE
feat: de/serialize based on human readability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,6 +2072,7 @@ name = "starknet-core"
 version = "0.11.1"
 dependencies = [
  "base64 0.21.0",
+ "bincode",
  "criterion",
  "crypto-bigint",
  "flate2",

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -30,6 +30,7 @@ sha3 = { version = "0.10.7", default-features = false }
 starknet-types-core = { version = "0.1.3", default-features = false, features = ["curve", "serde", "num-traits"] }
 
 [dev-dependencies]
+bincode = "1.3.3"
 criterion = { version = "0.4.0", default-features = false }
 hex-literal = "0.4.1"
 starknet-core = { path = ".", features = ["no_unknown_fields"] }

--- a/starknet-core/src/serde/num_hex.rs
+++ b/starknet-core/src/serde/num_hex.rs
@@ -1,5 +1,6 @@
 pub mod u64 {
     use alloc::{fmt::Formatter, format};
+    use core::mem;
 
     use serde::{de::Visitor, Deserializer, Serializer};
 
@@ -9,21 +10,29 @@ pub mod u64 {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&format!("{value:#x}"))
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&format!("{value:#x}"))
+        } else {
+            serializer.serialize_bytes(&value.to_be_bytes())
+        }
     }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_any(NumHexVisitor)
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_any(NumHexVisitor)
+        } else {
+            deserializer.deserialize_bytes(NumHexVisitor)
+        }
     }
 
     impl<'de> Visitor<'de> for NumHexVisitor {
         type Value = u64;
 
         fn expecting(&self, formatter: &mut Formatter) -> alloc::fmt::Result {
-            write!(formatter, "string")
+            write!(formatter, "string, or an array of u8")
         }
 
         fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
@@ -32,6 +41,12 @@ pub mod u64 {
         {
             u64::from_str_radix(v.trim_start_matches("0x"), 16)
                 .map_err(|err| serde::de::Error::custom(format!("invalid u64 hex string: {err}")))
+        }
+
+        fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+            <[u8; mem::size_of::<u64>()]>::try_from(v)
+                .map(u64::from_be_bytes)
+                .map_err(serde::de::Error::custom)
         }
     }
 }

--- a/starknet-core/src/serde/num_hex.rs
+++ b/starknet-core/src/serde/num_hex.rs
@@ -50,3 +50,29 @@ pub mod u64 {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use hex_literal::hex;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize)]
+    struct TestStruct(#[serde(with = "u64")] pub u64);
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    fn bin_ser() {
+        let r = bincode::serialize(&TestStruct(0x1234)).unwrap();
+        assert_eq!(r, hex!("0800000000000000 0000000000001234"));
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    fn bin_deser() {
+        let r =
+            bincode::deserialize::<TestStruct>(&hex!("0800000000000000 0000000000001234")).unwrap();
+        assert_eq!(r.0, 0x1234);
+    }
+}

--- a/starknet-core/src/types/hash_256.rs
+++ b/starknet-core/src/types/hash_256.rs
@@ -200,6 +200,8 @@ impl From<[u8; HASH_256_BYTE_COUNT]> for Hash256 {
 mod tests {
     use super::{Felt, FromHexError, Hash256, HASH_256_BYTE_COUNT};
 
+    use hex_literal::hex;
+
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_hash_256_from_hex_error_unexpected_length() {
@@ -256,5 +258,33 @@ mod tests {
 
         // Assert that the conversion from the `Felt` to `Hash256` is successful
         assert_eq!(Hash256::from_felt(&felt), hash_256);
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    fn bin_ser() {
+        let r = bincode::serialize(&Hash256::from_bytes(hex!(
+            "1111111111111111111111111111111111111111111111111111111111111111"
+        )))
+        .unwrap();
+        assert_eq!(
+            r,
+            hex!(
+                "2000000000000000 1111111111111111111111111111111111111111111111111111111111111111"
+            )
+        );
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    fn bin_deser() {
+        let r = bincode::deserialize::<Hash256>(&hex!(
+            "2000000000000000 1111111111111111111111111111111111111111111111111111111111111111"
+        ))
+        .unwrap();
+        assert_eq!(
+            r.inner,
+            hex!("1111111111111111111111111111111111111111111111111111111111111111")
+        );
     }
 }

--- a/starknet-core/src/types/hash_256.rs
+++ b/starknet-core/src/types/hash_256.rs
@@ -78,7 +78,11 @@ impl Serialize for Hash256 {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&format!("0x{}", hex::encode(self.inner)))
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&format!("0x{}", hex::encode(self.inner)))
+        } else {
+            serializer.serialize_bytes(self.as_bytes())
+        }
     }
 }
 
@@ -87,7 +91,11 @@ impl<'de> Deserialize<'de> for Hash256 {
     where
         D: serde::Deserializer<'de>,
     {
-        deserializer.deserialize_any(Hash256Visitor)
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_any(Hash256Visitor)
+        } else {
+            deserializer.deserialize_bytes(Hash256Visitor)
+        }
     }
 }
 
@@ -95,7 +103,7 @@ impl<'de> Visitor<'de> for Hash256Visitor {
     type Value = Hash256;
 
     fn expecting(&self, formatter: &mut Formatter) -> alloc::fmt::Result {
-        write!(formatter, "string")
+        write!(formatter, "string, or an array of u8")
     }
 
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
@@ -104,6 +112,12 @@ impl<'de> Visitor<'de> for Hash256Visitor {
     {
         v.parse()
             .map_err(|err| serde::de::Error::custom(format!("{}", err)))
+    }
+
+    fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+        <[u8; HASH_256_BYTE_COUNT]>::try_from(v)
+            .map(Hash256::from_bytes)
+            .map_err(serde::de::Error::custom)
     }
 }
 


### PR DESCRIPTION
This PR improves the serde impls used to mainly de/serialize the `FieldElement` type. The de/serialization implementations now take into consideration whether `Serialize`/`Deserialize` implementations should expect to de/serialize in human-readable form or not.

This possibly(?) introduces a breaking change due to this PR #527.