### PR TITLE
fix: failed deserialization when `accessible_scopes` is missing

### DIFF
--- a/starknet-core/src/types/contract/legacy.rs
+++ b/starknet-core/src/types/contract/legacy.rs
@@ -78,6 +78,7 @@ pub struct RawLegacyEntryPoint {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct LegacyAttribute {
+    #[serde(default)]
     pub accessible_scopes: Vec<String>,
     pub end_pc: u64,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Fixes #533.

Some legacy contract classes are missing this field. Thankfully, this patch does not affect class hash calculation, as `accessible_scopes` is skipped when empty in the first place.