### PR TITLE
feat: private field access for `RawXxx` types

### DIFF
--- a/starknet-accounts/src/account/declaration.rs
+++ b/starknet-accounts/src/account/declaration.rs
@@ -445,6 +445,22 @@ impl RawDeclaration {
             self.compiled_class_hash,
         ])
     }
+
+    pub fn contract_class(&self) -> &FlattenedSierraClass {
+        &self.contract_class
+    }
+
+    pub fn compiled_class_hash(&self) -> FieldElement {
+        self.compiled_class_hash
+    }
+
+    pub fn nonce(&self) -> FieldElement {
+        self.nonce
+    }
+
+    pub fn max_fee(&self) -> FieldElement {
+        self.max_fee
+    }
 }
 
 impl RawLegacyDeclaration {
@@ -468,6 +484,18 @@ impl RawLegacyDeclaration {
             chain_id,
             self.nonce,
         ]))
+    }
+
+    pub fn contract_class(&self) -> &LegacyContractClass {
+        &self.contract_class
+    }
+
+    pub fn nonce(&self) -> FieldElement {
+        self.nonce
+    }
+
+    pub fn max_fee(&self) -> FieldElement {
+        self.max_fee
     }
 }
 

--- a/starknet-accounts/src/account/execution.rs
+++ b/starknet-accounts/src/account/execution.rs
@@ -246,6 +246,18 @@ impl RawExecution {
             self.nonce,
         ])
     }
+
+    pub fn calls(&self) -> &[Call] {
+        &self.calls
+    }
+
+    pub fn nonce(&self) -> FieldElement {
+        self.nonce
+    }
+
+    pub fn max_fee(&self) -> FieldElement {
+        self.max_fee
+    }
 }
 
 impl<'a, A> PreparedExecution<'a, A>

--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -325,6 +325,20 @@ where
     }
 }
 
+impl RawAccountDeployment {
+    pub fn salt(&self) -> FieldElement {
+        self.salt
+    }
+
+    pub fn nonce(&self) -> FieldElement {
+        self.nonce
+    }
+
+    pub fn max_fee(&self) -> FieldElement {
+        self.max_fee
+    }
+}
+
 impl<'f, F> PreparedAccountDeployment<'f, F> {
     pub fn from_raw(raw_deployment: RawAccountDeployment, factory: &'f F) -> Self {
         Self {


### PR DESCRIPTION
Certain custom `Account` implementations require access to these internal fields, as they do more than just signing on the transaction hash. Exposing these fields offers the maximum flexibility on how accounts sign transactions.

Not exposing these fields results in exotic implementations like [this one](https://github.com/neotheprogramist/cairo-webauthn/pull/21/files#r1440597653). So it's really not good.

Adding getters instead of just making the fields `pub` though, to still retain a certain degree of encapsulation.