### PR TITLE
chore: update examples to use jsonrpc and cairo 1 accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Examples can be found in the [examples folder](./examples):
 
 6. [Query the latest block number with JSON-RPC](./examples/jsonrpc.rs)
 
-7. [Call a contract view function via sequencer gateway](./examples/sequencer_erc20_balance.rs)
+7. [Call a contract view function](./examples/erc20_balance.rs)
 
 8. [Deploy an Argent X account to a pre-funded address](./examples/deploy_argent_account.rs)
 

--- a/examples/declare_cairo0_contract.rs
+++ b/examples/declare_cairo0_contract.rs
@@ -6,7 +6,10 @@ use starknet::{
         chain_id,
         types::{contract::legacy::LegacyContractClass, BlockId, BlockTag, FieldElement},
     },
-    providers::SequencerGatewayProvider,
+    providers::{
+        jsonrpc::{HttpTransport, JsonRpcClient},
+        Url,
+    },
     signers::{LocalWallet, SigningKey},
 };
 
@@ -15,7 +18,10 @@ async fn main() {
     let contract_artifact: LegacyContractClass =
         serde_json::from_reader(std::fs::File::open("/path/to/contract/artifact.json").unwrap())
             .unwrap();
-    let provider = SequencerGatewayProvider::starknet_alpha_goerli();
+    let provider = JsonRpcClient::new(HttpTransport::new(
+        Url::parse("https://starknet-testnet.public.blastapi.io/rpc/v0_6").unwrap(),
+    ));
+
     let signer = LocalWallet::from(SigningKey::from_secret_scalar(
         FieldElement::from_hex_be("YOUR_PRIVATE_KEY_IN_HEX_HERE").unwrap(),
     ));
@@ -26,7 +32,7 @@ async fn main() {
         signer,
         address,
         chain_id::TESTNET,
-        ExecutionEncoding::Legacy,
+        ExecutionEncoding::New,
     );
 
     // `SingleOwnerAccount` defaults to checking nonce and estimating fees against the latest

--- a/examples/declare_cairo1_contract.rs
+++ b/examples/declare_cairo1_contract.rs
@@ -6,7 +6,10 @@ use starknet::{
         chain_id,
         types::{contract::SierraClass, BlockId, BlockTag, FieldElement},
     },
-    providers::SequencerGatewayProvider,
+    providers::{
+        jsonrpc::{HttpTransport, JsonRpcClient},
+        Url,
+    },
     signers::{LocalWallet, SigningKey},
 };
 
@@ -21,7 +24,10 @@ async fn main() {
     let compiled_class_hash =
         FieldElement::from_hex_be("COMPILED_CASM_CLASS_HASH_IN_HEX_HERE").unwrap();
 
-    let provider = SequencerGatewayProvider::starknet_alpha_goerli();
+    let provider = JsonRpcClient::new(HttpTransport::new(
+        Url::parse("https://starknet-testnet.public.blastapi.io/rpc/v0_6").unwrap(),
+    ));
+
     let signer = LocalWallet::from(SigningKey::from_secret_scalar(
         FieldElement::from_hex_be("YOUR_PRIVATE_KEY_IN_HEX_HERE").unwrap(),
     ));
@@ -32,7 +38,7 @@ async fn main() {
         signer,
         address,
         chain_id::TESTNET,
-        ExecutionEncoding::Legacy,
+        ExecutionEncoding::New,
     );
 
     // `SingleOwnerAccount` defaults to checking nonce and estimating fees against the latest

--- a/examples/deploy_argent_account.rs
+++ b/examples/deploy_argent_account.rs
@@ -2,7 +2,10 @@ use starknet::{
     accounts::{AccountFactory, ArgentAccountFactory},
     core::{chain_id, types::FieldElement},
     macros::felt,
-    providers::SequencerGatewayProvider,
+    providers::{
+        jsonrpc::{HttpTransport, JsonRpcClient},
+        Url,
+    },
     signers::{LocalWallet, SigningKey},
 };
 
@@ -14,7 +17,10 @@ async fn main() {
     // Anything you like here as salt
     let salt = felt!("12345678");
 
-    let provider = SequencerGatewayProvider::starknet_alpha_goerli();
+    let provider = JsonRpcClient::new(HttpTransport::new(
+        Url::parse("https://starknet-testnet.public.blastapi.io/rpc/v0_6").unwrap(),
+    ));
+
     let signer = LocalWallet::from(SigningKey::from_secret_scalar(
         FieldElement::from_hex_be("YOUR_PRIVATE_KEY_IN_HEX_HERE").unwrap(),
     ));

--- a/examples/deploy_contract.rs
+++ b/examples/deploy_contract.rs
@@ -8,7 +8,10 @@ use starknet::{
         types::{contract::legacy::LegacyContractClass, BlockId, BlockTag, FieldElement},
     },
     macros::felt,
-    providers::SequencerGatewayProvider,
+    providers::{
+        jsonrpc::{HttpTransport, JsonRpcClient},
+        Url,
+    },
     signers::{LocalWallet, SigningKey},
 };
 
@@ -20,7 +23,10 @@ async fn main() {
             .unwrap();
     let class_hash = contract_artifact.class_hash().unwrap();
 
-    let provider = SequencerGatewayProvider::starknet_alpha_goerli();
+    let provider = JsonRpcClient::new(HttpTransport::new(
+        Url::parse("https://starknet-testnet.public.blastapi.io/rpc/v0_6").unwrap(),
+    ));
+
     let signer = LocalWallet::from(SigningKey::from_secret_scalar(
         FieldElement::from_hex_be("YOUR_PRIVATE_KEY_IN_HEX_HERE").unwrap(),
     ));
@@ -30,7 +36,7 @@ async fn main() {
         signer,
         address,
         chain_id::TESTNET,
-        ExecutionEncoding::Legacy,
+        ExecutionEncoding::New,
     );
 
     // `SingleOwnerAccount` defaults to checking nonce and estimating fees against the latest

--- a/examples/erc20_balance.rs
+++ b/examples/erc20_balance.rs
@@ -1,12 +1,18 @@
 use starknet::{
     core::types::{BlockId, BlockTag, FieldElement, FunctionCall},
     macros::{felt, selector},
-    providers::{Provider, SequencerGatewayProvider},
+    providers::{
+        jsonrpc::{HttpTransport, JsonRpcClient},
+        Provider, Url,
+    },
 };
 
 #[tokio::main]
 async fn main() {
-    let provider = SequencerGatewayProvider::starknet_alpha_goerli();
+    let provider = JsonRpcClient::new(HttpTransport::new(
+        Url::parse("https://starknet-testnet.public.blastapi.io/rpc/v0_6").unwrap(),
+    ));
+
     let tst_token_address =
         felt!("0x07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10");
 

--- a/examples/get_block.rs
+++ b/examples/get_block.rs
@@ -1,11 +1,17 @@
 use starknet::{
     core::types::{BlockId, BlockTag},
-    providers::{Provider, SequencerGatewayProvider},
+    providers::{
+        jsonrpc::{HttpTransport, JsonRpcClient},
+        Provider, Url,
+    },
 };
 
 #[tokio::main]
 async fn main() {
-    let provider = SequencerGatewayProvider::starknet_alpha_goerli();
+    let provider = JsonRpcClient::new(HttpTransport::new(
+        Url::parse("https://starknet-testnet.public.blastapi.io/rpc/v0_6").unwrap(),
+    ));
+
     let latest_block = provider
         .get_block_with_tx_hashes(BlockId::Tag(BlockTag::Latest))
         .await;

--- a/examples/jsonrpc.rs
+++ b/examples/jsonrpc.rs
@@ -1,16 +1,14 @@
-use starknet_providers::{
+use starknet::providers::{
     jsonrpc::{HttpTransport, JsonRpcClient},
-    Provider,
+    Provider, Url,
 };
-use url::Url;
 
 #[tokio::main]
 async fn main() {
-    let rpc_client = JsonRpcClient::new(HttpTransport::new(
-        Url::parse("https://starknet-goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161")
-            .unwrap(),
+    let provider = JsonRpcClient::new(HttpTransport::new(
+        Url::parse("https://starknet-testnet.public.blastapi.io/rpc/v0_6").unwrap(),
     ));
 
-    let block_number = rpc_client.block_number().await.unwrap();
+    let block_number = provider.block_number().await.unwrap();
     println!("{block_number}");
 }

--- a/examples/mint_tokens.rs
+++ b/examples/mint_tokens.rs
@@ -5,13 +5,19 @@ use starknet::{
         types::{BlockId, BlockTag, FieldElement},
         utils::get_selector_from_name,
     },
-    providers::SequencerGatewayProvider,
+    providers::{
+        jsonrpc::{HttpTransport, JsonRpcClient},
+        Url,
+    },
     signers::{LocalWallet, SigningKey},
 };
 
 #[tokio::main]
 async fn main() {
-    let provider = SequencerGatewayProvider::starknet_alpha_goerli();
+    let provider = JsonRpcClient::new(HttpTransport::new(
+        Url::parse("https://starknet-testnet.public.blastapi.io/rpc/v0_6").unwrap(),
+    ));
+
     let signer = LocalWallet::from(SigningKey::from_secret_scalar(
         FieldElement::from_hex_be("YOUR_PRIVATE_KEY_IN_HEX_HERE").unwrap(),
     ));
@@ -26,7 +32,7 @@ async fn main() {
         signer,
         address,
         chain_id::TESTNET,
-        ExecutionEncoding::Legacy,
+        ExecutionEncoding::New,
     );
 
     // `SingleOwnerAccount` defaults to checking nonce and estimating fees against the latest


### PR DESCRIPTION
The current examples use the sequencer gateway, which has already been deprecated, and does not work in most cases.

> [!NOTE]
>
> It technically still works in the `get_block` example. But it's better to teach a new user to use JSON-RPC for that.

The PR also updates the account encoding from `Legacy` to `New`, considering that new users now most likely have Cairo 1 accounts.