### PR TITLE
Fix `from_affine_point` infinity definition

### DIFF
--- a/starknet-curve/src/ec_point.rs
+++ b/starknet-curve/src/ec_point.rs
@@ -155,7 +155,7 @@ impl ProjectivePoint {
             x: p.x,
             y: p.y,
             z: FieldElement::ONE,
-            infinity: false,
+            infinity: p.infinity,
         }
     }
 


### PR DESCRIPTION
At the moment, to construct a projective point from an affine point, the `from_affine_point` always consider `infinity` as false. 

However, this will be wrong if the affine point is the identity point, for which `infinity` has to be `true`. 

For this purpose, the `from_affine_point` method is modified to always take into account the `infinity` attribute from the provided `p` affine point during the construction of the projective point.