### PR TITLE
release: bump starknet-curve to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-curve"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "starknet-ff",
 ]

--- a/starknet-crypto-codegen/Cargo.toml
+++ b/starknet-crypto-codegen/Cargo.toml
@@ -16,6 +16,6 @@ keywords = ["ethereum", "starknet", "web3", "no_std"]
 proc-macro = true
 
 [dependencies]
-starknet-curve = { version = "0.4.0", path = "../starknet-curve" }
+starknet-curve = { version = "0.4.1", path = "../starknet-curve" }
 starknet-ff = { version = "0.3.6", path = "../starknet-ff", default-features = false }
 syn = { version = "2.0.15", default-features = false }

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["test-data/**"]
 
 [dependencies]
 starknet-crypto-codegen = { version = "0.3.2", path = "../starknet-crypto-codegen" }
-starknet-curve = { version = "0.4.0", path = "../starknet-curve" }
+starknet-curve = { version = "0.4.1", path = "../starknet-curve" }
 starknet-ff = { version = "0.3.6", path = "../starknet-ff", default-features = false }
 crypto-bigint = { version = "0.5.1", default-features = false, features = ["generic-array", "zeroize"] }
 hmac = { version = "0.12.1", default-features = false }

--- a/starknet-curve/Cargo.toml
+++ b/starknet-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-curve"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
To make #542 and #543 available on [crates.io](https://crates.io/).