### PR TITLE
feat: `double` method for `FieldElement`

### DIFF
--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -298,11 +298,7 @@ async fn can_execute_tst_mint_inner<P: Provider + Send + Sync>(provider: P, addr
             Call {
                 to: tst_token_address,
                 selector: get_selector_from_name("mint").unwrap(),
-                calldata: vec![
-                    address,
-                    random_amount * FieldElement::TWO,
-                    FieldElement::ZERO,
-                ],
+                calldata: vec![address, random_amount.double(), FieldElement::ZERO],
             },
         ])
         .send()

--- a/starknet-crypto-codegen/src/poseidon/mod.rs
+++ b/starknet-crypto-codegen/src/poseidon/mod.rs
@@ -75,8 +75,8 @@ pub fn compress_roundkeys_partial(rcs: &[[FieldElement; 3]]) -> Vec<FieldElement
 
         // MixLayer
         let t = state[0] + state[1] + state[2];
-        state[0] = t + FieldElement::TWO * state[0];
-        state[1] = t - FieldElement::TWO * state[1];
+        state[0] = t + state[0].double();
+        state[1] = t - state[1].double();
         state[2] = t - FieldElement::THREE * state[2];
 
         idx += 1;

--- a/starknet-crypto/src/poseidon_hash.rs
+++ b/starknet-crypto/src/poseidon_hash.rs
@@ -119,8 +119,8 @@ pub fn poseidon_permute_comp(state: &mut [FieldElement; 3]) {
 #[inline(always)]
 fn mix(state: &mut [FieldElement; 3]) {
     let t = state[0] + state[1] + state[2];
-    state[0] = t + FieldElement::TWO * state[0];
-    state[1] = t - FieldElement::TWO * state[1];
+    state[0] = t + state[0].double();
+    state[1] = t - state[1].double();
     state[2] = t - FieldElement::THREE * state[2];
 }
 

--- a/starknet-curve/src/ec_point.rs
+++ b/starknet-curve/src/ec_point.rs
@@ -46,7 +46,7 @@ impl AffinePoint {
         // l = (3x^2+a)/2y with a=1 from stark curve
         let lambda = {
             let dividend = FieldElement::THREE * (self.x * self.x) + FieldElement::ONE;
-            let divisor_inv = (FieldElement::TWO * self.y).invert().unwrap();
+            let divisor_inv = self.y.double().invert().unwrap();
             dividend * divisor_inv
         };
 
@@ -167,14 +167,14 @@ impl ProjectivePoint {
 
         // t=3x^2+az^2 with a=1 from stark curve
         let t = FieldElement::THREE * self.x * self.x + self.z * self.z;
-        let u = FieldElement::TWO * self.y * self.z;
-        let v = FieldElement::TWO * u * self.x * self.y;
-        let w = t * t - FieldElement::TWO * v;
+        let u = self.y.double() * self.z;
+        let v = u.double() * self.x * self.y;
+        let w = t * t - v.double();
 
         let uy = u * self.y;
 
         let x = u * w;
-        let y = t * (v - w) - FieldElement::TWO * uy * uy;
+        let y = t * (v - w) - (uy * uy).double();
         let z = u * u * u;
 
         self.x = x;

--- a/starknet-ff/src/lib.rs
+++ b/starknet-ff/src/lib.rs
@@ -268,6 +268,10 @@ impl FieldElement {
         self.inner.sqrt().map(|inner| Self { inner })
     }
 
+    pub fn double(&self) -> FieldElement {
+        *self + *self
+    }
+
     /// Performs a floor division. It's not implemented as the `Div` trait on purpose to
     /// distinguish from the "felt division".
     pub fn floor_div(&self, rhs: FieldElement) -> FieldElement {


### PR DESCRIPTION
## Description
This pull request proposes a performance enhancement in the implementation of elliptic curve operations. Instead of using a full multiplication operation like `FieldElement::TWO * a` to handle doubling (2 * a), it suggests utilizing the `double` method available in the `FieldElement` struct. 

The rationale behind this enhancement is that the doubling operation (a + a) requires only one addition between field elements, which is more performant compared to a full multiplication. Therefore, replacing multiplication with addition can improve the efficiency of various computations involving point doubling in elliptic curve arithmetic.

## Changes Made
- Added logic to utilize the `double` method from the `FieldElement` struct for doubling operations.
- Updated relevant computations to use the `double` method where appropriate.

