### PR TITLE
fix `PartialEq` impl for `AffinePoint` and `ProjectivePoint`

### DIFF
--- a/starknet-curve/src/ec_point.rs
+++ b/starknet-curve/src/ec_point.rs
@@ -167,12 +167,8 @@ impl PartialEq for ProjectivePoint {
             // An infinity point is not equal to a non-infinity point
             false
         } else {
-            // Calculate the inverse of z-coordinates
-            let z1inv = self.z.invert().unwrap();
-            let z2inv = other.z.invert().unwrap();
-
             // Compare the affine coordinates after applying the inverse of z-coordinates
-            self.x * z1inv == other.x * z2inv && self.y * z1inv == other.y * z2inv
+            self.x * other.z == other.x * self.z && self.y * other.z == other.y * self.z
         }
     }
 }


### PR DESCRIPTION
The `PartialEq` implementation is fixed for `AffinePoint` and `ProjectivePoint`

## Affine point representation

The `PartialEq` implementation is now not a simple derive but make the distinction between the infinity point and the other ones. For example (x: 1, y: 1, infinity: true) is considered equal to (x: 0, y: 0, infinity: true), if some reason such a scenario appears.

## Projective point representation

To check the equality of two points in projective representation, we have to multiply their respective x and y coordinates by their respective inverse of z in order to check the affine representation equality. For example, after some complex addition operation we could have:

- Point a: 
  - x: 1394885022820639888765864371787689253101079535605283429611290729169507199360
  - y: 3466468409258328941622611406382978541902641685460921658285130930497545127668
  - z: 2532798222741610990383047470051945227491955848255645468485242650998822377849
- Point b:
   - x: 181578671923351648088952251904405911647497904112889633530092804788888441313
   - y: 2834849044294229940592685914514626411034039923955499829698293302166695198377
   - z: 1606417725416313442233979084605483699902284981317231601514960254041079595126

Using the simple derivation of Eq and PartialEq traits that are in place at the moment, these points are not equal but, when multiplying them by their respective inverse of z they become:
- Point a: 
  - x: 2328614212890281406876832064084728120079899729645276919808500334657851012613
  - y: 1453813542945687218449843192838234282733589904309829900785153066025232406547
- Point b:
   - x: 2328614212890281406876832064084728120079899729645276919808500334657851012613
   - y: 1453813542945687218449843192838234282733589904309829900785153066025232406547

An so finally they are equal