### PR TITLE
fix `add_assign` impl between projective points

### DIFF
--- a/starknet-curve/src/ec_point.rs
+++ b/starknet-curve/src/ec_point.rs
@@ -208,11 +208,10 @@ impl ops::AddAssign<&AffinePoint> for ProjectivePoint {
         if u0 == u1 {
             if t0 != t1 {
                 self.infinity = true;
-                return;
             } else {
                 self.double_assign();
-                return;
             }
+            return;
         }
 
         let t = t0 - t1;
@@ -245,7 +244,7 @@ impl ops::AddAssign<&ProjectivePoint> for ProjectivePoint {
         let u0 = self.x * rhs.z;
         let u1 = rhs.x * self.z;
         if u0 == u1 {
-            if self.y == rhs.y {
+            if self.y * rhs.z == rhs.y * self.z {
                 self.double_assign();
             } else {
                 *self = ProjectivePoint::identity();


### PR DESCRIPTION
During `add_assign` implementation, z1 and z2 don't have to be equal. As a result, when `u0 == u1`, simply testing ` self.y == rhs.y` to confirm that a point doubling is needed is false. 

If we have y1 = y2, z1 != z2 can lead to `self.y * rhs.z != rhs.y * self.z`, hence identity needs to be returned. 

This PR fixes this.