### PR TITLE
Improve projective mul by scalar perf

### DIFF
--- a/starknet-curve/src/ec_point.rs
+++ b/starknet-curve/src/ec_point.rs
@@ -138,7 +138,7 @@ impl ops::Mul<&[bool]> for &AffinePoint {
     #[allow(clippy::suspicious_arithmetic_impl)]
     fn mul(self, rhs: &[bool]) -> Self::Output {
         let mut product = AffinePoint::identity();
-        for b in rhs.iter().rev() {
+        for b in rhs.iter().rev().skip_while(|b| !*b) {
             product.double_assign();
             if *b {
                 product += self;
@@ -284,7 +284,7 @@ impl ops::Mul<&[bool]> for &ProjectivePoint {
     #[allow(clippy::suspicious_arithmetic_impl)]
     fn mul(self, rhs: &[bool]) -> Self::Output {
         let mut product = ProjectivePoint::identity();
-        for b in rhs.iter().rev() {
+        for b in rhs.iter().rev().skip_while(|b| !*b) {
             product.double_assign();
             if *b {
                 product += self;


### PR DESCRIPTION
During the multiplication of a projective point by a scalar, the leading zeros can be skipped in the loop, because they induce unnecessary doubling calculations, giving always the identity value back before the first non zero element is reached in the `rhs` boolean array.

Skipping this useless calculations can reduce drastically the calculation costs, especially for small numbers (for example, is our scalar is 1, then 255 useless doubling are performed).