### PR TITLE
Refactor Pedersen hash and add test case

### DIFF
--- a/starknet-crypto/src/pedersen_hash.rs
+++ b/starknet-crypto/src/pedersen_hash.rs
@@ -21,7 +21,11 @@ pub fn pedersen_hash(x: &FieldElement, y: &FieldElement) -> FieldElement {
         bits.chunks(CURVE_CONSTS_BITS)
             .enumerate()
             .for_each(|(i, v)| {
-                let offset = bools_to_usize_le(v);
+                let offset = v
+                    .iter()
+                    .rev()
+                    .fold(0, |acc, &bit| (acc << 1) + bit as usize);
+
                 if offset > 0 {
                     // Table lookup at 'offset-1' in table for chunk 'i'
                     *acc += &prep[i * table_size + offset - 1];
@@ -36,22 +40,8 @@ pub fn pedersen_hash(x: &FieldElement, y: &FieldElement) -> FieldElement {
     add_points(&mut acc, &y[..248], &CURVE_CONSTS_P2); // Add b_low * P3
     add_points(&mut acc, &y[248..252], &CURVE_CONSTS_P3); // Add b_high * P4
 
-    // Convert to affine
-    let result = AffinePoint::from(&acc);
-
     // Return x-coordinate
-    result.x
-}
-
-#[inline]
-fn bools_to_usize_le(bools: &[bool]) -> usize {
-    let mut result: usize = 0;
-    for (ind, bit) in bools.iter().enumerate() {
-        if *bit {
-            result += 1 << ind;
-        }
-    }
-    result
+    AffinePoint::from(&acc).x
 }
 
 #[cfg(test)]
@@ -60,11 +50,11 @@ mod tests {
     use crate::test_utils::field_element_from_be_hex;
 
     // Test case ported from:
-    //   https://github.com/starkware-libs/crypto-cpp/blob/95864fbe11d5287e345432dbe1e80dea3c35fc58/src/starkware/crypto/ffi/crypto_lib_test.go
+    //   https://github.com/starkware-libs/starkex-for-spot-trading/blob/master/src/starkware/crypto/starkware/crypto/signature/test/config/signature_test_data.json
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    fn test_pedersen_hash() {
+    fn test_pedersen_hash_1() {
         let in1 = field_element_from_be_hex(
             "03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb",
         );
@@ -73,6 +63,22 @@ mod tests {
         );
         let expected_hash = field_element_from_be_hex(
             "030e480bed5fe53fa909cc0f8c4d99b8f9f2c016be4c41e13a4848797979c662",
+        );
+
+        assert_eq!(pedersen_hash(&in1, &in2), expected_hash);
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    fn test_pedersen_hash_2() {
+        let in1 = field_element_from_be_hex(
+            "058f580910a6ca59b28927c08fe6c43e2e303ca384badc365795fc645d479d45",
+        );
+        let in2 = field_element_from_be_hex(
+            "078734f65a067be9bdb39de18434d71e79f7b6466a4b66bbd979ab9e7515fe0b",
+        );
+        let expected_hash = field_element_from_be_hex(
+            "068cc0b76cddd1dd4ed2301ada9b7c872b23875d5ff837b3a87993e0d9996b87",
         );
 
         assert_eq!(pedersen_hash(&in1, &in2), expected_hash);

--- a/starknet-crypto/src/pedersen_hash.rs
+++ b/starknet-crypto/src/pedersen_hash.rs
@@ -50,37 +50,30 @@ mod tests {
     use crate::test_utils::field_element_from_be_hex;
 
     // Test case ported from:
-    //   https://github.com/starkware-libs/starkex-for-spot-trading/blob/master/src/starkware/crypto/starkware/crypto/signature/test/config/signature_test_data.json
+    //   https://github.com/starkware-libs/starkex-for-spot-trading/blob/607f0b4ce507e1d95cd018d206a2797f6ba4aab4/src/starkware/crypto/starkware/crypto/signature/test/config/signature_test_data.json
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    fn test_pedersen_hash_1() {
-        let in1 = field_element_from_be_hex(
-            "03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb",
-        );
-        let in2 = field_element_from_be_hex(
-            "0208a0a10250e382e1e4bbe2880906c2791bf6275695e02fbbc6aeff9cd8b31a",
-        );
-        let expected_hash = field_element_from_be_hex(
-            "030e480bed5fe53fa909cc0f8c4d99b8f9f2c016be4c41e13a4848797979c662",
-        );
+    fn test_pedersen_hash() {
+        let test_data = [
+            (
+                "03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb",
+                "0208a0a10250e382e1e4bbe2880906c2791bf6275695e02fbbc6aeff9cd8b31a",
+                "030e480bed5fe53fa909cc0f8c4d99b8f9f2c016be4c41e13a4848797979c662",
+            ),
+            (
+                "058f580910a6ca59b28927c08fe6c43e2e303ca384badc365795fc645d479d45",
+                "078734f65a067be9bdb39de18434d71e79f7b6466a4b66bbd979ab9e7515fe0b",
+                "068cc0b76cddd1dd4ed2301ada9b7c872b23875d5ff837b3a87993e0d9996b87",
+            ),
+        ];
 
-        assert_eq!(pedersen_hash(&in1, &in2), expected_hash);
-    }
+        for (in1, in2, expected_hash) in test_data.into_iter() {
+            let in1 = field_element_from_be_hex(in1);
+            let in2 = field_element_from_be_hex(in2);
+            let expected_hash = field_element_from_be_hex(expected_hash);
 
-    #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    fn test_pedersen_hash_2() {
-        let in1 = field_element_from_be_hex(
-            "058f580910a6ca59b28927c08fe6c43e2e303ca384badc365795fc645d479d45",
-        );
-        let in2 = field_element_from_be_hex(
-            "078734f65a067be9bdb39de18434d71e79f7b6466a4b66bbd979ab9e7515fe0b",
-        );
-        let expected_hash = field_element_from_be_hex(
-            "068cc0b76cddd1dd4ed2301ada9b7c872b23875d5ff837b3a87993e0d9996b87",
-        );
-
-        assert_eq!(pedersen_hash(&in1, &in2), expected_hash);
+            assert_eq!(pedersen_hash(&in1, &in2), expected_hash);
+        }
     }
 }


### PR DESCRIPTION
## Description

This pull request enhances the Pedersen hash implementation by making the following improvements:

- Replaced the `bools_to_usize_le` function with a more efficient iteration over the slice of bool `v`, eliminating unnecessary overhead (no change in perf detected through benchmark).
- Added an additional test case configuration for the Pedersen hash.

