### PR TITLE
Improve poseidon hash perf by using assign operators

### DIFF
--- a/starknet-crypto/src/poseidon_hash.rs
+++ b/starknet-crypto/src/poseidon_hash.rs
@@ -119,7 +119,8 @@ pub fn poseidon_permute_comp(state: &mut [FieldElement; 3]) {
 #[inline(always)]
 fn mix(state: &mut [FieldElement; 3]) {
     let t = state[0] + state[1] + state[2];
-    state[0] += state[0] + t;
+    state[0].double_assign();
+    state[0] += t;
     state[1] = t - state[1].double();
     state[2] = t - FieldElement::THREE * state[2];
 }
@@ -131,12 +132,13 @@ fn round_comp(state: &mut [FieldElement; 3], idx: usize, full: bool) {
         state[1] += POSEIDON_COMP_CONSTS[idx + 1];
         state[2] += POSEIDON_COMP_CONSTS[idx + 2];
 
-        state[0] *= state[0] * state[0];
-        state[1] *= state[1] * state[1];
-        state[2] *= state[2] * state[2];
+        state[0].pow3_assign();
+        state[1].pow3_assign();
+        state[2].pow3_assign();
     } else {
         state[2] += POSEIDON_COMP_CONSTS[idx];
-        state[2] *= state[2] * state[2];
+
+        state[2].pow3_assign();
     }
     mix(state);
 }

--- a/starknet-crypto/src/poseidon_hash.rs
+++ b/starknet-crypto/src/poseidon_hash.rs
@@ -119,7 +119,7 @@ pub fn poseidon_permute_comp(state: &mut [FieldElement; 3]) {
 #[inline(always)]
 fn mix(state: &mut [FieldElement; 3]) {
     let t = state[0] + state[1] + state[2];
-    state[0] = t + state[0].double();
+    state[0] += state[0] + t;
     state[1] = t - state[1].double();
     state[2] = t - FieldElement::THREE * state[2];
 }
@@ -130,12 +130,13 @@ fn round_comp(state: &mut [FieldElement; 3], idx: usize, full: bool) {
         state[0] += POSEIDON_COMP_CONSTS[idx];
         state[1] += POSEIDON_COMP_CONSTS[idx + 1];
         state[2] += POSEIDON_COMP_CONSTS[idx + 2];
-        state[0] = state[0] * state[0] * state[0];
-        state[1] = state[1] * state[1] * state[1];
-        state[2] = state[2] * state[2] * state[2];
+
+        state[0] *= state[0] * state[0];
+        state[1] *= state[1] * state[1];
+        state[2] *= state[2] * state[2];
     } else {
         state[2] += POSEIDON_COMP_CONSTS[idx];
-        state[2] = state[2] * state[2] * state[2];
+        state[2] *= state[2] * state[2];
     }
     mix(state);
 }

--- a/starknet-ff/src/lib.rs
+++ b/starknet-ff/src/lib.rs
@@ -272,6 +272,19 @@ impl FieldElement {
         *self + *self
     }
 
+    /// Doubles the field element in place.
+    #[inline]
+    pub fn double_assign(&mut self) {
+        *self += *self;
+    }
+
+    /// Raises the field element to the power of 3 in place.
+    #[inline]
+    pub fn pow3_assign(&mut self) {
+        let result = *self * *self;
+        *self *= result;
+    }
+
     /// Performs a floor division. It's not implemented as the `Div` trait on purpose to
     /// distinguish from the "felt division".
     pub fn floor_div(&self, rhs: FieldElement) -> FieldElement {


### PR DESCRIPTION
This pull request aims to enhance the performance of the poseidon hash by utilizing assignment multiplication (`mul_assign`) and addition (`add_assign`) operators whenever possible. By doing so, unnecessary copies are avoided, resulting in improved overall performance.
