### PR TITLE
Simplify k generation following RFC 6979

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "digest",
+ "digest 0.10.7",
  "itertools",
  "num-bigint",
  "num-traits",
@@ -84,7 +84,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std",
- "digest",
+ "digest 0.10.7",
  "num-bigint",
 ]
 
@@ -196,6 +196,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.11.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ded684142010808eb980d9974ef794da2bcf97d13396143b1515e9f0fb4a10e"
+dependencies = [
+ "crypto-common 0.2.0-pre.5",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,7 +292,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
 ]
 
@@ -398,9 +407,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2538c4e68e52548bacb3e83ac549f903d44f011ac9d5abb5e132e67d0808f7"
 dependencies = [
- "generic-array",
  "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -411,6 +418,15 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7aa2ec04f5120b830272a481e8d9d8ba4dda140d2cda59b0f1110d5eb93c38e"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -514,12 +530,23 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065d93ead7c220b85d5b4be4795d8398eac4ff68b5ee63895de0a3c1fb6edf25"
+dependencies = [
+ "block-buffer 0.11.0-pre.5",
+ "crypto-common 0.2.0-pre.5",
  "subtle",
 ]
 
@@ -546,15 +573,15 @@ checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
 dependencies = [
  "aes",
  "ctr",
- "digest",
+ "digest 0.10.7",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "pbkdf2",
  "rand",
  "scrypt",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.6",
  "sha3",
  "thiserror",
  "uuid",
@@ -759,7 +786,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd790a0795ee332ed3e8959e5b177beb70d7112eb7d345428ec17427897d5ce"
+dependencies = [
+ "digest 0.11.0-pre.8",
 ]
 
 [[package]]
@@ -795,6 +831,15 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c2311a0adecbffff284aabcf1249b1485193b16e685f9ef171b1ba82979cff"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1159,7 +1204,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1352,11 +1397,11 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.5.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "045972f2f66b9467a2f6834b7fd0f9b23ca214b4a8700b880c36edb726e96da6"
 dependencies = [
- "hmac",
+ "hmac 0.13.0-pre.3",
  "subtle",
 ]
 
@@ -1469,10 +1514,10 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -1581,7 +1626,18 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f33549bf3064b62478926aa89cbfc7c109aab66ae8f0d5d2ef839e482cc30d6"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-pre.8",
 ]
 
 [[package]]
@@ -1590,7 +1646,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -1710,22 +1766,20 @@ name = "starknet-crypto"
 version = "0.6.1"
 dependencies = [
  "criterion",
- "crypto-bigint",
  "hex",
  "hex-literal",
- "hmac",
  "num-bigint",
  "num-integer",
  "num-traits",
  "rfc6979",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0-pre.3",
  "starknet-crypto-codegen",
  "starknet-curve",
  "starknet-ff",
+ "subtle",
  "wasm-bindgen-test",
- "zeroize",
 ]
 
 [[package]]
@@ -1835,9 +1889,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -2069,9 +2123,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "uint"

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -17,14 +17,13 @@ exclude = ["test-data/**"]
 starknet-crypto-codegen = { version = "0.3.2", path = "../starknet-crypto-codegen" }
 starknet-curve = { version = "0.4.1", path = "../starknet-curve" }
 starknet-ff = { version = "0.3.6", path = "../starknet-ff", default-features = false }
-crypto-bigint = { version = "0.5.1", default-features = false, features = ["generic-array", "zeroize"] }
-hmac = { version = "0.12.1", default-features = false }
 num-bigint = { version = "0.4.3", default-features = false }
 num-integer = { version = "0.1.45", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
-rfc6979 = { version = "0.4.0", default-features = false }
-sha2 = { version = "0.10.6", default-features = false }
-zeroize = { version = "1.6.0", default-features = false }
+rfc6979 = { version = "0.5.0-pre.3", default-features = false }
+subtle = { version = "2.5.0", default-features = false }
+sha2 = { version = "0.11.0-pre.3", default-features = false }
+hex-literal  = { version = "0.4.1", default-features = false }
 hex = { version = "0.4.3", default-features = false, optional = true }
 
 [features]
@@ -36,7 +35,6 @@ signature-display = ["dep:hex", "alloc"]
 [dev-dependencies]
 criterion = { version = "0.4.0", default-features = false }
 hex = "0.4.3"
-hex-literal = "0.4.1"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
 

--- a/starknet-crypto/src/rfc6979.rs
+++ b/starknet-crypto/src/rfc6979.rs
@@ -1,12 +1,7 @@
-use crypto_bigint::{ArrayEncoding, ByteArray, Integer, U256};
-use hmac::digest::Digest;
-use sha2::digest::{crypto_common::BlockSizeUser, FixedOutputReset, HashMarker};
-use zeroize::{Zeroize, Zeroizing};
-
 use crate::FieldElement;
+use hex_literal::hex;
 
-const EC_ORDER: U256 =
-    U256::from_be_hex("0800000000000010ffffffffffffffffb781126dcae7b2321e66a241adc64d2f");
+const EC_ORDER: [u8; 32] = hex!("0800000000000010ffffffffffffffffb781126dcae7b2321e66a241adc64d2f");
 
 /// Deterministically generate ephemeral scalar `k` based on RFC 6979.
 ///
@@ -20,61 +15,32 @@ pub fn generate_k(
     private_key: &FieldElement,
     seed: Option<&FieldElement>,
 ) -> FieldElement {
-    // The message hash padding as implemented in `cairo-lang` is not needed here. The hash is
-    // padded in `cairo-lang` only to make sure the lowest 4 bits won't get truncated, but here it's
-    // never getting truncated anyways.
-    let message_hash = U256::from_be_slice(&message_hash.to_bytes_be()).to_be_byte_array();
-    let private_key = U256::from_be_slice(&private_key.to_bytes_be());
+    // Convert seed to bytes
+    let seed_bytes = seed.map_or([0u8; 32], |s| s.to_bytes_be());
 
-    let seed_bytes = match seed {
-        Some(seed) => seed.to_bytes_be(),
-        None => [0u8; 32],
-    };
-
+    // Find the index of the first non-zero byte in the seed
     let mut first_non_zero_index = 32;
-    for (ind, element) in seed_bytes.iter().enumerate() {
-        if *element != 0u8 {
+    for (ind, &element) in seed_bytes.iter().enumerate() {
+        if element != 0u8 {
             first_non_zero_index = ind;
             break;
         }
     }
 
-    let k = generate_k_shifted::<sha2::Sha256, _>(
-        &private_key,
-        &EC_ORDER,
-        &message_hash,
-        &seed_bytes[first_non_zero_index..],
+    // Convert GenericArray to [u8; 32]
+    let mut k_bytes = [0u8; 32];
+    k_bytes.copy_from_slice(
+        rfc6979::generate_k::<sha2::Sha256, rfc6979::consts::U32>(
+            (&private_key.to_bytes_be()).into(),
+            &EC_ORDER.into(),
+            (&message_hash.to_bytes_be()).into(),
+            &seed_bytes[first_non_zero_index..],
+        )
+        .as_slice(),
     );
 
-    let mut buffer = [0u8; 32];
-    buffer[..].copy_from_slice(&k.to_be_byte_array()[..]);
-
-    FieldElement::from_bytes_be(&buffer).unwrap()
-}
-
-// Modified from upstream `rfc6979::generate_k` with a hard-coded right bit shift. The more
-// idiomatic way of doing this seems to be to implement `U252` which handles bit truncation
-// interally.
-// TODO: change to use upstream `generate_k` directly.
-#[inline]
-fn generate_k_shifted<D, I>(x: &I, n: &I, h: &ByteArray<I>, data: &[u8]) -> Zeroizing<I>
-where
-    D: Default + Digest + BlockSizeUser + FixedOutputReset + HashMarker,
-    I: ArrayEncoding + Integer + Zeroize,
-{
-    let mut x = x.to_be_byte_array();
-    let mut hmac_drbg = rfc6979::HmacDrbg::<D>::new(&x, h, data);
-    x.zeroize();
-
-    loop {
-        let mut bytes = ByteArray::<I>::default();
-        hmac_drbg.fill_bytes(&mut bytes);
-        let k = I::from_be_byte_array(bytes) >> 4;
-
-        if (!k.is_zero() & k.ct_lt(n)).into() {
-            return Zeroizing::new(k);
-        }
-    }
+    // Convert bytes to FieldElement
+    FieldElement::from_bytes_be(&k_bytes).unwrap()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Summary
This pull request introduces a direct integration of the `rfc6979` crate to generate the scalar `k` according to RFC 6979. The integration is aimed at streamlining the logic within our codebase, ensuring simplicity, and reducing maintenance overheads by relying on established libraries from RustCrypto.

### Changes Made
- Integrated the `rfc6979` crate to handle the generation of scalar `k`.
- Refactored relevant sections of the codebase to utilize the new integration.
- Ensured consistency and compliance with RFC 6979 standards.

### Motivation
- **Simplifying Codebase**: By directly leveraging the `rfc6979` crate, we simplify the logic related to `k` generation, making it more concise and maintainable.
- **Reduced Maintenance Burden**: Depending on established libraries from RustCrypto reduces the need for maintaining custom solutions in our repository, ensuring compatibility and reliability.



