### PR TITLE
Simplify `parse_msg_to_l2` method and add unit tests

### DIFF
--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -504,7 +504,7 @@ impl L1HandlerTransaction {
                         .map_err(|_| ParseMsgToL2Error::FromAddressOutOfRange)?,
                     to_address: self.contract_address,
                     selector: self.entry_point_selector,
-                    payload: payload.to_vec(),
+                    payload: payload.into(),
                     nonce: self.nonce,
                 })
             },

--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -316,7 +316,7 @@ pub enum ExecuteInvocation {
 mod errors {
     use core::fmt::{Display, Formatter, Result};
 
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq)]
     pub enum ParseMsgToL2Error {
         EmptyCalldata,
         FromAddressOutOfRange,
@@ -495,19 +495,20 @@ impl PendingTransactionReceipt {
 
 impl L1HandlerTransaction {
     pub fn parse_msg_to_l2(&self) -> Result<MsgToL2, ParseMsgToL2Error> {
-        if self.calldata.is_empty() {
-            return Err(ParseMsgToL2Error::EmptyCalldata);
-        }
-
-        Ok(MsgToL2 {
-            from_address: self.calldata[0]
-                .try_into()
-                .map_err(|_| ParseMsgToL2Error::FromAddressOutOfRange)?,
-            to_address: self.contract_address,
-            selector: self.entry_point_selector,
-            payload: self.calldata[1..].to_vec(),
-            nonce: self.nonce,
-        })
+        self.calldata.split_first().map_or(
+            Err(ParseMsgToL2Error::EmptyCalldata),
+            |(from_address, payload)| {
+                Ok(MsgToL2 {
+                    from_address: (*from_address)
+                        .try_into()
+                        .map_err(|_| ParseMsgToL2Error::FromAddressOutOfRange)?,
+                    to_address: self.contract_address,
+                    selector: self.entry_point_selector,
+                    payload: payload.to_vec(),
+                    nonce: self.nonce,
+                })
+            },
+        )
     }
 }
 
@@ -619,5 +620,70 @@ mod tests {
                 .unwrap();
 
         assert_eq!(msg_to_l2.hash(), expected_hash);
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    fn test_parse_msg_to_l2_empty_calldata_error() {
+        let l1_handler_tx = L1HandlerTransaction {
+            transaction_hash: FieldElement::from_hex_be(
+                "0x374286ae28f201e61ffbc5b022cc9701208640b405ea34ea9799f97d5d2d23c",
+            )
+            .unwrap(),
+            version: FieldElement::ZERO,
+            nonce: 775628,
+            contract_address: FieldElement::from_hex_be(
+                "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+            )
+            .unwrap(),
+            entry_point_selector: FieldElement::from_hex_be(
+                "0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5",
+            )
+            .unwrap(),
+            calldata: Vec::new(), // Empty calldata
+        };
+
+        let result = l1_handler_tx.parse_msg_to_l2();
+
+        assert_eq!(result.unwrap_err(), ParseMsgToL2Error::EmptyCalldata);
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    fn test_parse_msg_to_l2_from_address_out_of_range_error() {
+        let l1_handler_tx = L1HandlerTransaction {
+            transaction_hash: FieldElement::from_hex_be(
+                "0x374286ae28f201e61ffbc5b022cc9701208640b405ea34ea9799f97d5d2d23c",
+            )
+            .unwrap(),
+            version: FieldElement::ZERO,
+            nonce: 775628,
+            contract_address: FieldElement::from_hex_be(
+                "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+            )
+            .unwrap(),
+            entry_point_selector: FieldElement::from_hex_be(
+                "0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5",
+            )
+            .unwrap(),
+            calldata: vec![
+                // Incorrect from address format, causing the conversion error
+                // Max address + 1
+                FieldElement::from_hex_be("0x10000000000000000000000000000000000000000").unwrap(),
+                FieldElement::from_hex_be(
+                    "0x689ead7d814e51ed93644bc145f0754839b8dcb340027ce0c30953f38f55d7",
+                )
+                .unwrap(),
+                FieldElement::from_hex_be("0x2c68af0bb140000").unwrap(),
+                FieldElement::from_hex_be("0x0").unwrap(),
+            ],
+        };
+
+        let result = l1_handler_tx.parse_msg_to_l2();
+
+        assert_eq!(
+            result.unwrap_err(),
+            ParseMsgToL2Error::FromAddressOutOfRange
+        );
     }
 }


### PR DESCRIPTION
- The `parse_msg_to_l2` method is simplified using `split_first` for `calldata` in order to decouple easily the `from_address` and the `payload`, handling potential errors in the mean time.
- Unit tests are added to tackle `ParseMsgToL2Error::EmptyCalldata` and `ParseMsgToL2Error::FromAddressOutOfRange` possible scenarios.