### PR TITLE
feat: Add `sepolia` to the `chan_id` module

### DIFF
--- a/starknet-core/src/chain_id.rs
+++ b/starknet-core/src/chain_id.rs
@@ -21,6 +21,13 @@ pub const TESTNET2: FieldElement = FieldElement::from_mont([
     33650220878420990,
 ]);
 
+pub const SEPOLIA: FieldElement = FieldElement::from_mont([
+    1555806712078248243,
+    18446744073708869172,
+    18446744073709551615,
+    507980251676163170,
+]);
+
 #[cfg(test)]
 mod test {
     use crate::utils::cairo_short_string_to_felt;
@@ -34,6 +41,7 @@ mod test {
             ("SN_MAIN", MAINNET),
             ("SN_GOERLI", TESTNET),
             ("SN_GOERLI2", TESTNET2),
+            ("SN_SEPOLIA", SEPOLIA),
         ]
         .into_iter()
         {


### PR DESCRIPTION
Add the `sepolia` chain ID to the `chain_id` module.