### PR TITLE
release: bump starknet to 0.10.0 (and deps)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,7 +1636,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "starknet"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "serde_json",
  "starknet-accounts",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "rand",
  "serde",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "base64 0.21.0",
  "criterion",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "criterion",
  "crypto-bigint",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto-codegen"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "starknet-curve",
  "starknet-ff",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-curve"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "starknet-ff",
 ]
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-ff"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "ark-ff",
  "bigdecimal",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-macros"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "starknet-core",
  "syn 2.0.15",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -34,14 +34,14 @@ members = [
 all-features = true
 
 [dependencies]
-starknet-ff = { version = "0.3.6", path = "./starknet-ff", default-features = false }
-starknet-crypto = { version = "0.6.1", path = "./starknet-crypto" }
-starknet-core = { version = "0.9.0", path = "./starknet-core", default-features = false }
-starknet-providers = { version = "0.9.0", path = "./starknet-providers" }
-starknet-contract = { version = "0.8.0", path = "./starknet-contract" }
-starknet-signers = { version = "0.7.0", path = "./starknet-signers" }
-starknet-accounts = { version = "0.8.0", path = "./starknet-accounts" }
-starknet-macros = { version = "0.1.6", path = "./starknet-macros" }
+starknet-ff = { version = "0.3.7", path = "./starknet-ff", default-features = false }
+starknet-crypto = { version = "0.6.2", path = "./starknet-crypto" }
+starknet-core = { version = "0.10.0", path = "./starknet-core", default-features = false }
+starknet-providers = { version = "0.10.0", path = "./starknet-providers" }
+starknet-contract = { version = "0.9.0", path = "./starknet-contract" }
+starknet-signers = { version = "0.8.0", path = "./starknet-signers" }
+starknet-accounts = { version = "0.9.0", path = "./starknet-accounts" }
+starknet-macros = { version = "0.1.7", path = "./starknet-macros" }
 
 [dev-dependencies]
 serde_json = "1.0.74"

--- a/examples/starknet-wasm/Cargo.toml
+++ b/examples/starknet-wasm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-starknet-ff = { version = "0.3.6", path = "../../starknet-ff" }
-starknet-crypto = { version = "0.6.1", path = "../../starknet-crypto" }
+starknet-ff = { version = "0.3.7", path = "../../starknet-ff" }
+starknet-crypto = { version = "0.6.2", path = "../../starknet-crypto" }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 wasm-bindgen = "0.2.84"

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-accounts"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,9 +14,9 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.9.0", path = "../starknet-core" }
-starknet-providers = { version = "0.9.0", path = "../starknet-providers" }
-starknet-signers = { version = "0.7.0", path = "../starknet-signers" }
+starknet-core = { version = "0.10.0", path = "../starknet-core" }
+starknet-providers = { version = "0.10.0", path = "../starknet-providers" }
+starknet-signers = { version = "0.8.0", path = "../starknet-signers" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 thiserror = "1.0.40"

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-contract"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,9 +14,9 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.9.0", path = "../starknet-core" }
-starknet-providers = { version = "0.9.0", path = "../starknet-providers" }
-starknet-accounts = { version = "0.8.0", path = "../starknet-accounts" }
+starknet-core = { version = "0.10.0", path = "../starknet-core" }
+starknet-providers = { version = "0.10.0", path = "../starknet-providers" }
+starknet-accounts = { version = "0.9.0", path = "../starknet-accounts" }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
 serde_with = "2.3.2"
@@ -24,6 +24,6 @@ thiserror = "1.0.40"
 
 [dev-dependencies]
 rand = { version = "0.8.5", features=["std_rng"] }
-starknet-signers = { version = "0.7.0", path = "../starknet-signers" }
+starknet-signers = { version = "0.8.0", path = "../starknet-signers" }
 tokio = { version = "1.27.0", features = ["full"] }
 url = "2.3.1"

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-core"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -17,8 +17,8 @@ exclude = ["test-data/**"]
 all-features = true
 
 [dependencies]
-starknet-crypto = { version = "0.6.1", path = "../starknet-crypto", default-features = false, features = ["alloc"] }
-starknet-ff = { version = "0.3.6", path = "../starknet-ff", default-features = false, features = ["serde"] }
+starknet-crypto = { version = "0.6.2", path = "../starknet-crypto", default-features = false, features = ["alloc"] }
+starknet-ff = { version = "0.3.7", path = "../starknet-ff", default-features = false, features = ["serde"] }
 base64 = { version = "0.21.0", default-features = false, features = ["alloc"] }
 flate2 = { version = "1.0.25", optional = true }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }

--- a/starknet-crypto-codegen/Cargo.toml
+++ b/starknet-crypto-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-crypto-codegen"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -16,6 +16,6 @@ keywords = ["ethereum", "starknet", "web3", "no_std"]
 proc-macro = true
 
 [dependencies]
-starknet-curve = { version = "0.4.1", path = "../starknet-curve" }
-starknet-ff = { version = "0.3.6", path = "../starknet-ff", default-features = false }
+starknet-curve = { version = "0.4.2", path = "../starknet-curve" }
+starknet-ff = { version = "0.3.7", path = "../starknet-ff", default-features = false }
 syn = { version = "2.0.15", default-features = false }

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-crypto"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,9 +14,9 @@ keywords = ["ethereum", "starknet", "web3", "no_std"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-crypto-codegen = { version = "0.3.2", path = "../starknet-crypto-codegen" }
-starknet-curve = { version = "0.4.1", path = "../starknet-curve" }
-starknet-ff = { version = "0.3.6", path = "../starknet-ff", default-features = false }
+starknet-crypto-codegen = { version = "0.3.3", path = "../starknet-crypto-codegen" }
+starknet-curve = { version = "0.4.2", path = "../starknet-curve" }
+starknet-ff = { version = "0.3.7", path = "../starknet-ff", default-features = false }
 crypto-bigint = { version = "0.5.1", default-features = false, features = ["generic-array", "zeroize"] }
 hmac = { version = "0.12.1", default-features = false }
 num-bigint = { version = "0.4.3", default-features = false }

--- a/starknet-curve/Cargo.toml
+++ b/starknet-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-curve"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,4 +13,4 @@ Stark curve
 keywords = ["ethereum", "starknet", "web3", "no_std"]
 
 [dependencies]
-starknet-ff = { version = "0.3.6", path = "../starknet-ff", default-features = false }
+starknet-ff = { version = "0.3.7", path = "../starknet-ff", default-features = false }

--- a/starknet-ff/Cargo.toml
+++ b/starknet-ff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-ff"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/starknet-macros/Cargo.toml
+++ b/starknet-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-macros"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -16,7 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 proc-macro = true
 
 [dependencies]
-starknet-core = { version = "0.9.0", path = "../starknet-core" }
+starknet-core = { version = "0.10.0", path = "../starknet-core" }
 syn = "2.0.15"
 
 [features]

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-providers"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.9.0", path = "../starknet-core" }
+starknet-core = { version = "0.10.0", path = "../starknet-core" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 ethereum-types = "0.14.1"

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-signers"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,8 +13,8 @@ Starknet signer implementations
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.9.0", path = "../starknet-core" }
-starknet-crypto = { version = "0.6.1", path = "../starknet-crypto" }
+starknet-core = { version = "0.10.0", path = "../starknet-core" }
+starknet-crypto = { version = "0.6.2", path = "../starknet-crypto" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 thiserror = "1.0.40"


### PR DESCRIPTION
Bumping `starknet` to v0.10.0, mainly to release the Sierra 1.5.0 support added in #565. Unfortunately, that PR introduced minor breaking changes:

- a new `bytecode_segment_lengths` field was added to `CompiledClass`
- a few new enum variants were added to `ComputeClassHashError`

While these are minor breakge and it's deemed very unlikely that anyone would actually get broken, as more and more applications depend on `starknet-rs`, it's more reasonable to fully adhere to SemVer and to bump version to `0.10.0` instead of `0.9.1`.