### PR TITLE
feat: support v3 transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,6 +1660,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet-core",
+ "starknet-crypto",
  "starknet-providers",
  "starknet-signers",
  "thiserror",

--- a/examples/declare_cairo1_contract.rs
+++ b/examples/declare_cairo1_contract.rs
@@ -49,7 +49,7 @@ async fn main() {
     let flattened_class = contract_artifact.flatten().unwrap();
 
     let result = account
-        .declare(Arc::new(flattened_class), compiled_class_hash)
+        .declare_v2(Arc::new(flattened_class), compiled_class_hash)
         .send()
         .await
         .unwrap();

--- a/examples/deploy_argent_account.rs
+++ b/examples/deploy_argent_account.rs
@@ -35,7 +35,7 @@ async fn main() {
     .await
     .unwrap();
 
-    let deployment = factory.deploy(salt);
+    let deployment = factory.deploy_v1(salt);
 
     let est_fee = deployment.estimate_fee().await.unwrap();
 

--- a/examples/deploy_contract.rs
+++ b/examples/deploy_contract.rs
@@ -49,7 +49,7 @@ async fn main() {
 
     let contract_factory = ContractFactory::new(class_hash, account);
     contract_factory
-        .deploy(vec![felt!("123456")], felt!("1122"), false)
+        .deploy_v1(vec![felt!("123456")], felt!("1122"), false)
         .send()
         .await
         .expect("Unable to deploy contract");

--- a/examples/mint_tokens.rs
+++ b/examples/mint_tokens.rs
@@ -40,7 +40,7 @@ async fn main() {
     account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let result = account
-        .execute(vec![Call {
+        .execute_v1(vec![Call {
             to: tst_token_address,
             selector: get_selector_from_name("mint").unwrap(),
             calldata: vec![

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -15,6 +15,7 @@ exclude = ["test-data/**"]
 
 [dependencies]
 starknet-core = { version = "0.10.0", path = "../starknet-core" }
+starknet-crypto = { version = "0.6.2", path = "../starknet-crypto" }
 starknet-providers = { version = "0.10.0", path = "../starknet-providers" }
 starknet-signers = { version = "0.8.0", path = "../starknet-signers" }
 async-trait = "0.1.68"

--- a/starknet-accounts/src/account/declaration.rs
+++ b/starknet-accounts/src/account/declaration.rs
@@ -1,7 +1,7 @@
 use super::{
-    super::NotPreparedError, Account, AccountError, ConnectedAccount, Declaration,
-    LegacyDeclaration, PreparedDeclaration, PreparedLegacyDeclaration, RawDeclaration,
-    RawLegacyDeclaration,
+    super::NotPreparedError, Account, AccountError, ConnectedAccount, DeclarationV2, DeclarationV3,
+    LegacyDeclaration, PreparedDeclarationV2, PreparedDeclarationV3, PreparedLegacyDeclaration,
+    RawDeclarationV2, RawDeclarationV3, RawLegacyDeclaration,
 };
 
 use starknet_core::{
@@ -9,10 +9,13 @@ use starknet_core::{
     types::{
         contract::{legacy::LegacyContractClass, ComputeClassHashError},
         BroadcastedDeclareTransaction, BroadcastedDeclareTransactionV1,
-        BroadcastedDeclareTransactionV2, BroadcastedTransaction, DeclareTransactionResult,
-        FeeEstimate, FieldElement, FlattenedSierraClass, SimulatedTransaction, SimulationFlag,
+        BroadcastedDeclareTransactionV2, BroadcastedDeclareTransactionV3, BroadcastedTransaction,
+        DataAvailabilityMode, DeclareTransactionResult, FeeEstimate, FieldElement,
+        FlattenedSierraClass, ResourceBounds, ResourceBoundsMapping, SimulatedTransaction,
+        SimulationFlag,
     },
 };
+use starknet_crypto::PoseidonHasher;
 use starknet_providers::Provider;
 use std::sync::Arc;
 
@@ -40,7 +43,15 @@ const QUERY_VERSION_TWO: FieldElement = FieldElement::from_mont([
     576460752142433232,
 ]);
 
-impl<'a, A> Declaration<'a, A> {
+/// 2 ^ 128 + 3
+const QUERY_VERSION_THREE: FieldElement = FieldElement::from_mont([
+    18446744073700081569,
+    17407,
+    18446744073709551584,
+    576460752142432688,
+]);
+
+impl<'a, A> DeclarationV2<'a, A> {
     pub fn new(
         contract_class: Arc<FlattenedSierraClass>,
         compiled_class_hash: FieldElement,
@@ -77,15 +88,15 @@ impl<'a, A> Declaration<'a, A> {
         }
     }
 
-    /// Calling this function after manually specifying `nonce` and `max_fee` turns [Declaration]
-    /// into [PreparedDeclaration]. Returns `Err` if either field is `None`.
-    pub fn prepared(self) -> Result<PreparedDeclaration<'a, A>, NotPreparedError> {
+    /// Calling this function after manually specifying `nonce` and `max_fee` turns [DeclarationV2]
+    /// into [PreparedDeclarationV2]. Returns `Err` if either field is `None`.
+    pub fn prepared(self) -> Result<PreparedDeclarationV2<'a, A>, NotPreparedError> {
         let nonce = self.nonce.ok_or(NotPreparedError)?;
         let max_fee = self.max_fee.ok_or(NotPreparedError)?;
 
-        Ok(PreparedDeclaration {
+        Ok(PreparedDeclarationV2 {
             account: self.account,
-            inner: RawDeclaration {
+            inner: RawDeclarationV2 {
                 contract_class: self.contract_class,
                 compiled_class_hash: self.compiled_class_hash,
                 nonce,
@@ -95,7 +106,7 @@ impl<'a, A> Declaration<'a, A> {
     }
 }
 
-impl<'a, A> Declaration<'a, A>
+impl<'a, A> DeclarationV2<'a, A>
 where
     A: ConnectedAccount + Sync,
 {
@@ -136,7 +147,7 @@ where
         self.prepare().await?.send().await
     }
 
-    async fn prepare(&self) -> Result<PreparedDeclaration<'a, A>, AccountError<A::SignError>> {
+    async fn prepare(&self) -> Result<PreparedDeclarationV2<'a, A>, AccountError<A::SignError>> {
         // Resolves nonce
         let nonce = match self.nonce {
             Some(value) => value,
@@ -159,9 +170,9 @@ where
             }
         };
 
-        Ok(PreparedDeclaration {
+        Ok(PreparedDeclarationV2 {
             account: self.account,
-            inner: RawDeclaration {
+            inner: RawDeclarationV2 {
                 contract_class: self.contract_class.clone(),
                 compiled_class_hash: self.compiled_class_hash,
                 nonce,
@@ -174,9 +185,9 @@ where
         &self,
         nonce: FieldElement,
     ) -> Result<FeeEstimate, AccountError<A::SignError>> {
-        let prepared = PreparedDeclaration {
+        let prepared = PreparedDeclarationV2 {
             account: self.account,
-            inner: RawDeclaration {
+            inner: RawDeclarationV2 {
                 contract_class: self.contract_class.clone(),
                 compiled_class_hash: self.compiled_class_hash,
                 nonce,
@@ -202,9 +213,9 @@ where
         skip_validate: bool,
         skip_fee_charge: bool,
     ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
-        let prepared = PreparedDeclaration {
+        let prepared = PreparedDeclarationV2 {
             account: self.account,
-            inner: RawDeclaration {
+            inner: RawDeclarationV2 {
                 contract_class: self.contract_class.clone(),
                 compiled_class_hash: self.compiled_class_hash,
                 nonce,
@@ -227,6 +238,240 @@ where
             .simulate_transaction(
                 self.account.block_id(),
                 BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V2(declare)),
+                &flags,
+            )
+            .await
+            .map_err(AccountError::Provider)
+    }
+}
+
+impl<'a, A> DeclarationV3<'a, A> {
+    pub fn new(
+        contract_class: Arc<FlattenedSierraClass>,
+        compiled_class_hash: FieldElement,
+        account: &'a A,
+    ) -> Self {
+        Self {
+            account,
+            contract_class,
+            compiled_class_hash,
+            nonce: None,
+            gas: None,
+            gas_price: None,
+            gas_estimate_multiplier: 1.5,
+            gas_price_estimate_multiplier: 1.5,
+        }
+    }
+
+    pub fn nonce(self, nonce: FieldElement) -> Self {
+        Self {
+            nonce: Some(nonce),
+            ..self
+        }
+    }
+
+    pub fn gas(self, gas: u64) -> Self {
+        Self {
+            gas: Some(gas),
+            ..self
+        }
+    }
+
+    pub fn gas_price(self, gas_price: u128) -> Self {
+        Self {
+            gas_price: Some(gas_price),
+            ..self
+        }
+    }
+
+    pub fn gas_estimate_multiplier(self, gas_estimate_multiplier: f64) -> Self {
+        Self {
+            gas_estimate_multiplier,
+            ..self
+        }
+    }
+
+    pub fn gas_price_estimate_multiplier(self, gas_price_estimate_multiplier: f64) -> Self {
+        Self {
+            gas_price_estimate_multiplier,
+            ..self
+        }
+    }
+
+    /// Calling this function after manually specifying `nonce`, `gas` and `gas_price` turns
+    /// [DeclarationV3] into [PreparedDeclarationV3]. Returns `Err` if any field is `None`.
+    pub fn prepared(self) -> Result<PreparedDeclarationV3<'a, A>, NotPreparedError> {
+        let nonce = self.nonce.ok_or(NotPreparedError)?;
+        let gas = self.gas.ok_or(NotPreparedError)?;
+        let gas_price = self.gas_price.ok_or(NotPreparedError)?;
+
+        Ok(PreparedDeclarationV3 {
+            account: self.account,
+            inner: RawDeclarationV3 {
+                contract_class: self.contract_class,
+                compiled_class_hash: self.compiled_class_hash,
+                nonce,
+                gas,
+                gas_price,
+            },
+        })
+    }
+}
+
+impl<'a, A> DeclarationV3<'a, A>
+where
+    A: ConnectedAccount + Sync,
+{
+    pub async fn estimate_fee(&self) -> Result<FeeEstimate, AccountError<A::SignError>> {
+        // Resolves nonce
+        let nonce = match self.nonce {
+            Some(value) => value,
+            None => self
+                .account
+                .get_nonce()
+                .await
+                .map_err(AccountError::Provider)?,
+        };
+
+        self.estimate_fee_with_nonce(nonce).await
+    }
+
+    pub async fn simulate(
+        &self,
+        skip_validate: bool,
+        skip_fee_charge: bool,
+    ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
+        // Resolves nonce
+        let nonce = match self.nonce {
+            Some(value) => value,
+            None => self
+                .account
+                .get_nonce()
+                .await
+                .map_err(AccountError::Provider)?,
+        };
+
+        self.simulate_with_nonce(nonce, skip_validate, skip_fee_charge)
+            .await
+    }
+
+    pub async fn send(&self) -> Result<DeclareTransactionResult, AccountError<A::SignError>> {
+        self.prepare().await?.send().await
+    }
+
+    async fn prepare(&self) -> Result<PreparedDeclarationV3<'a, A>, AccountError<A::SignError>> {
+        // Resolves nonce
+        let nonce = match self.nonce {
+            Some(value) => value,
+            None => self
+                .account
+                .get_nonce()
+                .await
+                .map_err(AccountError::Provider)?,
+        };
+
+        // Resolves fee settings
+        let (gas, gas_price) = match (self.gas, self.gas_price) {
+            (Some(gas), Some(gas_price)) => (gas, gas_price),
+            // We have to perform fee estimation as long as it's not fully specified
+            _ => {
+                let fee_estimate = self.estimate_fee_with_nonce(nonce).await?;
+
+                let gas = match self.gas {
+                    Some(gas) => gas,
+                    None => {
+                        (((TryInto::<u64>::try_into(fee_estimate.gas_consumed)
+                            .map_err(|_| AccountError::FeeOutOfRange)?)
+                            as f64)
+                            * self.gas_estimate_multiplier) as u64
+                    }
+                };
+
+                let gas_price = match self.gas_price {
+                    Some(gas_price) => gas_price,
+                    None => {
+                        (((TryInto::<u64>::try_into(fee_estimate.gas_price)
+                            .map_err(|_| AccountError::FeeOutOfRange)?)
+                            as f64)
+                            * self.gas_price_estimate_multiplier) as u128
+                    }
+                };
+
+                (gas, gas_price)
+            }
+        };
+
+        Ok(PreparedDeclarationV3 {
+            account: self.account,
+            inner: RawDeclarationV3 {
+                contract_class: self.contract_class.clone(),
+                compiled_class_hash: self.compiled_class_hash,
+                nonce,
+                gas,
+                gas_price,
+            },
+        })
+    }
+
+    async fn estimate_fee_with_nonce(
+        &self,
+        nonce: FieldElement,
+    ) -> Result<FeeEstimate, AccountError<A::SignError>> {
+        let prepared = PreparedDeclarationV3 {
+            account: self.account,
+            inner: RawDeclarationV3 {
+                contract_class: self.contract_class.clone(),
+                compiled_class_hash: self.compiled_class_hash,
+                nonce,
+                gas: 0,
+                gas_price: 0,
+            },
+        };
+        let declare = prepared.get_declare_request(true).await?;
+
+        self.account
+            .provider()
+            .estimate_fee_single(
+                BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V3(declare)),
+                [],
+                self.account.block_id(),
+            )
+            .await
+            .map_err(AccountError::Provider)
+    }
+
+    async fn simulate_with_nonce(
+        &self,
+        nonce: FieldElement,
+        skip_validate: bool,
+        skip_fee_charge: bool,
+    ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
+        let prepared = PreparedDeclarationV3 {
+            account: self.account,
+            inner: RawDeclarationV3 {
+                contract_class: self.contract_class.clone(),
+                compiled_class_hash: self.compiled_class_hash,
+                nonce,
+                gas: self.gas.unwrap_or_default(),
+                gas_price: self.gas_price.unwrap_or_default(),
+            },
+        };
+        let declare = prepared.get_declare_request(true).await?;
+
+        let mut flags = vec![];
+
+        if skip_validate {
+            flags.push(SimulationFlag::SkipValidate);
+        }
+        if skip_fee_charge {
+            flags.push(SimulationFlag::SkipFeeCharge);
+        }
+
+        self.account
+            .provider()
+            .simulate_transaction(
+                self.account.block_id(),
+                BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V3(declare)),
                 &flags,
             )
             .await
@@ -422,7 +667,7 @@ where
     }
 }
 
-impl RawDeclaration {
+impl RawDeclarationV2 {
     pub fn transaction_hash(
         &self,
         chain_id: FieldElement,
@@ -463,6 +708,86 @@ impl RawDeclaration {
     }
 }
 
+impl RawDeclarationV3 {
+    pub fn transaction_hash(
+        &self,
+        chain_id: FieldElement,
+        address: FieldElement,
+        query_only: bool,
+    ) -> FieldElement {
+        let mut hasher = PoseidonHasher::new();
+
+        hasher.update(PREFIX_DECLARE);
+        hasher.update(if query_only {
+            QUERY_VERSION_THREE
+        } else {
+            FieldElement::THREE
+        });
+        hasher.update(address);
+
+        hasher.update({
+            let mut fee_hasher = PoseidonHasher::new();
+
+            // Tip: fee market has not been been activated yet so it's hard-coded to be 0
+            fee_hasher.update(FieldElement::ZERO);
+
+            let mut resource_buffer = [
+                0, 0, b'L', b'1', b'_', b'G', b'A', b'S', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ];
+            resource_buffer[8..(8 + 8)].copy_from_slice(&self.gas.to_be_bytes());
+            resource_buffer[(8 + 8)..].copy_from_slice(&self.gas_price.to_be_bytes());
+            fee_hasher.update(FieldElement::from_bytes_be(&resource_buffer).unwrap());
+
+            // L2 resources are hard-coded to 0
+            let resource_buffer = [
+                0, 0, b'L', b'2', b'_', b'G', b'A', b'S', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ];
+            fee_hasher.update(FieldElement::from_bytes_be(&resource_buffer).unwrap());
+
+            fee_hasher.finalize()
+        });
+
+        // Hard-coded empty `paymaster_data`
+        hasher.update(PoseidonHasher::new().finalize());
+
+        hasher.update(chain_id);
+        hasher.update(self.nonce);
+
+        // Hard-coded L1 DA mode for nonce and fee
+        hasher.update(FieldElement::ZERO);
+
+        // Hard-coded empty `account_deployment_data`
+        hasher.update(PoseidonHasher::new().finalize());
+
+        hasher.update(self.contract_class.class_hash());
+        hasher.update(self.compiled_class_hash);
+
+        hasher.finalize()
+    }
+
+    pub fn contract_class(&self) -> &FlattenedSierraClass {
+        &self.contract_class
+    }
+
+    pub fn compiled_class_hash(&self) -> FieldElement {
+        self.compiled_class_hash
+    }
+
+    pub fn nonce(&self) -> FieldElement {
+        self.nonce
+    }
+
+    pub fn gas(&self) -> u64 {
+        self.gas
+    }
+
+    pub fn gas_price(&self) -> u128 {
+        self.gas_price
+    }
+}
+
 impl RawLegacyDeclaration {
     pub fn transaction_hash(
         &self,
@@ -499,7 +824,7 @@ impl RawLegacyDeclaration {
     }
 }
 
-impl<'a, A> PreparedDeclaration<'a, A>
+impl<'a, A> PreparedDeclarationV2<'a, A>
 where
     A: Account,
 {
@@ -511,7 +836,7 @@ where
     }
 }
 
-impl<'a, A> PreparedDeclaration<'a, A>
+impl<'a, A> PreparedDeclarationV2<'a, A>
 where
     A: ConnectedAccount,
 {
@@ -530,7 +855,7 @@ where
     ) -> Result<BroadcastedDeclareTransactionV2, AccountError<A::SignError>> {
         let signature = self
             .account
-            .sign_declaration(&self.inner, query_only)
+            .sign_declaration_v2(&self.inner, query_only)
             .await
             .map_err(AccountError::Signing)?;
 
@@ -541,6 +866,72 @@ where
             contract_class: self.inner.contract_class.clone(),
             compiled_class_hash: self.inner.compiled_class_hash,
             sender_address: self.account.address(),
+            is_query: query_only,
+        })
+    }
+}
+
+impl<'a, A> PreparedDeclarationV3<'a, A>
+where
+    A: Account,
+{
+    /// Locally calculates the hash of the transaction to be sent from this declaration given the
+    /// parameters.
+    pub fn transaction_hash(&self, query_only: bool) -> FieldElement {
+        self.inner
+            .transaction_hash(self.account.chain_id(), self.account.address(), query_only)
+    }
+}
+
+impl<'a, A> PreparedDeclarationV3<'a, A>
+where
+    A: ConnectedAccount,
+{
+    pub async fn send(&self) -> Result<DeclareTransactionResult, AccountError<A::SignError>> {
+        let tx_request = self.get_declare_request(false).await?;
+        self.account
+            .provider()
+            .add_declare_transaction(BroadcastedDeclareTransaction::V3(tx_request))
+            .await
+            .map_err(AccountError::Provider)
+    }
+
+    pub async fn get_declare_request(
+        &self,
+        query_only: bool,
+    ) -> Result<BroadcastedDeclareTransactionV3, AccountError<A::SignError>> {
+        let signature = self
+            .account
+            .sign_declaration_v3(&self.inner, query_only)
+            .await
+            .map_err(AccountError::Signing)?;
+
+        Ok(BroadcastedDeclareTransactionV3 {
+            sender_address: self.account.address(),
+            compiled_class_hash: self.inner.compiled_class_hash,
+            signature,
+            nonce: self.inner.nonce,
+            contract_class: self.inner.contract_class.clone(),
+            resource_bounds: ResourceBoundsMapping {
+                l1_gas: ResourceBounds {
+                    max_amount: self.inner.gas,
+                    max_price_per_unit: self.inner.gas_price,
+                },
+                // L2 resources are hard-coded to 0
+                l2_gas: ResourceBounds {
+                    max_amount: 0,
+                    max_price_per_unit: 0,
+                },
+            },
+            // Fee market has not been been activated yet so it's hard-coded to be 0
+            tip: 0,
+            // Hard-coded empty `paymaster_data`
+            paymaster_data: vec![],
+            // Hard-coded empty `account_deployment_data`
+            account_deployment_data: vec![],
+            // Hard-coded L1 DA mode for nonce and fee
+            nonce_data_availability_mode: DataAvailabilityMode::L1,
+            fee_data_availability_mode: DataAvailabilityMode::L1,
             is_query: query_only,
         })
     }

--- a/starknet-accounts/src/account/execution.rs
+++ b/starknet-accounts/src/account/execution.rs
@@ -1,16 +1,19 @@
 use super::{
-    super::NotPreparedError, Account, AccountError, ConnectedAccount, Execution, PreparedExecution,
-    RawExecution,
+    super::NotPreparedError, Account, AccountError, ConnectedAccount, ExecutionV1, ExecutionV3,
+    PreparedExecutionV1, PreparedExecutionV3, RawExecutionV1, RawExecutionV3,
 };
 use crate::{Call, ExecutionEncoder};
 
 use starknet_core::{
     crypto::compute_hash_on_elements,
     types::{
-        BroadcastedInvokeTransaction, BroadcastedInvokeTransactionV1, BroadcastedTransaction,
-        FeeEstimate, FieldElement, InvokeTransactionResult, SimulatedTransaction, SimulationFlag,
+        BroadcastedInvokeTransaction, BroadcastedInvokeTransactionV1,
+        BroadcastedInvokeTransactionV3, BroadcastedTransaction, DataAvailabilityMode, FeeEstimate,
+        FieldElement, InvokeTransactionResult, ResourceBounds, ResourceBoundsMapping,
+        SimulatedTransaction, SimulationFlag,
     },
 };
+use starknet_crypto::PoseidonHasher;
 use starknet_providers::Provider;
 
 /// Cairo string for "invoke"
@@ -29,7 +32,15 @@ const QUERY_VERSION_ONE: FieldElement = FieldElement::from_mont([
     576460752142433776,
 ]);
 
-impl<'a, A> Execution<'a, A> {
+/// 2 ^ 128 + 3
+const QUERY_VERSION_THREE: FieldElement = FieldElement::from_mont([
+    18446744073700081569,
+    17407,
+    18446744073709551584,
+    576460752142432688,
+]);
+
+impl<'a, A> ExecutionV1<'a, A> {
     pub fn new(calls: Vec<Call>, account: &'a A) -> Self {
         Self {
             account,
@@ -61,15 +72,15 @@ impl<'a, A> Execution<'a, A> {
         }
     }
 
-    /// Calling this function after manually specifying `nonce` and `max_fee` turns [Execution] into
-    /// [PreparedExecution]. Returns `Err` if either field is `None`.
-    pub fn prepared(self) -> Result<PreparedExecution<'a, A>, NotPreparedError> {
+    /// Calling this function after manually specifying `nonce` and `max_fee` turns [ExecutionV1] into
+    /// [PreparedExecutionV1]. Returns `Err` if either field is `None`.
+    pub fn prepared(self) -> Result<PreparedExecutionV1<'a, A>, NotPreparedError> {
         let nonce = self.nonce.ok_or(NotPreparedError)?;
         let max_fee = self.max_fee.ok_or(NotPreparedError)?;
 
-        Ok(PreparedExecution {
+        Ok(PreparedExecutionV1 {
             account: self.account,
-            inner: RawExecution {
+            inner: RawExecutionV1 {
                 calls: self.calls,
                 nonce,
                 max_fee,
@@ -78,7 +89,74 @@ impl<'a, A> Execution<'a, A> {
     }
 }
 
-impl<'a, A> Execution<'a, A>
+impl<'a, A> ExecutionV3<'a, A> {
+    pub fn new(calls: Vec<Call>, account: &'a A) -> Self {
+        Self {
+            account,
+            calls,
+            nonce: None,
+            gas: None,
+            gas_price: None,
+            gas_estimate_multiplier: 1.5,
+            gas_price_estimate_multiplier: 1.5,
+        }
+    }
+
+    pub fn nonce(self, nonce: FieldElement) -> Self {
+        Self {
+            nonce: Some(nonce),
+            ..self
+        }
+    }
+
+    pub fn gas(self, gas: u64) -> Self {
+        Self {
+            gas: Some(gas),
+            ..self
+        }
+    }
+
+    pub fn gas_price(self, gas_price: u128) -> Self {
+        Self {
+            gas_price: Some(gas_price),
+            ..self
+        }
+    }
+
+    pub fn gas_estimate_multiplier(self, gas_estimate_multiplier: f64) -> Self {
+        Self {
+            gas_estimate_multiplier,
+            ..self
+        }
+    }
+
+    pub fn gas_price_estimate_multiplier(self, gas_price_estimate_multiplier: f64) -> Self {
+        Self {
+            gas_price_estimate_multiplier,
+            ..self
+        }
+    }
+
+    /// Calling this function after manually specifying `nonce`, `gas` and `gas_price` turns
+    /// [ExecutionV3] into [PreparedExecutionV3]. Returns `Err` if any field is `None`.
+    pub fn prepared(self) -> Result<PreparedExecutionV3<'a, A>, NotPreparedError> {
+        let nonce = self.nonce.ok_or(NotPreparedError)?;
+        let gas = self.gas.ok_or(NotPreparedError)?;
+        let gas_price = self.gas_price.ok_or(NotPreparedError)?;
+
+        Ok(PreparedExecutionV3 {
+            account: self.account,
+            inner: RawExecutionV3 {
+                calls: self.calls,
+                nonce,
+                gas,
+                gas_price,
+            },
+        })
+    }
+}
+
+impl<'a, A> ExecutionV1<'a, A>
 where
     A: ConnectedAccount + Sync,
 {
@@ -119,7 +197,7 @@ where
         self.prepare().await?.send().await
     }
 
-    async fn prepare(&self) -> Result<PreparedExecution<'a, A>, AccountError<A::SignError>> {
+    async fn prepare(&self) -> Result<PreparedExecutionV1<'a, A>, AccountError<A::SignError>> {
         // Resolves nonce
         let nonce = match self.nonce {
             Some(value) => value,
@@ -142,9 +220,9 @@ where
             }
         };
 
-        Ok(PreparedExecution {
+        Ok(PreparedExecutionV1 {
             account: self.account,
-            inner: RawExecution {
+            inner: RawExecutionV1 {
                 calls: self.calls.clone(),
                 nonce,
                 max_fee,
@@ -156,9 +234,9 @@ where
         &self,
         nonce: FieldElement,
     ) -> Result<FeeEstimate, AccountError<A::SignError>> {
-        let prepared = PreparedExecution {
+        let prepared = PreparedExecutionV1 {
             account: self.account,
-            inner: RawExecution {
+            inner: RawExecutionV1 {
                 calls: self.calls.clone(),
                 nonce,
                 max_fee: FieldElement::ZERO,
@@ -172,7 +250,7 @@ where
         self.account
             .provider()
             .estimate_fee_single(
-                BroadcastedTransaction::Invoke(invoke),
+                BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(invoke)),
                 [],
                 self.account.block_id(),
             )
@@ -186,9 +264,9 @@ where
         skip_validate: bool,
         skip_fee_charge: bool,
     ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
-        let prepared = PreparedExecution {
+        let prepared = PreparedExecutionV1 {
             account: self.account,
-            inner: RawExecution {
+            inner: RawExecutionV1 {
                 calls: self.calls.clone(),
                 nonce,
                 max_fee: self.max_fee.unwrap_or_default(),
@@ -212,7 +290,7 @@ where
             .provider()
             .simulate_transaction(
                 self.account.block_id(),
-                BroadcastedTransaction::Invoke(invoke),
+                BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(invoke)),
                 &flags,
             )
             .await
@@ -220,7 +298,171 @@ where
     }
 }
 
-impl RawExecution {
+impl<'a, A> ExecutionV3<'a, A>
+where
+    A: ConnectedAccount + Sync,
+{
+    pub async fn estimate_fee(&self) -> Result<FeeEstimate, AccountError<A::SignError>> {
+        // Resolves nonce
+        let nonce = match self.nonce {
+            Some(value) => value,
+            None => self
+                .account
+                .get_nonce()
+                .await
+                .map_err(AccountError::Provider)?,
+        };
+
+        self.estimate_fee_with_nonce(nonce).await
+    }
+
+    pub async fn simulate(
+        &self,
+        skip_validate: bool,
+        skip_fee_charge: bool,
+    ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
+        // Resolves nonce
+        let nonce = match self.nonce {
+            Some(value) => value,
+            None => self
+                .account
+                .get_nonce()
+                .await
+                .map_err(AccountError::Provider)?,
+        };
+
+        self.simulate_with_nonce(nonce, skip_validate, skip_fee_charge)
+            .await
+    }
+
+    pub async fn send(&self) -> Result<InvokeTransactionResult, AccountError<A::SignError>> {
+        self.prepare().await?.send().await
+    }
+
+    async fn prepare(&self) -> Result<PreparedExecutionV3<'a, A>, AccountError<A::SignError>> {
+        // Resolves nonce
+        let nonce = match self.nonce {
+            Some(value) => value,
+            None => self
+                .account
+                .get_nonce()
+                .await
+                .map_err(AccountError::Provider)?,
+        };
+
+        // Resolves fee settings
+        let (gas, gas_price) = match (self.gas, self.gas_price) {
+            (Some(gas), Some(gas_price)) => (gas, gas_price),
+            // We have to perform fee estimation as long as it's not fully specified
+            _ => {
+                let fee_estimate = self.estimate_fee_with_nonce(nonce).await?;
+
+                let gas = match self.gas {
+                    Some(gas) => gas,
+                    None => {
+                        (((TryInto::<u64>::try_into(fee_estimate.gas_consumed)
+                            .map_err(|_| AccountError::FeeOutOfRange)?)
+                            as f64)
+                            * self.gas_estimate_multiplier) as u64
+                    }
+                };
+
+                let gas_price = match self.gas_price {
+                    Some(gas_price) => gas_price,
+                    None => {
+                        (((TryInto::<u64>::try_into(fee_estimate.gas_price)
+                            .map_err(|_| AccountError::FeeOutOfRange)?)
+                            as f64)
+                            * self.gas_price_estimate_multiplier) as u128
+                    }
+                };
+
+                (gas, gas_price)
+            }
+        };
+
+        Ok(PreparedExecutionV3 {
+            account: self.account,
+            inner: RawExecutionV3 {
+                calls: self.calls.clone(),
+                nonce,
+                gas,
+                gas_price,
+            },
+        })
+    }
+
+    async fn estimate_fee_with_nonce(
+        &self,
+        nonce: FieldElement,
+    ) -> Result<FeeEstimate, AccountError<A::SignError>> {
+        let prepared = PreparedExecutionV3 {
+            account: self.account,
+            inner: RawExecutionV3 {
+                calls: self.calls.clone(),
+                nonce,
+                gas: 0,
+                gas_price: 0,
+            },
+        };
+        let invoke = prepared
+            .get_invoke_request(true)
+            .await
+            .map_err(AccountError::Signing)?;
+
+        self.account
+            .provider()
+            .estimate_fee_single(
+                BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V3(invoke)),
+                [],
+                self.account.block_id(),
+            )
+            .await
+            .map_err(AccountError::Provider)
+    }
+
+    async fn simulate_with_nonce(
+        &self,
+        nonce: FieldElement,
+        skip_validate: bool,
+        skip_fee_charge: bool,
+    ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
+        let prepared = PreparedExecutionV3 {
+            account: self.account,
+            inner: RawExecutionV3 {
+                calls: self.calls.clone(),
+                nonce,
+                gas: self.gas.unwrap_or_default(),
+                gas_price: self.gas_price.unwrap_or_default(),
+            },
+        };
+        let invoke = prepared
+            .get_invoke_request(true)
+            .await
+            .map_err(AccountError::Signing)?;
+
+        let mut flags = vec![];
+
+        if skip_validate {
+            flags.push(SimulationFlag::SkipValidate);
+        }
+        if skip_fee_charge {
+            flags.push(SimulationFlag::SkipFeeCharge);
+        }
+
+        self.account
+            .provider()
+            .simulate_transaction(
+                self.account.block_id(),
+                BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V3(invoke)),
+                &flags,
+            )
+            .await
+            .map_err(AccountError::Provider)
+    }
+}
+
+impl RawExecutionV1 {
     pub fn transaction_hash<E>(
         &self,
         chain_id: FieldElement,
@@ -260,7 +502,95 @@ impl RawExecution {
     }
 }
 
-impl<'a, A> PreparedExecution<'a, A>
+impl RawExecutionV3 {
+    pub fn transaction_hash<E>(
+        &self,
+        chain_id: FieldElement,
+        address: FieldElement,
+        query_only: bool,
+        encoder: E,
+    ) -> FieldElement
+    where
+        E: ExecutionEncoder,
+    {
+        let mut hasher = PoseidonHasher::new();
+
+        hasher.update(PREFIX_INVOKE);
+        hasher.update(if query_only {
+            QUERY_VERSION_THREE
+        } else {
+            FieldElement::THREE
+        });
+        hasher.update(address);
+
+        hasher.update({
+            let mut fee_hasher = PoseidonHasher::new();
+
+            // Tip: fee market has not been been activated yet so it's hard-coded to be 0
+            fee_hasher.update(FieldElement::ZERO);
+
+            let mut resource_buffer = [
+                0, 0, b'L', b'1', b'_', b'G', b'A', b'S', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ];
+            resource_buffer[8..(8 + 8)].copy_from_slice(&self.gas.to_be_bytes());
+            resource_buffer[(8 + 8)..].copy_from_slice(&self.gas_price.to_be_bytes());
+            fee_hasher.update(FieldElement::from_bytes_be(&resource_buffer).unwrap());
+
+            // L2 resources are hard-coded to 0
+            let resource_buffer = [
+                0, 0, b'L', b'2', b'_', b'G', b'A', b'S', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ];
+            fee_hasher.update(FieldElement::from_bytes_be(&resource_buffer).unwrap());
+
+            fee_hasher.finalize()
+        });
+
+        // Hard-coded empty `paymaster_data`
+        hasher.update(PoseidonHasher::new().finalize());
+
+        hasher.update(chain_id);
+        hasher.update(self.nonce);
+
+        // Hard-coded L1 DA mode for nonce and fee
+        hasher.update(FieldElement::ZERO);
+
+        // Hard-coded empty `account_deployment_data`
+        hasher.update(PoseidonHasher::new().finalize());
+
+        hasher.update({
+            let mut calldata_hasher = PoseidonHasher::new();
+
+            encoder
+                .encode_calls(&self.calls)
+                .into_iter()
+                .for_each(|element| calldata_hasher.update(element));
+
+            calldata_hasher.finalize()
+        });
+
+        hasher.finalize()
+    }
+
+    pub fn calls(&self) -> &[Call] {
+        &self.calls
+    }
+
+    pub fn nonce(&self) -> FieldElement {
+        self.nonce
+    }
+
+    pub fn gas(&self) -> u64 {
+        self.gas
+    }
+
+    pub fn gas_price(&self) -> u128 {
+        self.gas_price
+    }
+}
+
+impl<'a, A> PreparedExecutionV1<'a, A>
 where
     A: Account,
 {
@@ -276,7 +606,23 @@ where
     }
 }
 
-impl<'a, A> PreparedExecution<'a, A>
+impl<'a, A> PreparedExecutionV3<'a, A>
+where
+    A: Account,
+{
+    /// Locally calculates the hash of the transaction to be sent from this execution given the
+    /// parameters.
+    pub fn transaction_hash(&self, query_only: bool) -> FieldElement {
+        self.inner.transaction_hash(
+            self.account.chain_id(),
+            self.account.address(),
+            query_only,
+            self.account,
+        )
+    }
+}
+
+impl<'a, A> PreparedExecutionV1<'a, A>
 where
     A: ConnectedAccount,
 {
@@ -287,7 +633,7 @@ where
             .map_err(AccountError::Signing)?;
         self.account
             .provider()
-            .add_invoke_transaction(tx_request)
+            .add_invoke_transaction(BroadcastedInvokeTransaction::V1(tx_request))
             .await
             .map_err(AccountError::Provider)
     }
@@ -298,18 +644,77 @@ where
     pub async fn get_invoke_request(
         &self,
         query_only: bool,
-    ) -> Result<BroadcastedInvokeTransaction, A::SignError> {
-        let signature = self.account.sign_execution(&self.inner, query_only).await?;
+    ) -> Result<BroadcastedInvokeTransactionV1, A::SignError> {
+        let signature = self
+            .account
+            .sign_execution_v1(&self.inner, query_only)
+            .await?;
 
-        Ok(BroadcastedInvokeTransaction::V1(
-            BroadcastedInvokeTransactionV1 {
-                max_fee: self.inner.max_fee,
-                signature,
-                nonce: self.inner.nonce,
-                sender_address: self.account.address(),
-                calldata: self.account.encode_calls(&self.inner.calls),
-                is_query: query_only,
+        Ok(BroadcastedInvokeTransactionV1 {
+            max_fee: self.inner.max_fee,
+            signature,
+            nonce: self.inner.nonce,
+            sender_address: self.account.address(),
+            calldata: self.account.encode_calls(&self.inner.calls),
+            is_query: query_only,
+        })
+    }
+}
+
+impl<'a, A> PreparedExecutionV3<'a, A>
+where
+    A: ConnectedAccount,
+{
+    pub async fn send(&self) -> Result<InvokeTransactionResult, AccountError<A::SignError>> {
+        let tx_request = self
+            .get_invoke_request(false)
+            .await
+            .map_err(AccountError::Signing)?;
+        self.account
+            .provider()
+            .add_invoke_transaction(BroadcastedInvokeTransaction::V3(tx_request))
+            .await
+            .map_err(AccountError::Provider)
+    }
+
+    // The `simulate` function is temporarily removed until it's supported in [Provider]
+    // TODO: add `simulate` back once transaction simulation in supported
+
+    pub async fn get_invoke_request(
+        &self,
+        query_only: bool,
+    ) -> Result<BroadcastedInvokeTransactionV3, A::SignError> {
+        let signature = self
+            .account
+            .sign_execution_v3(&self.inner, query_only)
+            .await?;
+
+        Ok(BroadcastedInvokeTransactionV3 {
+            sender_address: self.account.address(),
+            calldata: self.account.encode_calls(&self.inner.calls),
+            signature,
+            nonce: self.inner.nonce,
+            resource_bounds: ResourceBoundsMapping {
+                l1_gas: ResourceBounds {
+                    max_amount: self.inner.gas,
+                    max_price_per_unit: self.inner.gas_price,
+                },
+                // L2 resources are hard-coded to 0
+                l2_gas: ResourceBounds {
+                    max_amount: 0,
+                    max_price_per_unit: 0,
+                },
             },
-        ))
+            // Fee market has not been been activated yet so it's hard-coded to be 0
+            tip: 0,
+            // Hard-coded empty `paymaster_data`
+            paymaster_data: vec![],
+            // Hard-coded empty `account_deployment_data`
+            account_deployment_data: vec![],
+            // Hard-coded L1 DA mode for nonce and fee
+            nonce_data_availability_mode: DataAvailabilityMode::L1,
+            fee_data_availability_mode: DataAvailabilityMode::L1,
+            is_query: query_only,
+        })
     }
 }

--- a/starknet-accounts/src/factory/argent.rs
+++ b/starknet-accounts/src/factory/argent.rs
@@ -1,4 +1,7 @@
-use crate::{AccountFactory, PreparedAccountDeployment, RawAccountDeployment};
+use crate::{
+    AccountFactory, PreparedAccountDeploymentV1, PreparedAccountDeploymentV3,
+    RawAccountDeploymentV1, RawAccountDeploymentV3,
+};
 
 use async_trait::async_trait;
 use starknet_core::types::{BlockId, BlockTag, FieldElement};
@@ -74,12 +77,23 @@ where
         self.block_id
     }
 
-    async fn sign_deployment(
+    async fn sign_deployment_v1(
         &self,
-        deployment: &RawAccountDeployment,
+        deployment: &RawAccountDeploymentV1,
     ) -> Result<Vec<FieldElement>, Self::SignError> {
         let tx_hash =
-            PreparedAccountDeployment::from_raw(deployment.clone(), self).transaction_hash();
+            PreparedAccountDeploymentV1::from_raw(deployment.clone(), self).transaction_hash();
+        let signature = self.signer.sign_hash(&tx_hash).await?;
+
+        Ok(vec![signature.r, signature.s])
+    }
+
+    async fn sign_deployment_v3(
+        &self,
+        deployment: &RawAccountDeploymentV3,
+    ) -> Result<Vec<FieldElement>, Self::SignError> {
+        let tx_hash =
+            PreparedAccountDeploymentV3::from_raw(deployment.clone(), self).transaction_hash();
         let signature = self.signer.sign_hash(&tx_hash).await?;
 
         Ok(vec![signature.r, signature.s])

--- a/starknet-accounts/src/factory/open_zeppelin.rs
+++ b/starknet-accounts/src/factory/open_zeppelin.rs
@@ -1,4 +1,7 @@
-use crate::{AccountFactory, PreparedAccountDeployment, RawAccountDeployment};
+use crate::{
+    AccountFactory, PreparedAccountDeploymentV1, PreparedAccountDeploymentV3,
+    RawAccountDeploymentV1, RawAccountDeploymentV3,
+};
 
 use async_trait::async_trait;
 use starknet_core::types::{BlockId, BlockTag, FieldElement};
@@ -71,12 +74,23 @@ where
         self.block_id
     }
 
-    async fn sign_deployment(
+    async fn sign_deployment_v1(
         &self,
-        deployment: &RawAccountDeployment,
+        deployment: &RawAccountDeploymentV1,
     ) -> Result<Vec<FieldElement>, Self::SignError> {
         let tx_hash =
-            PreparedAccountDeployment::from_raw(deployment.clone(), self).transaction_hash();
+            PreparedAccountDeploymentV1::from_raw(deployment.clone(), self).transaction_hash();
+        let signature = self.signer.sign_hash(&tx_hash).await?;
+
+        Ok(vec![signature.r, signature.s])
+    }
+
+    async fn sign_deployment_v3(
+        &self,
+        deployment: &RawAccountDeploymentV3,
+    ) -> Result<Vec<FieldElement>, Self::SignError> {
+        let tx_hash =
+            PreparedAccountDeploymentV3::from_raw(deployment.clone(), self).transaction_hash();
         let signature = self.signer.sign_hash(&tx_hash).await?;
 
         Ok(vec![signature.r, signature.s])

--- a/starknet-accounts/src/lib.rs
+++ b/starknet-accounts/src/lib.rs
@@ -1,8 +1,9 @@
 mod account;
 pub use account::{
-    Account, AccountError, ConnectedAccount, Declaration, Execution, ExecutionEncoder,
-    LegacyDeclaration, PreparedDeclaration, PreparedExecution, PreparedLegacyDeclaration,
-    RawDeclaration, RawExecution, RawLegacyDeclaration,
+    Account, AccountError, ConnectedAccount, DeclarationV2, DeclarationV3, ExecutionEncoder,
+    ExecutionV1, ExecutionV3, LegacyDeclaration, PreparedDeclarationV2, PreparedDeclarationV3,
+    PreparedExecutionV1, PreparedExecutionV3, PreparedLegacyDeclaration, RawDeclarationV2,
+    RawDeclarationV3, RawExecutionV1, RawExecutionV3, RawLegacyDeclaration,
 };
 
 mod call;
@@ -10,8 +11,9 @@ pub use call::Call;
 
 mod factory;
 pub use factory::{
-    argent::ArgentAccountFactory, open_zeppelin::OpenZeppelinAccountFactory, AccountDeployment,
-    AccountFactory, AccountFactoryError, PreparedAccountDeployment, RawAccountDeployment,
+    argent::ArgentAccountFactory, open_zeppelin::OpenZeppelinAccountFactory, AccountDeploymentV1,
+    AccountDeploymentV3, AccountFactory, AccountFactoryError, PreparedAccountDeploymentV1,
+    PreparedAccountDeploymentV3, RawAccountDeploymentV1, RawAccountDeploymentV3,
 };
 
 pub mod single_owner;

--- a/starknet-accounts/src/single_owner.rs
+++ b/starknet-accounts/src/single_owner.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Account, Call, ConnectedAccount, ExecutionEncoder, RawDeclaration, RawExecution,
-    RawLegacyDeclaration,
+    Account, Call, ConnectedAccount, ExecutionEncoder, RawDeclarationV2, RawDeclarationV3,
+    RawExecutionV1, RawExecutionV3, RawLegacyDeclaration,
 };
 
 use async_trait::async_trait;
@@ -94,9 +94,9 @@ where
         self.chain_id
     }
 
-    async fn sign_execution(
+    async fn sign_execution_v1(
         &self,
-        execution: &RawExecution,
+        execution: &RawExecutionV1,
         query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError> {
         let tx_hash = execution.transaction_hash(self.chain_id, self.address, query_only, self);
@@ -109,9 +109,39 @@ where
         Ok(vec![signature.r, signature.s])
     }
 
-    async fn sign_declaration(
+    async fn sign_execution_v3(
         &self,
-        declaration: &RawDeclaration,
+        execution: &RawExecutionV3,
+        query_only: bool,
+    ) -> Result<Vec<FieldElement>, Self::SignError> {
+        let tx_hash = execution.transaction_hash(self.chain_id, self.address, query_only, self);
+        let signature = self
+            .signer
+            .sign_hash(&tx_hash)
+            .await
+            .map_err(SignError::Signer)?;
+
+        Ok(vec![signature.r, signature.s])
+    }
+
+    async fn sign_declaration_v2(
+        &self,
+        declaration: &RawDeclarationV2,
+        query_only: bool,
+    ) -> Result<Vec<FieldElement>, Self::SignError> {
+        let tx_hash = declaration.transaction_hash(self.chain_id, self.address, query_only);
+        let signature = self
+            .signer
+            .sign_hash(&tx_hash)
+            .await
+            .map_err(SignError::Signer)?;
+
+        Ok(vec![signature.r, signature.s])
+    }
+
+    async fn sign_declaration_v3(
+        &self,
+        declaration: &RawDeclarationV3,
         query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError> {
         let tx_hash = declaration.transaction_hash(self.chain_id, self.address, query_only);


### PR DESCRIPTION
Adds support for v3 transactions on account types. Methods like `.execute()` are replaced with suffixed versions like `.execute_v1()` and `.execute_v3()`. The original `.execute()` methods are still kept for now, but deprecated. To minimize breakage, these deprecated methods point to pre-v3 transactions instead of the latest, recommended v3 transactions.