### PR TITLE
ci: allow some nightly lints

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -78,11 +78,19 @@ jobs:
           components: "clippy"
           override: true
 
+      - name: "Set allowed lints"
+        run: |
+          if [ "${{ matrix.toolchain }}" == "nightly" ]; then
+            echo "ALLOWED=-A non_local_definitions" >> $GITHUB_ENV
+          else
+            echo "ALLOWED=" >> $GITHUB_ENV
+          fi
+
       - name: "Run Clippy (default)"
         run: |
-          cargo clippy --all --all-targets -- -D warnings
+          cargo clippy --all --all-targets -- -D warnings $ALLOWED
 
       - name: "Run Clippy (no_std)"
         run: |
-          cargo clippy --package starknet-crypto --no-default-features -- -D warnings
-          cargo clippy --package starknet-crypto --no-default-features --features alloc -- -D warnings
+          cargo clippy --package starknet-crypto --no-default-features -- -D warnings $ALLOWED
+          cargo clippy --package starknet-crypto --no-default-features --features alloc -- -D warnings $ALLOWED

--- a/starknet-contract/tests/contract_deployment.rs
+++ b/starknet-contract/tests/contract_deployment.rs
@@ -52,7 +52,7 @@ async fn can_deploy_contract_to_alpha_sepolia() {
             FieldElement::from_bytes_be(&salt_buffer).unwrap(),
             true,
         )
-        .max_fee(FieldElement::from_dec_str("1000000000000000000").unwrap())
+        .max_fee(FieldElement::from_dec_str("100000000000000000").unwrap())
         .send()
         .await;
 

--- a/starknet-crypto/src/test_utils.rs
+++ b/starknet-crypto/src/test_utils.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 use crate::FieldElement;
 
 pub fn field_element_from_be_hex(hex: &str) -> FieldElement {


### PR DESCRIPTION
A new nightly lint `non_local_definitions` is failing CI.