### PR TITLE
feat: do not estimate fee when gas is specified

### DIFF
--- a/starknet-accounts/src/account/declaration.rs
+++ b/starknet-accounts/src/account/declaration.rs
@@ -373,7 +373,29 @@ where
         // Resolves fee settings
         let (gas, gas_price) = match (self.gas, self.gas_price) {
             (Some(gas), Some(gas_price)) => (gas, gas_price),
-            // We have to perform fee estimation as long as it's not fully specified
+            (Some(gas), _) => {
+                // When `gas` is specified, we only need the L1 gas price in FRI. By specifying a
+                // a `gas` value, the user might be trying to avoid a full fee estimation (e.g.
+                // flaky dependencies), so it's in appropriate to call `estimate_fee` here.
+
+                // This is the lightest-weight block we can get
+                let block_l1_gas_price = self
+                    .account
+                    .provider()
+                    .get_block_with_tx_hashes(self.account.block_id())
+                    .await
+                    .map_err(AccountError::Provider)?
+                    .l1_gas_price()
+                    .price_in_fri;
+
+                let gas_price = (((TryInto::<u64>::try_into(block_l1_gas_price)
+                    .map_err(|_| AccountError::FeeOutOfRange)?)
+                    as f64)
+                    * self.gas_price_estimate_multiplier) as u128;
+
+                (gas, gas_price)
+            }
+            // We have to perform fee estimation as long as gas is not specified
             _ => {
                 let fee_estimate = self.estimate_fee_with_nonce(nonce).await?;
 

--- a/starknet-accounts/src/account/execution.rs
+++ b/starknet-accounts/src/account/execution.rs
@@ -353,7 +353,29 @@ where
         // Resolves fee settings
         let (gas, gas_price) = match (self.gas, self.gas_price) {
             (Some(gas), Some(gas_price)) => (gas, gas_price),
-            // We have to perform fee estimation as long as it's not fully specified
+            (Some(gas), _) => {
+                // When `gas` is specified, we only need the L1 gas price in FRI. By specifying a
+                // a `gas` value, the user might be trying to avoid a full fee estimation (e.g.
+                // flaky dependencies), so it's in appropriate to call `estimate_fee` here.
+
+                // This is the lightest-weight block we can get
+                let block_l1_gas_price = self
+                    .account
+                    .provider()
+                    .get_block_with_tx_hashes(self.account.block_id())
+                    .await
+                    .map_err(AccountError::Provider)?
+                    .l1_gas_price()
+                    .price_in_fri;
+
+                let gas_price = (((TryInto::<u64>::try_into(block_l1_gas_price)
+                    .map_err(|_| AccountError::FeeOutOfRange)?)
+                    as f64)
+                    * self.gas_price_estimate_multiplier) as u128;
+
+                (gas, gas_price)
+            }
+            // We have to perform fee estimation as long as gas is not specified
             _ => {
                 let fee_estimate = self.estimate_fee_with_nonce(nonce).await?;
 

--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -526,7 +526,29 @@ where
         // Resolves fee settings
         let (gas, gas_price) = match (self.gas, self.gas_price) {
             (Some(gas), Some(gas_price)) => (gas, gas_price),
-            // We have to perform fee estimation as long as it's not fully specified
+            (Some(gas), _) => {
+                // When `gas` is specified, we only need the L1 gas price in FRI. By specifying a
+                // a `gas` value, the user might be trying to avoid a full fee estimation (e.g.
+                // flaky dependencies), so it's in appropriate to call `estimate_fee` here.
+
+                // This is the lightest-weight block we can get
+                let block_l1_gas_price = self
+                    .factory
+                    .provider()
+                    .get_block_with_tx_hashes(self.factory.block_id())
+                    .await
+                    .map_err(AccountFactoryError::Provider)?
+                    .l1_gas_price()
+                    .price_in_fri;
+
+                let gas_price = (((TryInto::<u64>::try_into(block_l1_gas_price)
+                    .map_err(|_| AccountFactoryError::FeeOutOfRange)?)
+                    as f64)
+                    * self.gas_price_estimate_multiplier) as u128;
+
+                (gas, gas_price)
+            }
+            // We have to perform fee estimation as long as gas is not specified
             _ => {
                 let fee_estimate = self.estimate_fee_with_nonce(nonce).await?;
 

--- a/starknet-contract/tests/contract_deployment.rs
+++ b/starknet-contract/tests/contract_deployment.rs
@@ -98,7 +98,7 @@ async fn can_deploy_contract_to_alpha_sepolia_with_invoke_v3() {
             FieldElement::from_bytes_be(&salt_buffer).unwrap(),
             true,
         )
-        .gas(8000)
+        .gas(20000)
         .gas_price(100000000000000)
         .send()
         .await;

--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -340,6 +340,13 @@ impl MaybePendingBlockWithTxHashes {
             MaybePendingBlockWithTxHashes::PendingBlock(block) => &block.transactions,
         }
     }
+
+    pub fn l1_gas_price(&self) -> &ResourcePrice {
+        match self {
+            MaybePendingBlockWithTxHashes::Block(block) => &block.l1_gas_price,
+            MaybePendingBlockWithTxHashes::PendingBlock(block) => &block.l1_gas_price,
+        }
+    }
 }
 
 impl MaybePendingBlockWithTxs {
@@ -349,6 +356,13 @@ impl MaybePendingBlockWithTxs {
             MaybePendingBlockWithTxs::PendingBlock(block) => &block.transactions,
         }
     }
+
+    pub fn l1_gas_price(&self) -> &ResourcePrice {
+        match self {
+            MaybePendingBlockWithTxs::Block(block) => &block.l1_gas_price,
+            MaybePendingBlockWithTxs::PendingBlock(block) => &block.l1_gas_price,
+        }
+    }
 }
 
 impl MaybePendingBlockWithReceipts {
@@ -356,6 +370,13 @@ impl MaybePendingBlockWithReceipts {
         match self {
             MaybePendingBlockWithReceipts::Block(block) => &block.transactions,
             MaybePendingBlockWithReceipts::PendingBlock(block) => &block.transactions,
+        }
+    }
+
+    pub fn l1_gas_price(&self) -> &ResourcePrice {
+        match self {
+            MaybePendingBlockWithReceipts::Block(block) => &block.l1_gas_price,
+            MaybePendingBlockWithReceipts::PendingBlock(block) => &block.l1_gas_price,
         }
     }
 }


### PR DESCRIPTION
Similar to setting gas limit on Ethereum txs, setting L1 gas on a v3 Starknet tx signals that the caller understands the tx's impact. Previously, the library would incorrectly always perform a full fee estimation as long as any of `gas` and `gas_price` is not specified.