### PR TITLE
fix: missing nonce setter for `AccountDeploymentV3`

### DIFF
--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -227,6 +227,13 @@ impl<'f, F> AccountDeploymentV3<'f, F> {
         }
     }
 
+    pub fn nonce(self, nonce: FieldElement) -> Self {
+        Self {
+            nonce: Some(nonce),
+            ..self
+        }
+    }
+
     pub fn gas(self, gas: u64) -> Self {
         Self {
             gas: Some(gas),


### PR DESCRIPTION
No way to set `nonce` on `AccountDeploymentV3`.