### PR TITLE
fix: incorrect v3 max gas amount calculation

### DIFF
--- a/starknet-accounts/src/account/declaration.rs
+++ b/starknet-accounts/src/account/declaration.rs
@@ -402,8 +402,11 @@ where
                 let gas = match self.gas {
                     Some(gas) => gas,
                     None => {
-                        (((TryInto::<u64>::try_into(fee_estimate.gas_consumed)
-                            .map_err(|_| AccountError::FeeOutOfRange)?)
+                        (((TryInto::<u64>::try_into(
+                            (fee_estimate.overall_fee + fee_estimate.gas_price - FieldElement::ONE)
+                                .floor_div(fee_estimate.gas_price),
+                        )
+                        .map_err(|_| AccountError::FeeOutOfRange)?)
                             as f64)
                             * self.gas_estimate_multiplier) as u64
                     }

--- a/starknet-accounts/src/account/execution.rs
+++ b/starknet-accounts/src/account/execution.rs
@@ -382,8 +382,11 @@ where
                 let gas = match self.gas {
                     Some(gas) => gas,
                     None => {
-                        (((TryInto::<u64>::try_into(fee_estimate.gas_consumed)
-                            .map_err(|_| AccountError::FeeOutOfRange)?)
+                        (((TryInto::<u64>::try_into(
+                            (fee_estimate.overall_fee + fee_estimate.gas_price - FieldElement::ONE)
+                                .floor_div(fee_estimate.gas_price),
+                        )
+                        .map_err(|_| AccountError::FeeOutOfRange)?)
                             as f64)
                             * self.gas_estimate_multiplier) as u64
                     }

--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -562,8 +562,11 @@ where
                 let gas = match self.gas {
                     Some(gas) => gas,
                     None => {
-                        (((TryInto::<u64>::try_into(fee_estimate.gas_consumed)
-                            .map_err(|_| AccountFactoryError::FeeOutOfRange)?)
+                        (((TryInto::<u64>::try_into(
+                            (fee_estimate.overall_fee + fee_estimate.gas_price - FieldElement::ONE)
+                                .floor_div(fee_estimate.gas_price),
+                        )
+                        .map_err(|_| AccountFactoryError::FeeOutOfRange)?)
                             as f64)
                             * self.gas_estimate_multiplier) as u64
                     }

--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -397,7 +397,7 @@ async fn can_execute_eth_transfer_invoke_v3_inner<P: Provider + Send + Sync>(
                 FieldElement::ZERO,
             ],
         }])
-        .gas(20000)
+        .gas(200000)
         .gas_price(100000000000000)
         .send()
         .await
@@ -440,7 +440,7 @@ async fn can_execute_eth_transfer_invoke_v3_with_manual_gas_inner<P: Provider + 
                 FieldElement::ZERO,
             ],
         }])
-        .gas(20000)
+        .gas(200000)
         .send()
         .await
         .unwrap();
@@ -601,7 +601,7 @@ async fn can_declare_cairo1_contract_v3_inner<P: Provider + Send + Sync>(
             Arc::new(flattened_class),
             FieldElement::from_hex_be(&hashes.compiled_class_hash).unwrap(),
         )
-        .gas(20000)
+        .gas(200000)
         .gas_price(100000000000000)
         .send()
         .await

--- a/starknet-contract/tests/contract_deployment.rs
+++ b/starknet-contract/tests/contract_deployment.rs
@@ -98,7 +98,7 @@ async fn can_deploy_contract_to_alpha_sepolia_with_invoke_v3() {
             FieldElement::from_bytes_be(&salt_buffer).unwrap(),
             true,
         )
-        .gas(20000)
+        .gas(200000)
         .gas_price(100000000000000)
         .send()
         .await;


### PR DESCRIPTION
When using JSON-RPC v0.7.0, the fee estimate returned contains data gas info. Naively using `gas_consumed` as max gas amount results in insufficient fees. The correct way to do it is to calculate a pseudo gas amount by dividing the overall fee by the gas price.