### PR TITLE
fix: corrosion cpp integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,3 +49,30 @@ jobs:
       - name: "Build all feature combinations"
         run: |
           cargo hack build --package ${{ matrix.package }} --feature-powerset
+
+  cpp-integration:
+    name: "Build C++ integration example"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Checkout source code"
+        uses: "actions/checkout@v3"
+
+      - name: "Setup stable toolchain"
+        uses: "actions-rs/toolchain@v1"
+        with:
+          toolchain: "stable"
+          profile: "minimal"
+          override: true
+
+      - name: "Build starknet-cxx example"
+        run: |
+          cd ./examples/starknet-cxx
+          mkdir build
+          cd ./build
+          cmake -DCMAKE_BUILD_TYPE=Release ..
+          make
+
+      - name: "Run starknet-cxx example"
+        run: |
+          ./examples/starknet-cxx/build/main

--- a/examples/starknet-cxx/CMakeLists.txt
+++ b/examples/starknet-cxx/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_STANDARD 17)
 FetchContent_Declare(
     Corrosion
     GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-    GIT_TAG master
+    GIT_TAG v0.5.0
 )
 FetchContent_MakeAvailable(Corrosion)
 

--- a/examples/starknet-cxx/starknet-cxx/CMakeLists.txt
+++ b/examples/starknet-cxx/starknet-cxx/CMakeLists.txt
@@ -1,2 +1,2 @@
 corrosion_import_crate(MANIFEST_PATH Cargo.toml)
-corrosion_add_cxxbridge(starknet_cxx_bridge CRATE starknet-cxx MANIFEST_PATH starknet-cxx FILES lib.rs)
+corrosion_add_cxxbridge(starknet_cxx_bridge CRATE starknet_cxx MANIFEST_PATH starknet_cxx FILES lib.rs)


### PR DESCRIPTION
Fixes a recent breaking change in corrosion-rs breaking the starknet-cxx example. Also adds a CI workflow for checking the integration example.