### PR TITLE
feat: const ctors for `EthAddress` and `Hash256`

### DIFF
--- a/starknet-core/src/types/eth_address.rs
+++ b/starknet-core/src/types/eth_address.rs
@@ -71,6 +71,10 @@ mod errors {
 pub use errors::{FromBytesSliceError, FromFieldElementError, FromHexError};
 
 impl EthAddress {
+    pub const fn from_bytes(bytes: [u8; 20]) -> Self {
+        Self { inner: bytes }
+    }
+
     pub fn from_hex(hex: &str) -> Result<Self, FromHexError> {
         hex.parse()
     }

--- a/starknet-core/src/types/hash_256.rs
+++ b/starknet-core/src/types/hash_256.rs
@@ -56,7 +56,7 @@ mod errors {
 pub use errors::{FromHexError, ToFieldElementError};
 
 impl Hash256 {
-    pub fn from_bytes(bytes: [u8; HASH_256_BYTE_COUNT]) -> Self {
+    pub const fn from_bytes(bytes: [u8; HASH_256_BYTE_COUNT]) -> Self {
         Self { inner: bytes }
     }
 


### PR DESCRIPTION
So that these types can be constructed in a `const` context.