### PR TITLE
chore: make nightly clippy happy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 //! # Complete Starknet library in Rust™
 //!
 //! > _Note that `starknet-rs` is still experimental. Breaking changes will be made before the first
-//! stable release. Use at your own risk._
+//! > stable release. Use at your own risk._
 //!
 //! > _The underlying cryptography library `starknet-crypto` does NOT provide constant-time
-//! guarantees._
+//! > guarantees._
 //!
 //! `starknet-rs` is a Rust™ client library for Starknet. The current version offers full API
 //! coverage of the sequencer gateway and feeder gateway.

--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -180,6 +180,7 @@ async fn can_declare_cairo0_contract_with_sequencer() {
 }
 
 #[tokio::test]
+#[ignore = "Cairo 0 contract declaration has been blocked"]
 async fn can_declare_cairo0_contract_with_jsonrpc() {
     can_declare_cairo0_contract_inner(
         create_jsonrpc_client(),

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -665,7 +665,7 @@ async fn jsonrpc_estimate_fee() {
 
     let estimate = rpc_client
         .estimate_fee_single(
-            &BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(
+            BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(
                 BroadcastedInvokeTransactionV1 {
                     max_fee: FieldElement::ZERO,
                     signature: vec![


### PR DESCRIPTION
Resolves new nightly lints.

Also disables the Cairo 0 declaration test as it looks like it's now blocked on Sepolia.