### PR TITLE
feat: make hasher accept iterators rather than arrays

### DIFF
--- a/starknet-core/src/crypto.rs
+++ b/starknet-core/src/crypto.rs
@@ -46,14 +46,19 @@ mod errors {
 }
 pub use errors::{EcdsaSignError, EcdsaVerifyError};
 
-pub fn compute_hash_on_elements(data: &[Felt]) -> Felt {
+pub fn compute_hash_on_elements<'a, ESI, II>(data: II) -> Felt
+where
+    ESI: ExactSizeIterator<Item = &'a Felt>,
+    II: IntoIterator<IntoIter = ESI>,
+{
     let mut current_hash = Felt::ZERO;
+    let data_iter = data.into_iter();
+    let data_len = Felt::from(data_iter.len());
 
-    for item in data.iter() {
-        current_hash = pedersen_hash(&current_hash, item);
+    for elem in data_iter {
+        current_hash = pedersen_hash(&current_hash, elem);
     }
 
-    let data_len = Felt::from(data.len());
     pedersen_hash(&current_hash, &data_len)
 }
 

--- a/starknet-crypto/src/poseidon_hash.rs
+++ b/starknet-crypto/src/poseidon_hash.rs
@@ -95,6 +95,7 @@ pub fn poseidon_hash_many<'a, I: IntoIterator<Item = &'a Felt>>(msgs: I) -> Felt
 
         poseidon_permute_comp(&mut state);
     }
+    poseidon_permute_comp(&mut state);
 
     state[0]
 }


### PR DESCRIPTION
closes #575

No breaking change as both new impl are backward compatible with the only previously allowed input type `&[FieldElement]`