### PR TITLE
release: bump starknet to 0.11.0 (and deps) (#576)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,7 +1534,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "starknet"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde_json",
  "starknet-accounts",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "rand",
  "serde",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64 0.21.0",
  "criterion",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "crypto-bigint",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto-codegen"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "starknet-curve",
  "starknet-types-core",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-curve"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "starknet-types-core",
 ]
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-macros"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "starknet-core",
  "syn 2.0.63",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -33,13 +33,13 @@ members = [
 all-features = true
 
 [dependencies]
-starknet-crypto = { version = "0.6.2", path = "./starknet-crypto" }
-starknet-core = { version = "0.10.0", path = "./starknet-core", default-features = false }
-starknet-providers = { version = "0.10.0", path = "./starknet-providers" }
-starknet-contract = { version = "0.9.0", path = "./starknet-contract" }
-starknet-signers = { version = "0.8.0", path = "./starknet-signers" }
-starknet-accounts = { version = "0.9.0", path = "./starknet-accounts" }
-starknet-macros = { version = "0.1.7", path = "./starknet-macros" }
+starknet-crypto = { version = "0.7.0", path = "./starknet-crypto" }
+starknet-core = { version = "0.11.0", path = "./starknet-core", default-features = false }
+starknet-providers = { version = "0.11.0", path = "./starknet-providers" }
+starknet-contract = { version = "0.10.0", path = "./starknet-contract" }
+starknet-signers = { version = "0.9.0", path = "./starknet-signers" }
+starknet-accounts = { version = "0.10.0", path = "./starknet-accounts" }
+starknet-macros = { version = "0.2.0", path = "./starknet-macros" }
 
 [dev-dependencies]
 serde_json = "1.0.74"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To use the crate from [crates.io](https://crates.io/crates/starknet), add the fo
 
 ```toml
 [dependencies]
-starknet = "0.9.0"
+starknet = "0.11.0"
 ```
 
 Note that the [crates.io version](https://crates.io/crates/starknet) might be outdated. You may want to use the library directly from GitHub for all the latest features and fixes:

--- a/examples/starknet-wasm/Cargo.toml
+++ b/examples/starknet-wasm/Cargo.toml
@@ -19,6 +19,6 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-starknet-crypto = { version = "0.6.2", path = "../../starknet-crypto" }
+starknet-crypto = { version = "0.7.0", path = "../../starknet-crypto" }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 wasm-bindgen = "0.2.84"

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-accounts"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,10 +14,10 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.10.0", path = "../starknet-core" }
-starknet-crypto = { version = "0.6.2", path = "../starknet-crypto" }
-starknet-providers = { version = "0.10.0", path = "../starknet-providers" }
-starknet-signers = { version = "0.8.0", path = "../starknet-signers" }
+starknet-core = { version = "0.11.0", path = "../starknet-core" }
+starknet-crypto = { version = "0.7.0", path = "../starknet-crypto" }
+starknet-providers = { version = "0.11.0", path = "../starknet-providers" }
+starknet-signers = { version = "0.9.0", path = "../starknet-signers" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 thiserror = "1.0.40"

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-contract"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,9 +14,9 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.10.0", path = "../starknet-core" }
-starknet-providers = { version = "0.10.0", path = "../starknet-providers" }
-starknet-accounts = { version = "0.9.0", path = "../starknet-accounts" }
+starknet-core = { version = "0.11.0", path = "../starknet-core" }
+starknet-providers = { version = "0.11.0", path = "../starknet-providers" }
+starknet-accounts = { version = "0.10.0", path = "../starknet-accounts" }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
 serde_with = "2.3.2"
@@ -24,6 +24,6 @@ thiserror = "1.0.40"
 
 [dev-dependencies]
 rand = { version = "0.8.5", features=["std_rng"] }
-starknet-signers = { version = "0.8.0", path = "../starknet-signers" }
+starknet-signers = { version = "0.9.0", path = "../starknet-signers" }
 tokio = { version = "1.27.0", features = ["full"] }
 url = "2.3.1"

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-core"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -17,7 +17,7 @@ exclude = ["test-data/**"]
 all-features = true
 
 [dependencies]
-starknet-crypto = { version = "0.6.2", path = "../starknet-crypto", default-features = false, features = ["alloc"] }
+starknet-crypto = { version = "0.7.0", path = "../starknet-crypto", default-features = false, features = ["alloc"] }
 base64 = { version = "0.21.0", default-features = false, features = ["alloc"] }
 crypto-bigint = { version = "0.5.1", default-features = false }
 flate2 = { version = "1.0.25", optional = true }

--- a/starknet-crypto-codegen/Cargo.toml
+++ b/starknet-crypto-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-crypto-codegen"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -16,6 +16,6 @@ keywords = ["ethereum", "starknet", "web3", "no_std"]
 proc-macro = true
 
 [dependencies]
-starknet-curve = { version = "0.4.2", path = "../starknet-curve" }
+starknet-curve = { version = "0.5.0", path = "../starknet-curve" }
 syn = "2.0.55"
 starknet-types-core = { version = "0.1.3", default-features = false, features = ["curve"] }

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-crypto"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,8 +14,8 @@ keywords = ["ethereum", "starknet", "web3", "no_std"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-crypto-codegen = { version = "0.3.3", path = "../starknet-crypto-codegen" }
-starknet-curve = { version = "0.4.2", path = "../starknet-curve" }
+starknet-crypto-codegen = { version = "0.4.0", path = "../starknet-crypto-codegen" }
+starknet-curve = { version = "0.5.0", path = "../starknet-curve" }
 crypto-bigint = { version = "0.5.1", default-features = false, features = ["generic-array", "zeroize"] }
 hmac = { version = "0.12.1", default-features = false }
 num-bigint = { version = "0.4.3", default-features = false }

--- a/starknet-curve/Cargo.toml
+++ b/starknet-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-curve"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/starknet-macros/Cargo.toml
+++ b/starknet-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-macros"
-version = "0.1.7"
+version = "0.2.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -16,7 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 proc-macro = true
 
 [dependencies]
-starknet-core = { version = "0.10.0", path = "../starknet-core" }
+starknet-core = { version = "0.11.0", path = "../starknet-core" }
 syn = "2.0.15"
 
 [features]

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-providers"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.10.0", path = "../starknet-core" }
+starknet-core = { version = "0.11.0", path = "../starknet-core" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 ethereum-types = "0.14.1"

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-signers"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,8 +13,8 @@ Starknet signer implementations
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.10.0", path = "../starknet-core" }
-starknet-crypto = { version = "0.6.2", path = "../starknet-crypto" }
+starknet-core = { version = "0.11.0", path = "../starknet-core" }
+starknet-crypto = { version = "0.7.0", path = "../starknet-crypto" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 thiserror = "1.0.40"


### PR DESCRIPTION
Main changes for this release:

- JSON-RPC 0.7.1 support
- v3 transaction support
- migration to `Felt` type from `starknet-types-core`