### PR TITLE
feat: use query txs for account deployment simulation

### DIFF
--- a/starknet-accounts/src/factory/argent.rs
+++ b/starknet-accounts/src/factory/argent.rs
@@ -80,9 +80,10 @@ where
     async fn sign_deployment_v1(
         &self,
         deployment: &RawAccountDeploymentV1,
+        query_only: bool,
     ) -> Result<Vec<Felt>, Self::SignError> {
-        let tx_hash =
-            PreparedAccountDeploymentV1::from_raw(deployment.clone(), self).transaction_hash();
+        let tx_hash = PreparedAccountDeploymentV1::from_raw(deployment.clone(), self)
+            .transaction_hash(query_only);
         let signature = self.signer.sign_hash(&tx_hash).await?;
 
         Ok(vec![signature.r, signature.s])
@@ -91,9 +92,10 @@ where
     async fn sign_deployment_v3(
         &self,
         deployment: &RawAccountDeploymentV3,
+        query_only: bool,
     ) -> Result<Vec<Felt>, Self::SignError> {
-        let tx_hash =
-            PreparedAccountDeploymentV3::from_raw(deployment.clone(), self).transaction_hash();
+        let tx_hash = PreparedAccountDeploymentV3::from_raw(deployment.clone(), self)
+            .transaction_hash(query_only);
         let signature = self.signer.sign_hash(&tx_hash).await?;
 
         Ok(vec![signature.r, signature.s])

--- a/starknet-accounts/src/factory/open_zeppelin.rs
+++ b/starknet-accounts/src/factory/open_zeppelin.rs
@@ -77,9 +77,10 @@ where
     async fn sign_deployment_v1(
         &self,
         deployment: &RawAccountDeploymentV1,
+        query_only: bool,
     ) -> Result<Vec<Felt>, Self::SignError> {
-        let tx_hash =
-            PreparedAccountDeploymentV1::from_raw(deployment.clone(), self).transaction_hash();
+        let tx_hash = PreparedAccountDeploymentV1::from_raw(deployment.clone(), self)
+            .transaction_hash(query_only);
         let signature = self.signer.sign_hash(&tx_hash).await?;
 
         Ok(vec![signature.r, signature.s])
@@ -88,9 +89,10 @@ where
     async fn sign_deployment_v3(
         &self,
         deployment: &RawAccountDeploymentV3,
+        query_only: bool,
     ) -> Result<Vec<Felt>, Self::SignError> {
-        let tx_hash =
-            PreparedAccountDeploymentV3::from_raw(deployment.clone(), self).transaction_hash();
+        let tx_hash = PreparedAccountDeploymentV3::from_raw(deployment.clone(), self)
+            .transaction_hash(query_only);
         let signature = self.signer.sign_hash(&tx_hash).await?;
 
         Ok(vec![signature.r, signature.s])


### PR DESCRIPTION
Prevents replay attack and more importantly setting the stage for adding distinction between interactive and non-interactive signers, a necessary feature for practical use of hardware wallets.

This is a breaking change as the `AccountFactory` trait API has changed.