### PR TITLE
Enable `num-traits` feature in `starknet-types-core`

### DIFF
--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = { version = "1.0.96", default-features = false, features = ["alloc"
 serde_json_pythonic = { version = "0.1.2", default-features = false, features = ["alloc", "raw_value"] }
 serde_with = { version = "2.3.2", default-features = false, features = ["alloc", "macros"] }
 sha3 = { version = "0.10.7", default-features = false }
-starknet-types-core = { version = "0.1.3", default-features = false, features = ["curve", "serde"] }
+starknet-types-core = { version = "0.1.3", default-features = false, features = ["curve", "serde", "num-traits"] }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", default-features = false }


### PR DESCRIPTION
Before the migration to the new felt type, we used to be able to do `felt.try_into<u128>()` but the implementation has been removed since. The `num-traits` feature pretty much add implementations for the conversion to primitive uint types.

Would be nice to have it enabled directly from `starknet-rs` instead of having to add the `starknet-types-core` crate manually.