### PR TITLE
feat: signer interactivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,11 @@ Examples can be found in the [examples folder](./examples):
 
 10. [Deploy an OpenZeppelin account with Ledger](./examples/deploy_account_with_ledger.rs)
 
-11. [Parsing a JSON-RPC request on the server side](./examples/parse_jsonrpc_request.rs)
+11. [Transfer ERC20 tokens with Ledger](./examples/transfer_with_ledger.rs)
 
-12. [Inspecting a erased provider-specific error type](./examples/downcast_provider_error.rs)
+12. [Parsing a JSON-RPC request on the server side](./examples/parse_jsonrpc_request.rs)
+
+13. [Inspecting a erased provider-specific error type](./examples/downcast_provider_error.rs)
 
 ## License
 

--- a/examples/declare_cairo1_contract.rs
+++ b/examples/declare_cairo1_contract.rs
@@ -53,5 +53,6 @@ async fn main() {
         .await
         .unwrap();
 
-    dbg!(result);
+    println!("Transaction hash: {:#064x}", result.transaction_hash);
+    println!("Class hash: {:#064x}", result.class_hash);
 }

--- a/examples/deploy_account_with_ledger.rs
+++ b/examples/deploy_account_with_ledger.rs
@@ -51,6 +51,7 @@ async fn main() {
     match result {
         Ok(tx) => {
             println!("Transaction hash: {:#064x}", tx.transaction_hash);
+            println!("Account: {:#064x}", tx.contract_address);
         }
         Err(err) => {
             eprintln!("Error: {err}");

--- a/examples/deploy_argent_account.rs
+++ b/examples/deploy_argent_account.rs
@@ -47,6 +47,7 @@ async fn main() {
     match result {
         Ok(tx) => {
             println!("Transaction hash: {:#064x}", tx.transaction_hash);
+            println!("Account: {:#064x}", tx.contract_address);
         }
         Err(err) => {
             eprintln!("Error: {err}");

--- a/examples/mint_tokens.rs
+++ b/examples/mint_tokens.rs
@@ -51,5 +51,5 @@ async fn main() {
         .await
         .unwrap();
 
-    dbg!(result);
+    println!("Transaction hash: {:#064x}", result.transaction_hash);
 }

--- a/examples/transfer_with_ledger.rs
+++ b/examples/transfer_with_ledger.rs
@@ -1,31 +1,35 @@
-use std::sync::Arc;
-
 use starknet::{
-    accounts::{Account, ExecutionEncoding, SingleOwnerAccount},
+    accounts::{Account, Call, ExecutionEncoding, SingleOwnerAccount},
     core::{
         chain_id,
-        types::{contract::legacy::LegacyContractClass, BlockId, BlockTag, Felt},
+        types::{BlockId, BlockTag, Felt},
+        utils::get_selector_from_name,
     },
+    macros::felt,
     providers::{
         jsonrpc::{HttpTransport, JsonRpcClient},
         Url,
     },
-    signers::{LocalWallet, SigningKey},
+    signers::LedgerSigner,
 };
 
 #[tokio::main]
 async fn main() {
-    let contract_artifact: LegacyContractClass =
-        serde_json::from_reader(std::fs::File::open("/path/to/contract/artifact.json").unwrap())
-            .unwrap();
     let provider = JsonRpcClient::new(HttpTransport::new(
         Url::parse("https://starknet-sepolia.public.blastapi.io/rpc/v0_7").unwrap(),
     ));
 
-    let signer = LocalWallet::from(SigningKey::from_secret_scalar(
-        Felt::from_hex("YOUR_PRIVATE_KEY_IN_HEX_HERE").unwrap(),
-    ));
+    let signer = LedgerSigner::new(
+        "m/2645'/1195502025'/1470455285'/0'/0'/0"
+            .try_into()
+            .expect("unable to parse path"),
+    )
+    .await
+    .expect("failed to initialize Starknet Ledger app");
     let address = Felt::from_hex("YOUR_ACCOUNT_CONTRACT_ADDRESS_IN_HEX_HERE").unwrap();
+    let eth_token_address =
+        Felt::from_hex("0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7")
+            .unwrap();
 
     let mut account = SingleOwnerAccount::new(
         provider,
@@ -40,11 +44,14 @@ async fn main() {
     account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let result = account
-        .declare_legacy(Arc::new(contract_artifact))
+        .execute_v1(vec![Call {
+            to: eth_token_address,
+            selector: get_selector_from_name("transfer").unwrap(),
+            calldata: vec![felt!("0x1234"), felt!("100"), Felt::ZERO],
+        }])
         .send()
         .await
         .unwrap();
 
     println!("Transaction hash: {:#064x}", result.transaction_hash);
-    println!("Class hash: {:#064x}", result.class_hash);
 }

--- a/starknet-accounts/src/account/mod.rs
+++ b/starknet-accounts/src/account/mod.rs
@@ -55,6 +55,14 @@ pub trait Account: ExecutionEncoder + Sized {
         query_only: bool,
     ) -> Result<Vec<Felt>, Self::SignError>;
 
+    /// Whether the underlying signer implementation is interactive, such as a hardware wallet.
+    /// Implementations should return `true` if the signing operation is very expensive, even if not
+    /// strictly "interactive" as in requiring human input.
+    ///
+    /// This affects how an account makes decision on whether to request a real signature for
+    /// estimation/simulation purposes.
+    fn is_signer_interactive(&self) -> bool;
+
     fn execute_v1(&self, calls: Vec<Call>) -> ExecutionV1<Self> {
         ExecutionV1::new(calls, self)
     }
@@ -354,6 +362,10 @@ where
             .sign_legacy_declaration(legacy_declaration, query_only)
             .await
     }
+
+    fn is_signer_interactive(&self) -> bool {
+        (*self).is_signer_interactive()
+    }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -417,6 +429,10 @@ where
             .sign_legacy_declaration(legacy_declaration, query_only)
             .await
     }
+
+    fn is_signer_interactive(&self) -> bool {
+        self.as_ref().is_signer_interactive()
+    }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -479,6 +495,10 @@ where
         self.as_ref()
             .sign_legacy_declaration(legacy_declaration, query_only)
             .await
+    }
+
+    fn is_signer_interactive(&self) -> bool {
+        self.as_ref().is_signer_interactive()
     }
 }
 

--- a/starknet-accounts/src/factory/argent.rs
+++ b/starknet-accounts/src/factory/argent.rs
@@ -73,6 +73,10 @@ where
         &self.provider
     }
 
+    fn is_signer_interactive(&self) -> bool {
+        self.signer.is_interactive()
+    }
+
     fn block_id(&self) -> BlockId {
         self.block_id
     }

--- a/starknet-accounts/src/factory/open_zeppelin.rs
+++ b/starknet-accounts/src/factory/open_zeppelin.rs
@@ -70,6 +70,10 @@ where
         &self.provider
     }
 
+    fn is_signer_interactive(&self) -> bool {
+        self.signer.is_interactive()
+    }
+
     fn block_id(&self) -> BlockId {
         self.block_id
     }

--- a/starknet-accounts/src/single_owner.rs
+++ b/starknet-accounts/src/single_owner.rs
@@ -170,6 +170,10 @@ where
 
         Ok(vec![signature.r, signature.s])
     }
+
+    fn is_signer_interactive(&self) -> bool {
+        self.signer.is_interactive()
+    }
 }
 
 impl<P, S> ExecutionEncoder for SingleOwnerAccount<P, S>

--- a/starknet-signers/src/ledger.rs
+++ b/starknet-signers/src/ledger.rs
@@ -163,6 +163,10 @@ impl Signer for LedgerSigner {
 
         Ok(signature)
     }
+
+    fn is_interactive(&self) -> bool {
+        true
+    }
 }
 
 impl From<coins_ledger::LedgerError> for LedgerError {

--- a/starknet-signers/src/local_wallet.rs
+++ b/starknet-signers/src/local_wallet.rs
@@ -36,6 +36,10 @@ impl Signer for LocalWallet {
     async fn sign_hash(&self, hash: &Felt) -> Result<Signature, Self::SignError> {
         Ok(self.private_key.sign(hash)?)
     }
+
+    fn is_interactive(&self) -> bool {
+        false
+    }
 }
 
 impl From<SigningKey> for LocalWallet {

--- a/starknet-signers/src/signer.rs
+++ b/starknet-signers/src/signer.rs
@@ -15,4 +15,14 @@ pub trait Signer {
     async fn get_public_key(&self) -> Result<VerifyingKey, Self::GetPublicKeyError>;
 
     async fn sign_hash(&self, hash: &Felt) -> Result<Signature, Self::SignError>;
+
+    /// Whether the underlying signer implementation is interactive, such as a hardware wallet.
+    /// Implementations should return `true` if the signing operation is very expensive, even if not
+    /// strictly "interactive" as in requiring human input.
+    ///
+    /// This mainly affects the transaction simulation strategy used by higher-level types. With
+    /// non-interactive signers, it's fine to sign multiple times for getting the most accurate
+    /// estimation/simulation possible; but with interactive signers, they would accept less
+    /// accurate results to minimize signing requests.
+    fn is_interactive(&self) -> bool;
 }


### PR DESCRIPTION
Makes signer implementations specify whether a signing operation is "interactive" (or just expensive). Utilizing this new information, `Account` and `AccountFactory` now make more informed decisions on whether to request real signatures for different types of operations.

The most significant benefit of this change is allowing using hardware wallet without excessive unnecessary signing requests.

This PR is made a breaking change, despite the possibility of maintaining backward compatibility by providing default implementations of the new trait methods. This is because #611 has already introduced a breaking change on `starknet-signers` anyway.

Breaking changes include:

- `get_invoke_request` and `get_declare_request` methods are no longer `pub`; it was a mistake making them public in the first place;
- new trait methods on `Signer`, `Account`, and `AccountFactory` without default impls.