### PR TITLE
ci: replace macos-11 with macos-12

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-11]
+        os: [ubuntu-latest, macos-12]
         toolchain: [stable, nightly]
 
     steps:


### PR DESCRIPTION
GitHub removed hosted `macos-11` runners.