### PR TITLE
fix: `std` not enabled for `starknet-types-core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,10 +1117,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lambdaworks-crypto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb5d4f22241504f7c7b8d2c3a7d7835d7c07117f10bff2a7d96a9ef6ef217c3"
+dependencies = [
+ "lambdaworks-math",
+ "serde",
+ "sha2",
+ "sha3",
+]
+
+[[package]]
 name = "lambdaworks-math"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "358e172628e713b80a530a59654154bfc45783a6ed70ea284839800cebdf8f97"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "lazy_static"
@@ -2112,6 +2128,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe29a53d28ff630e4c7827788f14b28f9386d27cb9d05186a5f2e73218c34677"
 dependencies = [
+ "lambdaworks-crypto",
  "lambdaworks-math",
  "num-bigint",
  "num-integer",

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -29,7 +29,7 @@ starknet-types-core = { version = "0.1.3", default-features = false, features = 
 
 [features]
 default = ["std", "signature-display"]
-std = []
+std = ["starknet-types-core/std"]
 alloc = ["hex?/alloc", "starknet-types-core/alloc"]
 signature-display = ["dep:hex", "alloc"]
 


### PR DESCRIPTION
Should be enabled when `std` is used on `starknet-crypto`.