### PR TITLE
feat: get ledger app version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,6 +1783,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
 name = "serde"
 version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,6 +2122,7 @@ dependencies = [
  "eth-keystore",
  "getrandom",
  "rand",
+ "semver",
  "starknet-core",
  "starknet-crypto",
  "thiserror",

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = "1.0.40"
 crypto-bigint = { version = "0.5.1", default-features = false }
 rand = { version = "0.8.5", features = ["std_rng"] }
 coins-bip32 = { version = "0.11.1", optional = true }
+semver = { version = "1.0.23", optional = true }
 
 # Using a fork until https://github.com/summa-tx/coins/issues/137 is fixed
 coins-ledger = { git = "https://github.com/xJonathanLEI/coins", rev = "0e3be5db0b18b683433de6b666556b99c726e785", default-features = false, optional = true }
@@ -37,4 +38,4 @@ wasm-bindgen-test = "0.3.34"
 [features]
 default = []
 
-ledger = ["coins-bip32", "coins-ledger"]
+ledger = ["coins-bip32", "coins-ledger", "semver"]


### PR DESCRIPTION
Add support for the `GetVersion` command of the Ledger app. With this addition all current functionalities of the Ledger app are supported in `starknet-rs`.