### PR TITLE
Replace declare_v1 suggestion with declare_v2

### DIFF
--- a/starknet-accounts/src/account/mod.rs
+++ b/starknet-accounts/src/account/mod.rs
@@ -92,7 +92,7 @@ pub trait Account: ExecutionEncoder + Sized {
         DeclarationV3::new(contract_class, compiled_class_hash, self)
     }
 
-    #[deprecated = "use version specific variants (`declare_v1` & `declare_v3`) instead"]
+    #[deprecated = "use version specific variants (`declare_v2` & `declare_v3`) instead"]
     fn declare(
         &self,
         contract_class: Arc<FlattenedSierraClass>,


### PR DESCRIPTION
The warning message suggests a method that doesn't exist.