### PR TITLE
docs: fix broken links and add CI

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+
+name: "Build documentation"
+
+jobs:
+  build-doc:
+    name: "Build documentation"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Checkout source code"
+        uses: "actions/checkout@v3"
+
+      - name: "Setup stable toolchain"
+        uses: "actions-rs/toolchain@v1"
+        with:
+          toolchain: "stable"
+          profile: "minimal"
+          override: true
+
+      - name: "Build docs"
+        run: |
+          RUSTDOCFLAGS="-D warnings -A rustdoc::missing-crate-level-docs" cargo doc --all

--- a/examples/starknet-cxx/starknet-cxx/src/lib.rs
+++ b/examples/starknet-cxx/starknet-cxx/src/lib.rs
@@ -1,5 +1,5 @@
 //! This is a quick demo on exposing `starknet-crypto` to C++ with the cxx bridge:
-//!   https://github.com/xJonathanLEI/starknet-rs/issues/325
+//!   <https://github.com/xJonathanLEI/starknet-rs/issues/325>
 //!
 //! This wrapper crate expose functions that operate on strings, which is bad and probably hurts
 //! performance. It's possible to make the C++ side create `Felt` instances and operate on

--- a/starknet-core/src/serde/mod.rs
+++ b/starknet-core/src/serde/mod.rs
@@ -1,7 +1,7 @@
 /// Custom serialization/deserialization implementations for [`Vec<u8>`].
 pub mod byte_array;
 
-/// Custom serialization/deserialization implementations for [`Felt`].
+/// Custom serialization/deserialization implementations for [`Felt`](crate::types::Felt).
 pub mod unsigned_field_element;
 
 pub(crate) mod num_hex;

--- a/starknet-core/src/types/eth_address.rs
+++ b/starknet-core/src/types/eth_address.rs
@@ -23,7 +23,7 @@ struct EthAddressVisitor;
 mod errors {
     use core::fmt::{Display, Formatter, Result};
 
-    /// Errors parsing [`EthAddress`] from a hex string.
+    /// Errors parsing [`EthAddress`](super::EthAddress) from a hex string.
     #[derive(Debug)]
     pub enum FromHexError {
         /// The hex string is not 40 hexadecimal characters in length without the `0x` prefix.
@@ -32,11 +32,12 @@ mod errors {
         InvalidHexString,
     }
 
-    /// The [`Felt`] value is out of range for converting into [`EthAddress`].
+    /// The [`Felt`](super::Felt) value is out of range for converting into
+    /// [`EthAddress`](super::EthAddress).
     #[derive(Debug)]
     pub struct FromFieldElementError;
 
-    /// The byte slice is out of range for converting into [`EthAddress`].
+    /// The byte slice is out of range for converting into [`EthAddress`](super::EthAddress).
     #[derive(Debug)]
     pub struct FromBytesSliceError;
 

--- a/starknet-core/src/types/hash_256.rs
+++ b/starknet-core/src/types/hash_256.rs
@@ -20,7 +20,7 @@ struct Hash256Visitor;
 mod errors {
     use core::fmt::{Display, Formatter, Result};
 
-    /// Errors parsing [`Hash256`] from a hex string.
+    /// Errors parsing [`Hash256`](super::Hash256) from a hex string.
     #[derive(Debug)]
     pub enum FromHexError {
         /// The hex string is not 64 hexadecimal characters in length without the `0x` prefix.
@@ -29,7 +29,7 @@ mod errors {
         InvalidHexString,
     }
 
-    /// The hash value is out of range for converting into [`Felt`].
+    /// The hash value is out of range for converting into [`Felt`](super::Felt).
     #[derive(Debug)]
     pub struct ToFieldElementError;
 

--- a/starknet-core/src/types/receipt_block.rs
+++ b/starknet-core/src/types/receipt_block.rs
@@ -4,7 +4,8 @@ use serde_with::serde_as;
 use crate::serde::unsigned_field_element::UfeHex;
 use starknet_types_core::felt::Felt;
 
-/// Block identifier used in [`TransactionReceiptWithBlockInfo`].
+/// Block identifier used in
+/// [`TransactionReceiptWithBlockInfo`](super::TransactionReceiptWithBlockInfo).
 ///
 /// Instead of directly exposing the `block_hash` and `block_number` fields as [`Option<Felt>`],
 /// this struct captures the fact that these fields are always [`Some`](Option::Some) or

--- a/starknet-core/src/utils.rs
+++ b/starknet-core/src/utils.rs
@@ -66,7 +66,7 @@ mod errors {
     /// Possible errors for decoding a Cairo short string.
     #[derive(Debug)]
     pub enum ParseCairoShortStringError {
-        /// The encoded [`Felt`] value is out of range.
+        /// The encoded [`Felt`](super::Felt) value is out of range.
         ValueOutOfRange,
         /// A null terminator (`0x00`) is encountered.
         UnexpectedNullTerminator,

--- a/starknet-providers/src/jsonrpc/transports/http.rs
+++ b/starknet-providers/src/jsonrpc/transports/http.rs
@@ -41,7 +41,7 @@ impl HttpTransport {
     }
 
     /// Consumes the current [`HttpTransport`] instance and returns a new one with the header
-    /// appended. Same as calling [`add_header`].
+    /// appended. Same as calling [`add_header`](fn.add_header).
     pub fn with_header(self, name: String, value: String) -> Self {
         let mut headers = self.headers;
         headers.push((name, value));

--- a/starknet-providers/src/provider.rs
+++ b/starknet-providers/src/provider.rs
@@ -247,7 +247,7 @@ pub trait Provider {
     where
         B: AsRef<BlockId> + Send + Sync;
 
-    /// Same as [estimate_fee], but only with one estimate.
+    /// Same as [`estimate_fee`](fn.estimate_fee), but only with one estimate.
     async fn estimate_fee_single<R, S, B>(
         &self,
         request: R,
@@ -271,7 +271,7 @@ pub trait Provider {
         }
     }
 
-    /// Same as [simulate_transactions], but only with one simulation.
+    /// Same as [`simulate_transactions`](fn.simulate_transactions), but only with one simulation.
     async fn simulate_transaction<B, T, S>(
         &self,
         block_id: B,

--- a/starknet-providers/src/sequencer/mod.rs
+++ b/starknet-providers/src/sequencer/mod.rs
@@ -40,16 +40,18 @@ pub enum GatewayClientError {
     /// Sequencer error responses not parsable into [`StarknetError`]
     #[error(transparent)]
     SequencerError(SequencerError),
-    /// Method is not supported (only when using as [Provider])
+    /// Method is not supported (only when using as [`Provider`](crate::Provider))
     #[error("method not supported")]
     MethodNotSupported,
-    /// Model conversion error (only when using as [Provider])
+    /// Model conversion error (only when using as [`Provider`](crate::Provider))
     #[error("unable to convert gateway models to jsonrpc types")]
     ModelConversionError,
-    /// Simulating multiple transactions is not supported (only when using as [Provider])
+    /// Simulating multiple transactions is not supported (only when using as
+    /// [`Provider`](crate::Provider))
     #[error("simulating multiple transactions not supported")]
     BulkSimulationNotSupported,
-    /// At least one of the simulation flags is not supported (only when using as [Provider])
+    /// At least one of the simulation flags is not supported (only when using as
+    /// [`Provider`](crate::Provider))
     #[error("unsupported simulation flag")]
     UnsupportedSimulationFlag,
 }
@@ -140,7 +142,7 @@ impl SequencerGatewayProvider {
     }
 
     /// Consumes the current [`SequencerGatewayProvider`] instance and returns a new one with the
-    /// header appended. Same as calling [`add_header`].
+    /// header appended. Same as calling [`add_header`](fn.add_header).
     pub fn with_header(self, name: String, value: String) -> Self {
         let mut headers = self.headers;
         headers.push((name, value));


### PR DESCRIPTION
Fixes a few broken links and adds a new CI check for ensuring `cargo doc` succeeds without warnings.