### PR TITLE
Allow explicit configuration of interactive signer

### DIFF
--- a/starknet-accounts/src/account/declaration.rs
+++ b/starknet-accounts/src/account/declaration.rs
@@ -68,6 +68,7 @@ impl<'a, A> DeclarationV2<'a, A> {
             nonce: None,
             max_fee: None,
             fee_estimate_multiplier: 1.1,
+            is_signer_interactive: None,
         }
     }
 
@@ -93,6 +94,14 @@ impl<'a, A> DeclarationV2<'a, A> {
     pub fn fee_estimate_multiplier(self, fee_estimate_multiplier: f64) -> Self {
         Self {
             fee_estimate_multiplier,
+            ..self
+        }
+    }
+
+    /// Returns a new [`DeclarationV2`] with the an interactive signer.
+    pub fn with_interactive_signer(self) -> Self {
+        Self {
+            is_signer_interactive: Some(()),
             ..self
         }
     }
@@ -209,7 +218,7 @@ where
         &self,
         nonce: Felt,
     ) -> Result<FeeEstimate, AccountError<A::SignError>> {
-        let skip_signature = self.account.is_signer_interactive();
+        let skip_signature = self.is_signer_interactive();
 
         let prepared = PreparedDeclarationV2 {
             account: self.account,
@@ -245,7 +254,7 @@ where
         skip_validate: bool,
         skip_fee_charge: bool,
     ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
-        let skip_signature = if self.account.is_signer_interactive() {
+        let skip_signature = if self.is_signer_interactive() {
             // If signer is interactive, we would try to minimize signing requests. However, if the
             // caller has decided to not skip validation, it's best we still request a real
             // signature, as otherwise the simulation would most likely fail.
@@ -285,6 +294,14 @@ where
             .await
             .map_err(AccountError::Provider)
     }
+
+    fn is_signer_interactive(&self) -> bool {
+        if self.is_signer_interactive.is_some() {
+            true
+        } else {
+            self.account.is_signer_interactive()
+        }
+    }
 }
 
 impl<'a, A> DeclarationV3<'a, A> {
@@ -306,6 +323,7 @@ impl<'a, A> DeclarationV3<'a, A> {
             gas_price: None,
             gas_estimate_multiplier: 1.5,
             gas_price_estimate_multiplier: 1.5,
+            is_signer_interactive: None,
         }
     }
 
@@ -349,6 +367,14 @@ impl<'a, A> DeclarationV3<'a, A> {
     pub fn gas_price_estimate_multiplier(self, gas_price_estimate_multiplier: f64) -> Self {
         Self {
             gas_price_estimate_multiplier,
+            ..self
+        }
+    }
+
+    /// Returns a new [`DeclarationV3`] with the an interactive signer.
+    pub fn with_interactive_signer(self) -> Self {
+        Self {
+            is_signer_interactive: Some(()),
             ..self
         }
     }
@@ -519,7 +545,7 @@ where
         &self,
         nonce: Felt,
     ) -> Result<FeeEstimate, AccountError<A::SignError>> {
-        let skip_signature = self.account.is_signer_interactive();
+        let skip_signature = self.is_signer_interactive();
 
         let prepared = PreparedDeclarationV3 {
             account: self.account,
@@ -556,7 +582,7 @@ where
         skip_validate: bool,
         skip_fee_charge: bool,
     ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
-        let skip_signature = if self.account.is_signer_interactive() {
+        let skip_signature = if self.is_signer_interactive() {
             // If signer is interactive, we would try to minimize signing requests. However, if the
             // caller has decided to not skip validation, it's best we still request a real
             // signature, as otherwise the simulation would most likely fail.
@@ -597,6 +623,14 @@ where
             .await
             .map_err(AccountError::Provider)
     }
+
+    fn is_signer_interactive(&self) -> bool {
+        if self.is_signer_interactive.is_some() {
+            true
+        } else {
+            self.account.is_signer_interactive()
+        }
+    }
 }
 
 impl<'a, A> LegacyDeclaration<'a, A> {
@@ -611,6 +645,7 @@ impl<'a, A> LegacyDeclaration<'a, A> {
             nonce: None,
             max_fee: None,
             fee_estimate_multiplier: 1.1,
+            is_signer_interactive: None,
         }
     }
 
@@ -636,6 +671,14 @@ impl<'a, A> LegacyDeclaration<'a, A> {
     pub fn fee_estimate_multiplier(self, fee_estimate_multiplier: f64) -> Self {
         Self {
             fee_estimate_multiplier,
+            ..self
+        }
+    }
+
+    /// Returns a new [`LegacyDeclaration`] with the an interactive signer.
+    pub fn with_interactive_signer(self) -> Self {
+        Self {
+            is_signer_interactive: Some(()),
             ..self
         }
     }
@@ -753,7 +796,7 @@ where
         &self,
         nonce: Felt,
     ) -> Result<FeeEstimate, AccountError<A::SignError>> {
-        let skip_signature = self.account.is_signer_interactive();
+        let skip_signature = self.is_signer_interactive();
 
         let prepared = PreparedLegacyDeclaration {
             account: self.account,
@@ -788,7 +831,7 @@ where
         skip_validate: bool,
         skip_fee_charge: bool,
     ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
-        let skip_signature = if self.account.is_signer_interactive() {
+        let skip_signature = if self.is_signer_interactive() {
             // If signer is interactive, we would try to minimize signing requests. However, if the
             // caller has decided to not skip validation, it's best we still request a real
             // signature, as otherwise the simulation would most likely fail.
@@ -826,6 +869,14 @@ where
             )
             .await
             .map_err(AccountError::Provider)
+    }
+
+    fn is_signer_interactive(&self) -> bool {
+        if self.is_signer_interactive.is_some() {
+            true
+        } else {
+            self.account.is_signer_interactive()
+        }
     }
 }
 

--- a/starknet-accounts/src/account/mod.rs
+++ b/starknet-accounts/src/account/mod.rs
@@ -242,6 +242,7 @@ pub struct ExecutionV1<'a, A> {
     nonce: Option<Felt>,
     max_fee: Option<Felt>,
     fee_estimate_multiplier: f64,
+    is_signer_interactive: Option<()>,
 }
 
 /// Abstraction over `INVOKE` transactions from accounts for invoking contracts. This struct uses
@@ -260,6 +261,7 @@ pub struct ExecutionV3<'a, A> {
     gas_price: Option<u128>,
     gas_estimate_multiplier: f64,
     gas_price_estimate_multiplier: f64,
+    is_signer_interactive: Option<()>,
 }
 
 /// Abstraction over `DECLARE` transactions from accounts for invoking contracts. This struct uses
@@ -276,6 +278,7 @@ pub struct DeclarationV2<'a, A> {
     nonce: Option<Felt>,
     max_fee: Option<Felt>,
     fee_estimate_multiplier: f64,
+    is_signer_interactive: Option<()>,
 }
 
 /// Abstraction over `DECLARE` transactions from accounts for invoking contracts. This struct uses
@@ -295,6 +298,7 @@ pub struct DeclarationV3<'a, A> {
     gas_price: Option<u128>,
     gas_estimate_multiplier: f64,
     gas_price_estimate_multiplier: f64,
+    is_signer_interactive: Option<()>,
 }
 
 /// An intermediate type allowing users to optionally specify `nonce` and/or `max_fee`.
@@ -306,6 +310,7 @@ pub struct LegacyDeclaration<'a, A> {
     nonce: Option<Felt>,
     max_fee: Option<Felt>,
     fee_estimate_multiplier: f64,
+    is_signer_interactive: Option<()>,
 }
 
 /// [`ExecutionV1`] but with `nonce` and `max_fee` already determined.


### PR DESCRIPTION
The current `is_interactive_signer` interface doesn't support conditionally interactive signers depending on the execution context. In particular, session signers can be interactive or non-interactive depending on whether the session token contains the necessary scopes to sign a transaction or not.

This PR allows us to explicitly configure the `is_interactive_signer` parameter and allows us more control over how it is set.