### PR TITLE
feat: dynamic signer interactivity

### DIFF
--- a/examples/mint_tokens.rs
+++ b/examples/mint_tokens.rs
@@ -1,8 +1,8 @@
 use starknet::{
-    accounts::{Account, Call, ExecutionEncoding, SingleOwnerAccount},
+    accounts::{Account, ExecutionEncoding, SingleOwnerAccount},
     core::{
         chain_id,
-        types::{BlockId, BlockTag, Felt},
+        types::{BlockId, BlockTag, Call, Felt},
         utils::get_selector_from_name,
     },
     providers::{

--- a/examples/transfer_with_ledger.rs
+++ b/examples/transfer_with_ledger.rs
@@ -1,8 +1,8 @@
 use starknet::{
-    accounts::{Account, Call, ExecutionEncoding, SingleOwnerAccount},
+    accounts::{Account, ExecutionEncoding, SingleOwnerAccount},
     core::{
         chain_id,
-        types::{BlockId, BlockTag, Felt},
+        types::{BlockId, BlockTag, Call, Felt},
         utils::get_selector_from_name,
     },
     macros::felt,

--- a/starknet-accounts/src/account/declaration.rs
+++ b/starknet-accounts/src/account/declaration.rs
@@ -17,6 +17,7 @@ use starknet_core::{
 };
 use starknet_crypto::PoseidonHasher;
 use starknet_providers::Provider;
+use starknet_signers::SignerInteractivityContext;
 use std::sync::Arc;
 
 /// Cairo string for "declare"
@@ -209,7 +210,9 @@ where
         &self,
         nonce: Felt,
     ) -> Result<FeeEstimate, AccountError<A::SignError>> {
-        let skip_signature = self.account.is_signer_interactive();
+        let skip_signature = self
+            .account
+            .is_signer_interactive(SignerInteractivityContext::Other);
 
         let prepared = PreparedDeclarationV2 {
             account: self.account,
@@ -245,7 +248,10 @@ where
         skip_validate: bool,
         skip_fee_charge: bool,
     ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
-        let skip_signature = if self.account.is_signer_interactive() {
+        let skip_signature = if self
+            .account
+            .is_signer_interactive(SignerInteractivityContext::Other)
+        {
             // If signer is interactive, we would try to minimize signing requests. However, if the
             // caller has decided to not skip validation, it's best we still request a real
             // signature, as otherwise the simulation would most likely fail.
@@ -519,7 +525,9 @@ where
         &self,
         nonce: Felt,
     ) -> Result<FeeEstimate, AccountError<A::SignError>> {
-        let skip_signature = self.account.is_signer_interactive();
+        let skip_signature = self
+            .account
+            .is_signer_interactive(SignerInteractivityContext::Other);
 
         let prepared = PreparedDeclarationV3 {
             account: self.account,
@@ -556,7 +564,10 @@ where
         skip_validate: bool,
         skip_fee_charge: bool,
     ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
-        let skip_signature = if self.account.is_signer_interactive() {
+        let skip_signature = if self
+            .account
+            .is_signer_interactive(SignerInteractivityContext::Other)
+        {
             // If signer is interactive, we would try to minimize signing requests. However, if the
             // caller has decided to not skip validation, it's best we still request a real
             // signature, as otherwise the simulation would most likely fail.
@@ -753,7 +764,9 @@ where
         &self,
         nonce: Felt,
     ) -> Result<FeeEstimate, AccountError<A::SignError>> {
-        let skip_signature = self.account.is_signer_interactive();
+        let skip_signature = self
+            .account
+            .is_signer_interactive(SignerInteractivityContext::Other);
 
         let prepared = PreparedLegacyDeclaration {
             account: self.account,
@@ -788,7 +801,10 @@ where
         skip_validate: bool,
         skip_fee_charge: bool,
     ) -> Result<SimulatedTransaction, AccountError<A::SignError>> {
-        let skip_signature = if self.account.is_signer_interactive() {
+        let skip_signature = if self
+            .account
+            .is_signer_interactive(SignerInteractivityContext::Other)
+        {
             // If signer is interactive, we would try to minimize signing requests. However, if the
             // caller has decided to not skip validation, it's best we still request a real
             // signature, as otherwise the simulation would most likely fail.

--- a/starknet-accounts/src/account/mod.rs
+++ b/starknet-accounts/src/account/mod.rs
@@ -1,12 +1,11 @@
-use crate::Call;
-
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 use starknet_core::types::{
     contract::{legacy::LegacyContractClass, CompressProgramError, ComputeClassHashError},
-    BlockId, BlockTag, Felt, FlattenedSierraClass,
+    BlockId, BlockTag, Call, Felt, FlattenedSierraClass,
 };
 use starknet_providers::{Provider, ProviderError};
+use starknet_signers::SignerInteractivityContext;
 use std::{error::Error, sync::Arc};
 
 mod declaration;
@@ -89,7 +88,7 @@ pub trait Account: ExecutionEncoder + Sized {
     ///
     /// This affects how an account makes decision on whether to request a real signature for
     /// estimation/simulation purposes.
-    fn is_signer_interactive(&self) -> bool;
+    fn is_signer_interactive(&self, context: SignerInteractivityContext<'_>) -> bool;
 
     /// Generates an instance of [`ExecutionV1`] for sending `INVOKE` v1 transactions. Pays
     /// transaction fees in `ETH`.
@@ -465,8 +464,8 @@ where
             .await
     }
 
-    fn is_signer_interactive(&self) -> bool {
-        (*self).is_signer_interactive()
+    fn is_signer_interactive(&self, context: SignerInteractivityContext<'_>) -> bool {
+        (*self).is_signer_interactive(context)
     }
 }
 
@@ -532,8 +531,8 @@ where
             .await
     }
 
-    fn is_signer_interactive(&self) -> bool {
-        self.as_ref().is_signer_interactive()
+    fn is_signer_interactive(&self, context: SignerInteractivityContext<'_>) -> bool {
+        self.as_ref().is_signer_interactive(context)
     }
 }
 
@@ -599,8 +598,8 @@ where
             .await
     }
 
-    fn is_signer_interactive(&self) -> bool {
-        self.as_ref().is_signer_interactive()
+    fn is_signer_interactive(&self, context: SignerInteractivityContext<'_>) -> bool {
+        self.as_ref().is_signer_interactive(context)
     }
 }
 

--- a/starknet-accounts/src/factory/argent.rs
+++ b/starknet-accounts/src/factory/argent.rs
@@ -6,7 +6,7 @@ use crate::{
 use async_trait::async_trait;
 use starknet_core::types::{BlockId, BlockTag, Felt};
 use starknet_providers::Provider;
-use starknet_signers::Signer;
+use starknet_signers::{Signer, SignerInteractivityContext};
 
 /// [`AccountFactory`] implementation for deploying `Argent X` account contracts.
 #[derive(Debug)]
@@ -78,7 +78,8 @@ where
     }
 
     fn is_signer_interactive(&self) -> bool {
-        self.signer.is_interactive()
+        self.signer
+            .is_interactive(SignerInteractivityContext::Other)
     }
 
     fn block_id(&self) -> BlockId {

--- a/starknet-accounts/src/factory/open_zeppelin.rs
+++ b/starknet-accounts/src/factory/open_zeppelin.rs
@@ -6,7 +6,7 @@ use crate::{
 use async_trait::async_trait;
 use starknet_core::types::{BlockId, BlockTag, Felt};
 use starknet_providers::Provider;
-use starknet_signers::Signer;
+use starknet_signers::{Signer, SignerInteractivityContext};
 
 /// [`AccountFactory`] implementation for deploying `OpenZeppelin` account contracts.
 #[derive(Debug)]
@@ -75,7 +75,8 @@ where
     }
 
     fn is_signer_interactive(&self) -> bool {
-        self.signer.is_interactive()
+        self.signer
+            .is_interactive(SignerInteractivityContext::Other)
     }
 
     fn block_id(&self) -> BlockId {

--- a/starknet-accounts/src/lib.rs
+++ b/starknet-accounts/src/lib.rs
@@ -10,9 +10,6 @@ pub use account::{
     RawDeclarationV3, RawExecutionV1, RawExecutionV3, RawLegacyDeclaration,
 };
 
-mod call;
-pub use call::Call;
-
 mod factory;
 pub use factory::{
     argent::ArgentAccountFactory, open_zeppelin::OpenZeppelinAccountFactory, AccountDeploymentV1,

--- a/starknet-accounts/src/single_owner.rs
+++ b/starknet-accounts/src/single_owner.rs
@@ -1,12 +1,12 @@
 use crate::{
-    Account, Call, ConnectedAccount, ExecutionEncoder, RawDeclarationV2, RawDeclarationV3,
+    Account, ConnectedAccount, ExecutionEncoder, RawDeclarationV2, RawDeclarationV3,
     RawExecutionV1, RawExecutionV3, RawLegacyDeclaration,
 };
 
 use async_trait::async_trait;
-use starknet_core::types::{contract::ComputeClassHashError, BlockId, BlockTag, Felt};
+use starknet_core::types::{contract::ComputeClassHashError, BlockId, BlockTag, Call, Felt};
 use starknet_providers::Provider;
-use starknet_signers::Signer;
+use starknet_signers::{Signer, SignerInteractivityContext};
 
 /// A generic [`Account`] implementation for controlling account contracts that only have one signer
 /// using ECDSA the STARK curve.
@@ -177,8 +177,8 @@ where
         Ok(vec![signature.r, signature.s])
     }
 
-    fn is_signer_interactive(&self) -> bool {
-        self.signer.is_interactive()
+    fn is_signer_interactive(&self, context: SignerInteractivityContext<'_>) -> bool {
+        self.signer.is_interactive(context)
     }
 }
 

--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -1,5 +1,5 @@
 use starknet_accounts::{
-    Account, AccountError, Call, ConnectedAccount, ExecutionEncoding, SingleOwnerAccount,
+    Account, AccountError, ConnectedAccount, ExecutionEncoding, SingleOwnerAccount,
 };
 use starknet_core::{
     types::{
@@ -7,7 +7,7 @@ use starknet_core::{
             legacy::{LegacyContractClass, RawLegacyAbiEntry, RawLegacyFunction},
             SierraClass,
         },
-        BlockId, BlockTag, Felt, StarknetError,
+        BlockId, BlockTag, Call, Felt, StarknetError,
     },
     utils::get_selector_from_name,
 };

--- a/starknet-contract/src/factory.rs
+++ b/starknet-contract/src/factory.rs
@@ -1,6 +1,6 @@
-use starknet_accounts::{Account, AccountError, Call, ConnectedAccount, ExecutionV1, ExecutionV3};
+use starknet_accounts::{Account, AccountError, ConnectedAccount, ExecutionV1, ExecutionV3};
 use starknet_core::{
-    types::{FeeEstimate, Felt, InvokeTransactionResult, SimulatedTransaction},
+    types::{Call, FeeEstimate, Felt, InvokeTransactionResult, SimulatedTransaction},
     utils::{get_udc_deployed_address, UdcUniqueSettings, UdcUniqueness},
 };
 

--- a/starknet-core/src/types/call.rs
+++ b/starknet-core/src/types/call.rs
@@ -1,4 +1,6 @@
-use starknet_core::types::Felt;
+use alloc::vec::*;
+
+use crate::types::Felt;
 
 /// A contract call as part of a multi-call execution request.
 #[derive(Debug, Clone)]

--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -62,6 +62,9 @@ pub use receipt_block::ReceiptBlock;
 mod msg;
 pub use msg::MsgToL2;
 
+mod call;
+pub use call::Call;
+
 // TODO: move generated request code to `starknet-providers`
 /// Module containing JSON-RPC request types.
 pub mod requests;

--- a/starknet-signers/src/ledger.rs
+++ b/starknet-signers/src/ledger.rs
@@ -8,7 +8,7 @@ use crypto_bigint::{ArrayEncoding, U256};
 use semver::Version;
 use starknet_core::{crypto::Signature, types::Felt};
 
-use crate::{Signer, VerifyingKey};
+use crate::{Signer, SignerInteractivityContext, VerifyingKey};
 
 pub use coins_bip32::path::DerivationPath;
 
@@ -128,7 +128,7 @@ impl Signer for LedgerSigner {
         self.app.sign_hash(self.derivation_path.clone(), hash).await
     }
 
-    fn is_interactive(&self) -> bool {
+    fn is_interactive(&self, _context: SignerInteractivityContext<'_>) -> bool {
         true
     }
 }

--- a/starknet-signers/src/lib.rs
+++ b/starknet-signers/src/lib.rs
@@ -9,7 +9,7 @@ pub use key_pair::{SigningKey, VerifyingKey};
 pub use key_pair::KeystoreError;
 
 mod signer;
-pub use signer::Signer;
+pub use signer::{Signer, SignerInteractivityContext};
 
 /// Module containing types related to the use of a simple in-memory signer.
 pub mod local_wallet;

--- a/starknet-signers/src/local_wallet.rs
+++ b/starknet-signers/src/local_wallet.rs
@@ -1,4 +1,4 @@
-use crate::{Infallible, Signer, SigningKey, VerifyingKey};
+use crate::{Infallible, Signer, SignerInteractivityContext, SigningKey, VerifyingKey};
 
 use async_trait::async_trait;
 use starknet_core::{
@@ -42,7 +42,7 @@ impl Signer for LocalWallet {
         Ok(self.private_key.sign(hash)?)
     }
 
-    fn is_interactive(&self) -> bool {
+    fn is_interactive(&self, _context: SignerInteractivityContext<'_>) -> bool {
         false
     }
 }


### PR DESCRIPTION
Signer interactivity seems to also be non-binary. This PR enables signer implementations to make better interactivity reporting decision based on what's being signed.

A use case for this would be that calls to a specific contract on certain selectors might be deemed safe and would not require user confirmation. Apparently this needs to be enforced on the actual account contract, but having accurate interactivity on the client side helps the library make better decision on transaction estimation and simulation.

This is technically a breaking change on the existing `HEAD` but since this whole interactivity feature hasn't been released yet so we're free to break anything.