### PR TITLE
feat: jsonrpc batch requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,19 +92,21 @@ Examples can be found in the [examples folder](./examples):
 
 6. [Query the latest block number with JSON-RPC](./examples/jsonrpc.rs)
 
-7. [Call a contract view function](./examples/erc20_balance.rs)
+7. [Batched JSON-RPC requests](./examples/batch.rs)
 
-8. [Deploy an Argent X account to a pre-funded address](./examples/deploy_argent_account.rs)
+8. [Call a contract view function](./examples/erc20_balance.rs)
 
-9. [Inspect public key with Ledger](./examples/ledger_public_key.rs)
+9. [Deploy an Argent X account to a pre-funded address](./examples/deploy_argent_account.rs)
 
-10. [Deploy an OpenZeppelin account with Ledger](./examples/deploy_account_with_ledger.rs)
+10. [Inspect public key with Ledger](./examples/ledger_public_key.rs)
 
-11. [Transfer ERC20 tokens with Ledger](./examples/transfer_with_ledger.rs)
+11. [Deploy an OpenZeppelin account with Ledger](./examples/deploy_account_with_ledger.rs)
 
-12. [Parsing a JSON-RPC request on the server side](./examples/parse_jsonrpc_request.rs)
+12. [Transfer ERC20 tokens with Ledger](./examples/transfer_with_ledger.rs)
 
-13. [Inspecting a erased provider-specific error type](./examples/downcast_provider_error.rs)
+13. [Parsing a JSON-RPC request on the server side](./examples/parse_jsonrpc_request.rs)
+
+14. [Inspecting a erased provider-specific error type](./examples/downcast_provider_error.rs)
 
 ## License
 

--- a/examples/batch.rs
+++ b/examples/batch.rs
@@ -1,0 +1,36 @@
+use starknet::providers::{
+    jsonrpc::{HttpTransport, JsonRpcClient},
+    Provider, ProviderRequestData, ProviderResponseData, Url,
+};
+use starknet_core::types::{
+    requests::{BlockNumberRequest, GetBlockTransactionCountRequest},
+    BlockId,
+};
+
+#[tokio::main]
+async fn main() {
+    let provider = JsonRpcClient::new(HttpTransport::new(
+        Url::parse("https://starknet-sepolia.public.blastapi.io/rpc/v0_7").unwrap(),
+    ));
+
+    let responses = provider
+        .batch_requests([
+            ProviderRequestData::BlockNumber(BlockNumberRequest),
+            ProviderRequestData::GetBlockTransactionCount(GetBlockTransactionCountRequest {
+                block_id: BlockId::Number(100),
+            }),
+        ])
+        .await
+        .unwrap();
+
+    match (&responses[0], &responses[1]) {
+        (
+            ProviderResponseData::BlockNumber(block_number),
+            ProviderResponseData::GetBlockTransactionCount(count),
+        ) => {
+            println!("The latest block is #{}", block_number);
+            println!("Block #100 has {} transactions", count);
+        }
+        _ => panic!("unexpected response type"),
+    }
+}

--- a/examples/parse_jsonrpc_request.rs
+++ b/examples/parse_jsonrpc_request.rs
@@ -1,4 +1,4 @@
-use starknet_providers::jsonrpc::{JsonRpcRequest, JsonRpcRequestData};
+use starknet_providers::{jsonrpc::JsonRpcRequest, ProviderRequestData};
 
 fn main() {
     // Let's pretend this is the raw request body coming from HTTP
@@ -17,7 +17,7 @@ fn main() {
     println!("Request received: {:#?}", parsed_request);
 
     match parsed_request.data {
-        JsonRpcRequestData::GetBlockTransactionCount(req) => {
+        ProviderRequestData::GetBlockTransactionCount(req) => {
             println!(
                 "starknet_getBlockTransactionCount request received for block: {:?}",
                 req.block_id

--- a/starknet-providers/src/any.rs
+++ b/starknet-providers/src/any.rs
@@ -12,7 +12,7 @@ use starknet_core::types::{
 
 use crate::{
     jsonrpc::{HttpTransport, JsonRpcClient},
-    Provider, ProviderError, SequencerGatewayProvider,
+    Provider, ProviderError, ProviderRequestData, ProviderResponseData, SequencerGatewayProvider,
 };
 
 /// A convenient Box-able type that implements the [Provider] trait. This can be useful when you
@@ -662,6 +662,23 @@ impl Provider for AnyProvider {
             Self::SequencerGateway(inner) => {
                 <SequencerGatewayProvider as Provider>::trace_block_transactions(inner, block_id)
                     .await
+            }
+        }
+    }
+
+    async fn batch_requests<R>(
+        &self,
+        requests: R,
+    ) -> Result<Vec<ProviderResponseData>, ProviderError>
+    where
+        R: AsRef<[ProviderRequestData]> + Send + Sync,
+    {
+        match self {
+            Self::JsonRpcHttp(inner) => {
+                <JsonRpcClient<HttpTransport> as Provider>::batch_requests(inner, requests).await
+            }
+            Self::SequencerGateway(inner) => {
+                <SequencerGatewayProvider as Provider>::batch_requests(inner, requests).await
             }
         }
     }

--- a/starknet-providers/src/jsonrpc/transports/http.rs
+++ b/starknet-providers/src/jsonrpc/transports/http.rs
@@ -3,7 +3,10 @@ use log::trace;
 use reqwest::{Client, Url};
 use serde::{de::DeserializeOwned, Serialize};
 
-use crate::jsonrpc::{transports::JsonRpcTransport, JsonRpcMethod, JsonRpcResponse};
+use crate::{
+    jsonrpc::{transports::JsonRpcTransport, JsonRpcMethod, JsonRpcResponse},
+    ProviderRequestData,
+};
 
 /// A [`JsonRpcTransport`] implementation that uses HTTP connections.
 #[derive(Debug)]
@@ -21,6 +24,9 @@ pub enum HttpTransportError {
     Reqwest(reqwest::Error),
     /// JSON serialization/deserialization errors.
     Json(serde_json::Error),
+    /// Unexpected response ID.
+    #[error("unexpected response ID: {0}")]
+    UnexpectedResponseId(u64),
 }
 
 #[derive(Debug, Serialize)]
@@ -109,5 +115,68 @@ impl JsonRpcTransport for HttpTransport {
         let parsed_response = serde_json::from_str(&response_body).map_err(Self::Error::Json)?;
 
         Ok(parsed_response)
+    }
+
+    async fn send_requests<R>(
+        &self,
+        requests: R,
+    ) -> Result<Vec<JsonRpcResponse<serde_json::Value>>, Self::Error>
+    where
+        R: AsRef<[ProviderRequestData]> + Send + Sync,
+    {
+        let request_bodies = requests
+            .as_ref()
+            .iter()
+            .enumerate()
+            .map(|(ind, request)| JsonRpcRequest {
+                id: ind as u64,
+                jsonrpc: "2.0",
+                method: request.jsonrpc_method(),
+                params: request,
+            })
+            .collect::<Vec<_>>();
+
+        let request_count = request_bodies.len();
+
+        let request_body = serde_json::to_string(&request_bodies).map_err(Self::Error::Json)?;
+        trace!("Sending request via JSON-RPC: {}", request_body);
+
+        let mut request = self
+            .client
+            .post(self.url.clone())
+            .body(request_body)
+            .header("Content-Type", "application/json");
+        for (name, value) in &self.headers {
+            request = request.header(name, value);
+        }
+
+        let response = request.send().await.map_err(Self::Error::Reqwest)?;
+
+        let response_body = response.text().await.map_err(Self::Error::Reqwest)?;
+        trace!("Response from JSON-RPC: {}", response_body);
+
+        let parsed_response: Vec<JsonRpcResponse<serde_json::Value>> =
+            serde_json::from_str(&response_body).map_err(Self::Error::Json)?;
+
+        let mut responses: Vec<Option<JsonRpcResponse<serde_json::Value>>> = vec![];
+        responses.resize(request_bodies.len(), None);
+
+        // Re-order the responses as servers do not maintain order.
+        for response_item in parsed_response {
+            let id = match &response_item {
+                JsonRpcResponse::Success { id, .. } | JsonRpcResponse::Error { id, .. } => {
+                    *id as usize
+                }
+            };
+
+            if id >= request_count {
+                return Err(HttpTransportError::UnexpectedResponseId(id as u64));
+            }
+
+            responses[id] = Some(response_item);
+        }
+
+        let responses = responses.into_iter().flatten().collect::<Vec<_>>();
+        Ok(responses)
     }
 }

--- a/starknet-providers/src/jsonrpc/transports/mod.rs
+++ b/starknet-providers/src/jsonrpc/transports/mod.rs
@@ -3,7 +3,10 @@ use auto_impl::auto_impl;
 use serde::{de::DeserializeOwned, Serialize};
 use std::error::Error;
 
-use crate::jsonrpc::{JsonRpcMethod, JsonRpcResponse};
+use crate::{
+    jsonrpc::{JsonRpcMethod, JsonRpcResponse},
+    ProviderRequestData,
+};
 
 mod http;
 pub use http::{HttpTransport, HttpTransportError};
@@ -26,4 +29,12 @@ pub trait JsonRpcTransport {
     where
         P: Serialize + Send + Sync,
         R: DeserializeOwned;
+
+    /// Sends multiple JSON-RPC requests in parallel.
+    async fn send_requests<R>(
+        &self,
+        requests: R,
+    ) -> Result<Vec<JsonRpcResponse<serde_json::Value>>, Self::Error>
+    where
+        R: AsRef<[ProviderRequestData]> + Send + Sync;
 }

--- a/starknet-providers/src/lib.rs
+++ b/starknet-providers/src/lib.rs
@@ -7,7 +7,7 @@
 #![deny(missing_docs)]
 
 mod provider;
-pub use provider::{Provider, ProviderError};
+pub use provider::{Provider, ProviderError, ProviderRequestData, ProviderResponseData};
 
 // Sequencer-related functionalities are mostly deprecated so we skip the docs.
 /// Module containing types related to the (now deprecated) sequencer gateway client.

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -17,7 +17,7 @@ use starknet_core::types::{
 use crate::{
     provider::ProviderImplError,
     sequencer::{models::conversions::ConversionError, GatewayClientError},
-    Provider, ProviderError, SequencerGatewayProvider,
+    Provider, ProviderError, ProviderRequestData, ProviderResponseData, SequencerGatewayProvider,
 };
 
 use super::models::TransactionFinalityStatus;
@@ -410,6 +410,20 @@ impl Provider for SequencerGatewayProvider {
         // With JSON-RPC v0.5.0 it's no longer possible to convert feeder traces to JSON-RPC traces. So we simply pretend that it's not supported here.
         //
         // This is fine as the feeder gateway is soon to be removed anyways.
+        Err(ProviderError::Other(Box::new(
+            GatewayClientError::MethodNotSupported,
+        )))
+    }
+
+    async fn batch_requests<R>(
+        &self,
+        requests: R,
+    ) -> Result<Vec<ProviderResponseData>, ProviderError>
+    where
+        R: AsRef<[ProviderRequestData]> + Send + Sync,
+    {
+        // Not implemented for now. It's technically possible to simulate this by running multiple
+        // requests in parallel.
         Err(ProviderError::Other(Box::new(
             GatewayClientError::MethodNotSupported,
         )))

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -1,5 +1,6 @@
 use starknet_core::{
     types::{
+        requests::{CallRequest, GetBlockTransactionCountRequest},
         BlockId, BlockTag, BroadcastedInvokeTransaction, BroadcastedInvokeTransactionV1,
         BroadcastedTransaction, ContractClass, DeclareTransaction, DeployAccountTransaction,
         EthAddress, EventFilter, ExecuteInvocation, ExecutionResult, Felt, FunctionCall,
@@ -12,7 +13,7 @@ use starknet_core::{
 };
 use starknet_providers::{
     jsonrpc::{HttpTransport, JsonRpcClient},
-    Provider, ProviderError,
+    Provider, ProviderError, ProviderRequestData, ProviderResponseData,
 };
 use url::Url;
 
@@ -870,6 +871,48 @@ async fn jsonrpc_trace_deploy_account() {
     match trace {
         TransactionTrace::DeployAccount(_) => {}
         _ => panic!("unexpected trace type"),
+    }
+}
+
+#[tokio::test]
+async fn jsonrpc_batch() {
+    let rpc_client = create_jsonrpc_client();
+
+    let responses = rpc_client
+        .batch_requests([
+            ProviderRequestData::GetBlockTransactionCount(GetBlockTransactionCountRequest {
+                block_id: BlockId::Number(20_000),
+            }),
+            ProviderRequestData::Call(CallRequest {
+                request: FunctionCall {
+                    contract_address: Felt::from_hex(
+                        "049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    )
+                    .unwrap(),
+                    entry_point_selector: get_selector_from_name("balanceOf").unwrap(),
+                    calldata: vec![Felt::from_hex(
+                        "03f47d3911396b6d579fd7848cf576286ab6f96dda977915d6c7b10f3dd2315b",
+                    )
+                    .unwrap()],
+                },
+                block_id: BlockId::Tag(BlockTag::Latest),
+            }),
+        ])
+        .await
+        .unwrap();
+
+    match &responses[0] {
+        ProviderResponseData::GetBlockTransactionCount(count) => {
+            assert_eq!(*count, 6);
+        }
+        _ => panic!("unexpected response type"),
+    }
+
+    match &responses[1] {
+        ProviderResponseData::Call(eth_balance) => {
+            assert!(eth_balance[0] > Felt::ZERO);
+        }
+        _ => panic!("unexpected response type"),
     }
 }
 


### PR DESCRIPTION
Resolves #593. Supersedes #600.

Implements a type-safe version of the JSON-RPC batch request feature. Users can now do this:

```rust
let responses = provider
    .batch_requests([
        ProviderRequestData::BlockNumber(BlockNumberRequest),
        ProviderRequestData::GetBlockTransactionCount(GetBlockTransactionCountRequest {
            block_id: BlockId::Number(100),
        }),
    ])
    .await
    .unwrap();

match (&responses[0], &responses[1]) {
    (
        ProviderResponseData::BlockNumber(block_number),
        ProviderResponseData::GetBlockTransactionCount(count),
    ) => {
        println!("The latest block is #{}", block_number);
        println!("Block #100 has {} transactions", count);
    }
    _ => panic!("unexpected response type"),
}
```

and the underlying requests would be sent in the just one HTTP request.