### PR TITLE
chore: add `poseidon_permute_comp` back

### DIFF
--- a/starknet-crypto/src/lib.rs
+++ b/starknet-crypto/src/lib.rs
@@ -35,7 +35,9 @@ pub use starknet_types_core::felt::Felt;
 
 pub use pedersen_hash::pedersen_hash;
 
-pub use poseidon_hash::{poseidon_hash, poseidon_hash_many, poseidon_hash_single, PoseidonHasher};
+pub use poseidon_hash::{
+    poseidon_hash, poseidon_hash_many, poseidon_hash_single, poseidon_permute_comp, PoseidonHasher,
+};
 
 pub use ecdsa::{get_public_key, recover, sign, verify, ExtendedSignature, Signature};
 

--- a/starknet-crypto/src/poseidon_hash.rs
+++ b/starknet-crypto/src/poseidon_hash.rs
@@ -97,6 +97,11 @@ pub fn poseidon_hash_many<'a, I: IntoIterator<Item = &'a Felt>>(msgs: I) -> Felt
     state[0]
 }
 
+/// Poseidon permutation function.                                                            
+pub fn poseidon_permute_comp(state: &mut [Felt; 3]) {
+    Poseidon::hades_permutation(state)
+}
+
 #[cfg(test)]
 mod tests {
     use starknet_types_core::hash::StarkHash;


### PR DESCRIPTION
This function is no longer really needed but removing a public function is a SemVer breaking change. The breakage is totally unnecessary here.