### PR TITLE
chore: adapt wasmtime 14 CLI parsing changes

### DIFF
--- a/scripts/run_bench_wasm.sh
+++ b/scripts/run_bench_wasm.sh
@@ -27,5 +27,10 @@ benches=(
 )
 
 for bench in ${benches[@]}; do
-  $RUNTIME run --dir=. $REPO_ROOT/target/bench-wasm/$bench.wasm -- --bench
+  if [[ "$RUNTIME" == "wasmtime" ]]; then
+    # https://github.com/bytecodealliance/wasmtime/issues/7384
+    $RUNTIME run --dir=. -- $REPO_ROOT/target/bench-wasm/$bench.wasm --bench
+  else
+    $RUNTIME run --dir=. $REPO_ROOT/target/bench-wasm/$bench.wasm -- --bench
+  fi
 done


### PR DESCRIPTION
`./scripts/run_bench_wasm.sh wasmtime` no longer works due to https://github.com/bytecodealliance/wasmtime/issues/7384. Updates the command for `wasmtime` to use the new format.