### PR TITLE
chore: make nightly clippy happy again

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: "Set allowed lints"
         run: |
           if [ "${{ matrix.toolchain }}" == "nightly" ]; then
-            echo "ALLOWED=-A non_local_definitions -A clippy::too_long_first_doc_paragraph" >> $GITHUB_ENV
+            echo "ALLOWED=-A non_local_definitions -A clippy::too_long_first_doc_paragraph -A clippy::needless_return" >> $GITHUB_ENV
           else
             echo "ALLOWED=" >> $GITHUB_ENV
           fi

--- a/starknet-accounts/src/account/declaration.rs
+++ b/starknet-accounts/src/account/declaration.rs
@@ -486,8 +486,8 @@ where
                         let gas_price =
                             u64::from_le_bytes(gas_price_bytes[..8].try_into().unwrap());
 
-                        (((overall_fee + gas_price - 1) / gas_price) as f64
-                            * self.gas_estimate_multiplier) as u64
+                        (overall_fee.div_ceil(gas_price) as f64 * self.gas_estimate_multiplier)
+                            as u64
                     }
                 };
 

--- a/starknet-accounts/src/account/execution.rs
+++ b/starknet-accounts/src/account/execution.rs
@@ -466,8 +466,8 @@ where
                         let gas_price =
                             u64::from_le_bytes(gas_price_bytes[..8].try_into().unwrap());
 
-                        ((((overall_fee + gas_price - 1) / gas_price) as f64)
-                            * self.gas_estimate_multiplier) as u64
+                        ((overall_fee.div_ceil(gas_price) as f64) * self.gas_estimate_multiplier)
+                            as u64
                     }
                 };
 

--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -694,8 +694,8 @@ where
                         let gas_price =
                             u64::from_le_bytes(gas_price_bytes[..8].try_into().unwrap());
 
-                        ((((overall_fee + gas_price - 1) / gas_price) as f64)
-                            * self.gas_estimate_multiplier) as u64
+                        ((overall_fee.div_ceil(gas_price) as f64) * self.gas_estimate_multiplier)
+                            as u64
                     }
                 };
 

--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -355,7 +355,7 @@ async fn can_execute_eth_transfer_invoke_v3_inner<P: Provider + Send + Sync>(
             calldata: vec![Felt::from_hex("0x1234").unwrap(), Felt::ONE, Felt::ZERO],
         }])
         .gas(100000)
-        .gas_price(800000000000000)
+        .gas_price(900000000000000)
         .send()
         .await
         .unwrap();
@@ -545,7 +545,7 @@ async fn can_declare_cairo1_contract_v3_inner<P: Provider + Send + Sync>(
             Felt::from_hex(&hashes.compiled_class_hash).unwrap(),
         )
         .gas(100000)
-        .gas_price(800000000000000)
+        .gas_price(900000000000000)
         .send()
         .await
         .unwrap();

--- a/starknet-contract/tests/contract_deployment.rs
+++ b/starknet-contract/tests/contract_deployment.rs
@@ -81,7 +81,7 @@ async fn can_deploy_contract_to_alpha_sepolia_with_invoke_v3() {
     let result = factory
         .deploy_v3(vec![Felt::ONE], Felt::from_bytes_be(&salt_buffer), true)
         .gas(100000)
-        .gas_price(800000000000000)
+        .gas_price(900000000000000)
         .send()
         .await;
 


### PR DESCRIPTION
Allows `clippy::needless_return` as it causes false positives in tests.