### PR TITLE
feat: implement `Encode` and `Decode` for primitive collection types

### DIFF
--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -10,14 +10,16 @@ use starknet::{
 struct CairoType {
     a: Felt,
     b: Option<u32>,
-    c: bool,
+    c: Vec<bool>,
+    d: [u8; 2],
 }
 
 fn main() {
     let instance = CairoType {
         a: felt!("123456789"),
         b: Some(100),
-        c: false,
+        c: vec![false, true],
+        d: [3, 4],
     };
 
     let mut serialized = vec![];
@@ -25,7 +27,17 @@ fn main() {
 
     assert_eq!(
         serialized,
-        [felt!("123456789"), felt!("0"), felt!("100"), felt!("0")]
+        [
+            felt!("123456789"),
+            felt!("0"),
+            felt!("100"),
+            felt!("2"),
+            felt!("0"),
+            felt!("1"),
+            felt!("2"),
+            felt!("3"),
+            felt!("4"),
+        ]
     );
 
     let restored = CairoType::decode(&serialized).unwrap();


### PR DESCRIPTION
Makes `Vec<T>` and arrays implement `Encode` and `Decode`.