### PR TITLE
feat: `.events()` helper on `TransactionReceipt`

### DIFF
--- a/examples/starknet-wasm/src/lib.rs
+++ b/examples/starknet-wasm/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unused_unit)]
+#![allow(unexpected_cfgs)]
 
 use starknet_crypto::Felt;
 use wasm_bindgen::prelude::*;

--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -614,6 +614,17 @@ impl TransactionReceipt {
             Self::DeployAccount(receipt) => &receipt.execution_result,
         }
     }
+
+    /// Gets a reference to the transaction's emitted events.
+    pub fn events(&self) -> &[Event] {
+        match self {
+            Self::Invoke(receipt) => &receipt.events,
+            Self::L1Handler(receipt) => &receipt.events,
+            Self::Declare(receipt) => &receipt.events,
+            Self::Deploy(receipt) => &receipt.events,
+            Self::DeployAccount(receipt) => &receipt.events,
+        }
+    }
 }
 
 impl L1HandlerTransaction {


### PR DESCRIPTION
Adds a `.events()` helper function on `TransactionReceipt` to allow easy access to the underlying events without explicit matching.