### PR TITLE
fix: overly-restrictive wasm cfg for keystore

### DIFF
--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -24,7 +24,7 @@ coins-bip32 = { version = "0.11.1", optional = true }
 coins-ledger = { version = "0.12.0", default-features = false, optional = true }
 semver = { version = "1.0.23", optional = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
 eth-keystore = { version = "0.5.0", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/starknet-signers/src/key_pair.rs
+++ b/starknet-signers/src/key_pair.rs
@@ -19,7 +19,7 @@ pub struct VerifyingKey {
 }
 
 /// Errors using an encrypted JSON keystore.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 #[derive(Debug, thiserror::Error)]
 pub enum KeystoreError {
     /// The file path is invalid.
@@ -59,7 +59,7 @@ impl SigningKey {
     }
 
     /// Loads the private key from a Web3 Secret Storage Definition keystore.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub fn from_keystore<P>(path: P, password: &str) -> Result<Self, KeystoreError>
     where
         P: AsRef<std::path::Path>,
@@ -70,7 +70,7 @@ impl SigningKey {
     }
 
     /// Encrypts and saves the private key to a Web3 Secret Storage Definition JSON file.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub fn save_as_keystore<P>(&self, path: P, password: &str) -> Result<(), KeystoreError>
     where
         P: AsRef<std::path::Path>,

--- a/starknet-signers/src/lib.rs
+++ b/starknet-signers/src/lib.rs
@@ -5,7 +5,7 @@
 mod key_pair;
 pub use key_pair::{SigningKey, VerifyingKey};
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub use key_pair::KeystoreError;
 
 mod signer;


### PR DESCRIPTION
Currently keystore related functionalities are disabled when compiling for `wasm32`, with the assumption that wasm targets do not have a file system.

This is not entirely true though. WASI targets for example for access to files. This PR fixes it by relaxing the condition to only disable them when `target_os` is `unknown`.