### PR TITLE
typo-Update argent.rs

### DIFF
--- a/starknet-accounts/src/factory/argent.rs
+++ b/starknet-accounts/src/factory/argent.rs
@@ -87,7 +87,7 @@ where
     fn calldata(&self) -> Vec<Felt> {
         let mut calldata = vec![];
 
-        // Encoding this sturct never fails
+        // Encoding this struct never fails
         ArgentAccountConstructorParams {
             owner: ArgentSigner::Starknet(self.owner_public_key),
             guardian: self.guardian_public_key.map(ArgentSigner::Starknet),


### PR DESCRIPTION
# Fix: Corrected typo in source file

## Changes
- `starknet-accounts/src/factory/argent.rs:90`: "sturct" corrected to "struct".

## Purpose
- Improved code accuracy and ensured professionalism by fixing the typo.
