### PR TITLE
feat: deprecate pre-v3 transactions

### DIFF
--- a/examples/declare_cairo1_contract.rs
+++ b/examples/declare_cairo1_contract.rs
@@ -48,7 +48,7 @@ async fn main() {
     let flattened_class = contract_artifact.flatten().unwrap();
 
     let result = account
-        .declare_v2(Arc::new(flattened_class), compiled_class_hash)
+        .declare_v3(Arc::new(flattened_class), compiled_class_hash)
         .send()
         .await
         .unwrap();

--- a/examples/deploy_account_with_ledger.rs
+++ b/examples/deploy_account_with_ledger.rs
@@ -34,7 +34,7 @@ async fn main() {
         .await
         .unwrap();
 
-    let deployment = factory.deploy_v1(salt);
+    let deployment = factory.deploy_v3(salt);
 
     let est_fee = deployment.estimate_fee().await.unwrap();
 

--- a/examples/deploy_argent_account.rs
+++ b/examples/deploy_argent_account.rs
@@ -29,7 +29,7 @@ async fn main() {
         .await
         .unwrap();
 
-    let deployment = factory.deploy_v1(salt);
+    let deployment = factory.deploy_v3(salt);
 
     let est_fee = deployment.estimate_fee().await.unwrap();
 

--- a/examples/deploy_contract.rs
+++ b/examples/deploy_contract.rs
@@ -49,7 +49,7 @@ async fn main() {
 
     let contract_factory = ContractFactory::new(class_hash, account);
     contract_factory
-        .deploy_v1(vec![felt!("123456")], felt!("1122"), false)
+        .deploy_v3(vec![felt!("123456")], felt!("1122"), false)
         .send()
         .await
         .expect("Unable to deploy contract");

--- a/examples/mint_tokens.rs
+++ b/examples/mint_tokens.rs
@@ -38,7 +38,7 @@ async fn main() {
     account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let result = account
-        .execute_v1(vec![Call {
+        .execute_v3(vec![Call {
             to: tst_token_address,
             selector: get_selector_from_name("mint").unwrap(),
             calldata: vec![

--- a/examples/transfer_with_ledger.rs
+++ b/examples/transfer_with_ledger.rs
@@ -44,7 +44,7 @@ async fn main() {
     account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let result = account
-        .execute_v1(vec![Call {
+        .execute_v3(vec![Call {
             to: eth_token_address,
             selector: get_selector_from_name("transfer").unwrap(),
             calldata: vec![felt!("0x1234"), felt!("100"), Felt::ZERO],

--- a/starknet-accounts/src/account/mod.rs
+++ b/starknet-accounts/src/account/mod.rs
@@ -92,6 +92,7 @@ pub trait Account: ExecutionEncoder + Sized {
 
     /// Generates an instance of [`ExecutionV1`] for sending `INVOKE` v1 transactions. Pays
     /// transaction fees in `ETH`.
+    #[deprecated = "pre-v3 transactions are deprecated and will be disabled on Starknet soon; use `execute_v3` instead"]
     fn execute_v1(&self, calls: Vec<Call>) -> ExecutionV1<'_, Self> {
         ExecutionV1::new(calls, self)
     }
@@ -104,8 +105,9 @@ pub trait Account: ExecutionEncoder + Sized {
 
     /// Generates an instance of [`ExecutionV1`] for sending `INVOKE` v1 transactions. Pays
     /// transaction fees in `ETH`.
-    #[deprecated = "use version specific variants (`execute_v1` & `execute_v3`) instead"]
+    #[deprecated = "pre-v3 transactions are deprecated and will be disabled on Starknet soon; use `execute_v3` instead"]
     fn execute(&self, calls: Vec<Call>) -> ExecutionV1<'_, Self> {
+        #[allow(deprecated)]
         self.execute_v1(calls)
     }
 
@@ -124,6 +126,7 @@ pub trait Account: ExecutionEncoder + Sized {
     ///
     /// This method is only used for declaring Sierra (Cairo 1) classes. To declare legacy (Cairo 0)
     /// classes use [`declare_legacy`](fn.declare_legacy) instead.
+    #[deprecated = "pre-v3 transactions are deprecated and will be disabled on Starknet soon; use `declare_v3` instead"]
     fn declare_v2(
         &self,
         contract_class: Arc<FlattenedSierraClass>,
@@ -170,12 +173,13 @@ pub trait Account: ExecutionEncoder + Sized {
     ///
     /// This method is only used for declaring Sierra (Cairo 1) classes. To declare legacy (Cairo 0)
     /// classes use [`declare_legacy`](fn.declare_legacy) instead.
-    #[deprecated = "use version specific variants (`declare_v2` & `declare_v3`) instead"]
+    #[deprecated = "pre-v3 transactions are deprecated and will be disabled on Starknet soon; use `declare_v3` instead"]
     fn declare(
         &self,
         contract_class: Arc<FlattenedSierraClass>,
         compiled_class_hash: Felt,
     ) -> DeclarationV2<'_, Self> {
+        #[allow(deprecated)]
         self.declare_v2(contract_class, compiled_class_hash)
     }
 

--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -117,6 +117,7 @@ pub trait AccountFactory: Sized {
 
     /// Generates an instance of [`AccountDeploymentV1`] for sending `DEPLOY_ACCOUNT` v1
     /// transactions. Pays transaction fees in `ETH`.
+    #[deprecated = "pre-v3 transactions are deprecated and will be disabled on Starknet soon; use `deploy_v3` instead"]
     fn deploy_v1(&self, salt: Felt) -> AccountDeploymentV1<'_, Self> {
         AccountDeploymentV1::new(salt, self)
     }
@@ -129,8 +130,9 @@ pub trait AccountFactory: Sized {
 
     /// Generates an instance of [`AccountDeploymentV1`] for sending `DEPLOY_ACCOUNT` v1
     /// transactions. Pays transaction fees in `ETH`.
-    #[deprecated = "use version specific variants (`deploy_v1` & `deploy_v3`) instead"]
+    #[deprecated = "pre-v3 transactions are deprecated and will be disabled on Starknet soon; use `deploy_v3` instead"]
     fn deploy(&self, salt: Felt) -> AccountDeploymentV1<'_, Self> {
+        #[allow(deprecated)]
         self.deploy_v1(salt)
     }
 }

--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -202,6 +202,7 @@ async fn can_get_nonce_inner<P: Provider + Send + Sync>(provider: P, address: &s
     assert_ne!(account.get_nonce().await.unwrap(), Felt::ZERO);
 }
 
+#[allow(deprecated)]
 async fn can_estimate_invoke_v1_fee_inner<P: Provider + Send + Sync>(provider: P, address: &str) {
     let signer = LocalWallet::from(SigningKey::from_secret_scalar(
         Felt::from_hex("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").unwrap(),
@@ -268,7 +269,7 @@ async fn can_parse_fee_estimation_error_inner<P: Provider + Send + Sync>(
     account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     match account
-        .execute_v1(vec![Call {
+        .execute_v3(vec![Call {
             to: eth_token_address,
             selector: get_selector_from_name("transfer").unwrap(),
             calldata: vec![
@@ -290,6 +291,7 @@ async fn can_parse_fee_estimation_error_inner<P: Provider + Send + Sync>(
     }
 }
 
+#[allow(deprecated)]
 async fn can_execute_eth_transfer_invoke_v1_inner<P: Provider + Send + Sync>(
     provider: P,
     address: &str,
@@ -400,6 +402,7 @@ async fn can_execute_eth_transfer_invoke_v3_with_manual_gas_inner<P: Provider + 
     assert!(result.transaction_hash > Felt::ZERO);
 }
 
+#[allow(deprecated)]
 async fn can_declare_cairo1_contract_v2_inner<P: Provider + Send + Sync>(
     provider: P,
     address: &str,

--- a/starknet-contract/src/factory.rs
+++ b/starknet-contract/src/factory.rs
@@ -88,6 +88,7 @@ where
 {
     /// Generates an instance of [`DeploymentV1`] for sending `INVOKE` v1 transactions for the
     /// contract deployment. Pays transaction fees in `ETH`.
+    #[deprecated = "pre-v3 transactions are deprecated and will be disabled on Starknet soon; use `deploy_v3` instead"]
     pub const fn deploy_v1(
         &self,
         constructor_calldata: Vec<Felt>,
@@ -128,13 +129,14 @@ where
 
     /// Generates an instance of [`DeploymentV1`] for sending `INVOKE` v1 transactions for the
     /// contract deployment. Pays transaction fees in `ETH`.
-    #[deprecated = "use version specific variants (`deploy_v1` & `deploy_v3`) instead"]
+    #[deprecated = "pre-v3 transactions are deprecated and will be disabled on Starknet soon; use `deploy_v3` instead"]
     pub const fn deploy(
         &self,
         constructor_calldata: Vec<Felt>,
         salt: Felt,
         unique: bool,
     ) -> DeploymentV1<'_, A> {
+        #[allow(deprecated)]
         self.deploy_v1(constructor_calldata, salt, unique)
     }
 }
@@ -399,6 +401,7 @@ mod tests {
 
     use super::*;
 
+    #[allow(deprecated)]
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_deployed_address_unique() {

--- a/starknet-contract/tests/contract_deployment.rs
+++ b/starknet-contract/tests/contract_deployment.rs
@@ -14,6 +14,7 @@ const CHAIN_ID: Felt = Felt::from_raw([
     1555806712078248243,
 ]);
 
+#[allow(deprecated)]
 #[tokio::test]
 async fn can_deploy_contract_to_alpha_sepolia_with_invoke_v1() {
     let rpc_url = std::env::var("STARKNET_RPC")


### PR DESCRIPTION
Pre-v3 transactions are now deprecated and will be disabled on Starknet soon. This PR deprecates all non-v3 methods to add a compilation warnings to downstream applications.