### PR TITLE
release: bump starknet to 0.13.0 (and deps)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "starknet"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde_json",
  "starknet-accounts",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2073,7 +2073,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "rand",
  "serde",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "criterion",
  "crypto-bigint",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2193,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -33,18 +33,18 @@ members = [
 all-features = true
 
 [dependencies]
-starknet-crypto = { version = "0.7.3", path = "./starknet-crypto" }
-starknet-core = { version = "0.12.0", path = "./starknet-core", default-features = false }
+starknet-crypto = { version = "0.7.4", path = "./starknet-crypto" }
+starknet-core = { version = "0.12.1", path = "./starknet-core", default-features = false }
 starknet-core-derive = { version = "0.1.0", path = "./starknet-core-derive", features = ["import_from_starknet"] }
-starknet-providers = { version = "0.12.0", path = "./starknet-providers" }
-starknet-contract = { version = "0.11.0", path = "./starknet-contract" }
-starknet-signers = { version = "0.10.0", path = "./starknet-signers" }
-starknet-accounts = { version = "0.11.0", path = "./starknet-accounts" }
+starknet-providers = { version = "0.12.1", path = "./starknet-providers" }
+starknet-contract = { version = "0.12.0", path = "./starknet-contract" }
+starknet-signers = { version = "0.10.1", path = "./starknet-signers" }
+starknet-accounts = { version = "0.12.0", path = "./starknet-accounts" }
 starknet-macros = { version = "0.2.1", path = "./starknet-macros" }
 
 [dev-dependencies]
 serde_json = "1.0.74"
-starknet-signers = { version = "0.10.0", path = "./starknet-signers", features = ["ledger"] }
+starknet-signers = { version = "0.10.1", path = "./starknet-signers", features = ["ledger"] }
 tokio = { version = "1.15.0", features = ["full"] }
 url = "2.2.2"
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To use the crate from [crates.io](https://crates.io/crates/starknet), add the fo
 
 ```toml
 [dependencies]
-starknet = "0.11.0"
+starknet = "0.13.0"
 ```
 
 Note that the [crates.io version](https://crates.io/crates/starknet) might be outdated. You may want to use the library directly from GitHub for all the latest features and fixes:

--- a/examples/starknet-wasm/Cargo.toml
+++ b/examples/starknet-wasm/Cargo.toml
@@ -19,6 +19,6 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-starknet-crypto = { version = "0.7.3", path = "../../starknet-crypto" }
+starknet-crypto = { version = "0.7.4", path = "../../starknet-crypto" }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 wasm-bindgen = "0.2.84"

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-accounts"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,10 +14,10 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.12.0", path = "../starknet-core" }
-starknet-crypto = { version = "0.7.3", path = "../starknet-crypto" }
-starknet-providers = { version = "0.12.0", path = "../starknet-providers" }
-starknet-signers = { version = "0.10.0", path = "../starknet-signers" }
+starknet-core = { version = "0.12.1", path = "../starknet-core" }
+starknet-crypto = { version = "0.7.4", path = "../starknet-crypto" }
+starknet-providers = { version = "0.12.1", path = "../starknet-providers" }
+starknet-signers = { version = "0.10.1", path = "../starknet-signers" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 thiserror = "1.0.40"

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-contract"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,9 +14,9 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.12.0", path = "../starknet-core" }
-starknet-providers = { version = "0.12.0", path = "../starknet-providers" }
-starknet-accounts = { version = "0.11.0", path = "../starknet-accounts" }
+starknet-core = { version = "0.12.1", path = "../starknet-core" }
+starknet-providers = { version = "0.12.1", path = "../starknet-providers" }
+starknet-accounts = { version = "0.12.0", path = "../starknet-accounts" }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
 serde_with = "3.9.0"
@@ -24,7 +24,7 @@ thiserror = "1.0.40"
 
 [dev-dependencies]
 rand = { version = "0.8.5", features=["std_rng"] }
-starknet-signers = { version = "0.10.0", path = "../starknet-signers" }
+starknet-signers = { version = "0.10.1", path = "../starknet-signers" }
 tokio = { version = "1.27.0", features = ["full"] }
 url = "2.3.1"
 

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-core"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -17,7 +17,7 @@ exclude = ["test-data/**"]
 all-features = true
 
 [dependencies]
-starknet-crypto = { version = "0.7.3", path = "../starknet-crypto", default-features = false, features = ["alloc"] }
+starknet-crypto = { version = "0.7.4", path = "../starknet-crypto", default-features = false, features = ["alloc"] }
 starknet-core-derive = { version = "0.1.0", path = "../starknet-core-derive" }
 base64 = { version = "0.21.0", default-features = false, features = ["alloc"] }
 crypto-bigint = { version = "0.5.1", default-features = false }

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-crypto"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/starknet-macros/Cargo.toml
+++ b/starknet-macros/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 proc-macro = true
 
 [dependencies]
-starknet-core = { version = "0.12.0", path = "../starknet-core" }
+starknet-core = { version = "0.12.1", path = "../starknet-core" }
 syn = "2.0.15"
 
 [features]

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-providers"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.12.0", path = "../starknet-core" }
+starknet-core = { version = "0.12.1", path = "../starknet-core" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 ethereum-types = "0.14.1"

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-signers"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,8 +13,8 @@ Starknet signer implementations
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.12.0", path = "../starknet-core" }
-starknet-crypto = { version = "0.7.3", path = "../starknet-crypto" }
+starknet-core = { version = "0.12.1", path = "../starknet-core" }
+starknet-crypto = { version = "0.7.4", path = "../starknet-crypto" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 thiserror = "1.0.40"


### PR DESCRIPTION
Makes a bunch of new features available, mainly:

- deprecation of pre-v3 transactions;
- initial `TypedData` (SNIP-12) support;
- native `ByteArray` type;

among other minor improvements.