### PR TITLE
chore: make nightly clippy happy

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: "Set allowed lints"
         run: |
           if [ "${{ matrix.toolchain }}" == "nightly" ]; then
-            echo "ALLOWED=-A non_local_definitions -A clippy::too_long_first_doc_paragraph -A clippy::needless_return" >> $GITHUB_ENV
+            echo "ALLOWED=-A non_local_definitions -A clippy::too_long_first_doc_paragraph -A clippy::needless_return -A clippy::missing_const_for_fn" >> $GITHUB_ENV
           else
             echo "ALLOWED=" >> $GITHUB_ENV
           fi

--- a/starknet-core/src/types/typed_data/mod.rs
+++ b/starknet-core/src/types/typed_data/mod.rs
@@ -570,7 +570,7 @@ impl TypedData {
     where
         H: TypedDataHasher,
     {
-        let mut new_layer = Vec::with_capacity((layer.len() + 1) / 2);
+        let mut new_layer = Vec::with_capacity(layer.len().div_ceil(2));
         for chunk in layer.chunks(2) {
             new_layer.push(if chunk.len() == 2 {
                 if chunk[0] <= chunk[1] {


### PR DESCRIPTION
`clippy::missing_const_for_fn` is disabled as it labels functions that can _only_ be `const` in nightly Rust.