### PR TITLE
Fix runtime error during transaction hash calculation

### DIFF
--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -687,7 +687,7 @@ where
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             ];
             resource_buffer[8..(8 + 8)].copy_from_slice(&self.inner.l1_data_gas.to_be_bytes());
-            resource_buffer[(8 + 8)..].copy_from_slice(&self.inner.l1_data_gas.to_be_bytes());
+            resource_buffer[(8 + 8)..].copy_from_slice(&self.inner.l1_data_gas_price.to_be_bytes());
             fee_hasher.update(Felt::from_bytes_be(&resource_buffer));
 
             fee_hasher.finalize()


### PR DESCRIPTION
in `PreparedAccountDeploymentV3::transaction_hash()` resource buffer for l1_data_gas property is incorrectly filled 2 times with l1_data_gas