### PR TITLE
fix: fixed issue with array element handling in Bash loop

### DIFF
--- a/scripts/run_bench_wasm.sh
+++ b/scripts/run_bench_wasm.sh
@@ -26,7 +26,7 @@ benches=(
   rfc6979_generate_k
 )
 
-for bench in ${benches[@]}; do
+for bench in "${benches[@]}"; do
   if [[ "$RUNTIME" == "wasmtime" ]]; then
     # https://github.com/bytecodealliance/wasmtime/issues/7384
     $RUNTIME run --dir=. -- $REPO_ROOT/target/bench-wasm/$bench.wasm --bench


### PR DESCRIPTION
I’ve fixed an issue where array elements containing spaces or special characters might cause unexpected behavior in loops. By adding quotes around `${benches[@]}`, we ensure that elements like "my_bench 1" are correctly handled as a single item, preventing the array from being split incorrectly.
This small change helps avoid potential errors and ensures more reliable script execution.