### PR TITLE
chore: fix `read_line` input handling

### DIFF
--- a/examples/deploy_account_with_ledger.rs
+++ b/examples/deploy_account_with_ledger.rs
@@ -45,7 +45,8 @@ async fn main() {
         deployment.address()
     );
     println!("Press ENTER after account is funded to continue deployment...");
-    std::io::stdin().read_line(&mut String::new()).unwrap();
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input).unwrap();
 
     let result = deployment.send().await;
     match result {


### PR DESCRIPTION
Fixed the issue where `read_line` was called with a temporary string.
Updated to pass a mutable reference to a proper `String` variable.