### PR TITLE
Update github actions versions due to deprecation

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: "Checkout source code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
         with:
           submodules: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: "Checkout source code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Setup stable toolchain"
         uses: "actions-rs/toolchain@v1"
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: "Checkout source code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Setup stable toolchain"
         uses: "actions-rs/toolchain@v1"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: "Checkout source code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Setup stable toolchain"
         uses: "actions-rs/toolchain@v1"


### PR DESCRIPTION
Artifact Actions v3 will be deprecated by January 30, 2025. GitHub has started temporarily failing workflows that haven't been updated ahead of this deadline. This PR updates the action versions accordingly, following the [official migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md).