### PR TITLE
feat: change default account block to pending

### DIFF
--- a/examples/declare_cairo1_contract.rs
+++ b/examples/declare_cairo1_contract.rs
@@ -4,7 +4,7 @@ use starknet::{
     accounts::{Account, ExecutionEncoding, SingleOwnerAccount},
     core::{
         chain_id,
-        types::{contract::SierraClass, BlockId, BlockTag, Felt},
+        types::{contract::SierraClass, Felt},
     },
     providers::{
         jsonrpc::{HttpTransport, JsonRpcClient},
@@ -32,17 +32,13 @@ async fn main() {
     ));
     let address = Felt::from_hex("YOUR_ACCOUNT_CONTRACT_ADDRESS_IN_HEX_HERE").unwrap();
 
-    let mut account = SingleOwnerAccount::new(
+    let account = SingleOwnerAccount::new(
         provider,
         signer,
         address,
         chain_id::SEPOLIA,
         ExecutionEncoding::New,
     );
-
-    // `SingleOwnerAccount` defaults to checking nonce and estimating fees against the latest
-    // block. Optionally change the target block to pending with the following line:
-    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     // We need to flatten the ABI into a string first
     let flattened_class = contract_artifact.flatten().unwrap();

--- a/examples/deploy_contract.rs
+++ b/examples/deploy_contract.rs
@@ -5,7 +5,7 @@ use starknet::{
     contract::ContractFactory,
     core::{
         chain_id,
-        types::{contract::legacy::LegacyContractClass, BlockId, BlockTag, Felt},
+        types::{contract::legacy::LegacyContractClass, Felt},
     },
     macros::felt,
     providers::{
@@ -31,17 +31,13 @@ async fn main() {
         Felt::from_hex("YOUR_PRIVATE_KEY_IN_HEX_HERE").unwrap(),
     ));
     let address = Felt::from_hex("YOUR_ACCOUNT_CONTRACT_ADDRESS_IN_HEX_HERE").unwrap();
-    let mut account = SingleOwnerAccount::new(
+    let account = SingleOwnerAccount::new(
         provider,
         signer,
         address,
         chain_id::SEPOLIA,
         ExecutionEncoding::New,
     );
-
-    // `SingleOwnerAccount` defaults to checking nonce and estimating fees against the latest
-    // block. Optionally change the target block to pending with the following line:
-    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     // Wrapping in `Arc` is meaningless here. It's just showcasing it could be done as
     // `Arc<Account>` implements `Account` too.

--- a/examples/mint_tokens.rs
+++ b/examples/mint_tokens.rs
@@ -2,7 +2,7 @@ use starknet::{
     accounts::{Account, ExecutionEncoding, SingleOwnerAccount},
     core::{
         chain_id,
-        types::{BlockId, BlockTag, Call, Felt},
+        types::{Call, Felt},
         utils::get_selector_from_name,
     },
     providers::{
@@ -25,17 +25,13 @@ async fn main() {
     let tst_token_address =
         Felt::from_hex("07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10").unwrap();
 
-    let mut account = SingleOwnerAccount::new(
+    let account = SingleOwnerAccount::new(
         provider,
         signer,
         address,
         chain_id::SEPOLIA,
         ExecutionEncoding::New,
     );
-
-    // `SingleOwnerAccount` defaults to checking nonce and estimating fees against the latest
-    // block. Optionally change the target block to pending with the following line:
-    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let result = account
         .execute_v3(vec![Call {

--- a/examples/transfer_with_ledger.rs
+++ b/examples/transfer_with_ledger.rs
@@ -2,7 +2,7 @@ use starknet::{
     accounts::{Account, ExecutionEncoding, SingleOwnerAccount},
     core::{
         chain_id,
-        types::{BlockId, BlockTag, Call, Felt},
+        types::{Call, Felt},
         utils::get_selector_from_name,
     },
     macros::felt,
@@ -31,17 +31,13 @@ async fn main() {
         Felt::from_hex("0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7")
             .unwrap();
 
-    let mut account = SingleOwnerAccount::new(
+    let account = SingleOwnerAccount::new(
         provider,
         signer,
         address,
         chain_id::SEPOLIA,
         ExecutionEncoding::New,
     );
-
-    // `SingleOwnerAccount` defaults to checking nonce and estimating fees against the latest
-    // block. Optionally change the target block to pending with the following line:
-    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let result = account
         .execute_v3(vec![Call {

--- a/starknet-accounts/src/single_owner.rs
+++ b/starknet-accounts/src/single_owner.rs
@@ -68,7 +68,7 @@ where
             signer,
             address,
             chain_id,
-            block_id: BlockId::Tag(BlockTag::Latest),
+            block_id: BlockId::Tag(BlockTag::Pending),
             encoding,
         }
     }

--- a/starknet-accounts/tests/single_owner_account.rs
+++ b/starknet-accounts/tests/single_owner_account.rs
@@ -2,9 +2,7 @@ use starknet_accounts::{
     Account, AccountError, ConnectedAccount, ExecutionEncoding, SingleOwnerAccount,
 };
 use starknet_core::{
-    types::{
-        contract::SierraClass, BlockId, BlockTag, Call, ContractExecutionError, Felt, StarknetError,
-    },
+    types::{contract::SierraClass, Call, ContractExecutionError, Felt, StarknetError},
     utils::get_selector_from_name,
 };
 use starknet_providers::{
@@ -114,9 +112,8 @@ async fn can_get_nonce_inner<P: Provider + Send + Sync>(provider: P, address: &s
     ));
     let address = Felt::from_hex(address).unwrap();
 
-    let mut account =
+    let account =
         SingleOwnerAccount::new(provider, signer, address, CHAIN_ID, ExecutionEncoding::New);
-    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     assert_ne!(account.get_nonce().await.unwrap(), Felt::ZERO);
 }
@@ -129,9 +126,8 @@ async fn can_estimate_invoke_v3_fee_inner<P: Provider + Send + Sync>(provider: P
     let eth_token_address =
         Felt::from_hex("049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7").unwrap();
 
-    let mut account =
+    let account =
         SingleOwnerAccount::new(provider, signer, address, CHAIN_ID, ExecutionEncoding::New);
-    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let fee_estimate = account
         .execute_v3(vec![Call {
@@ -157,9 +153,8 @@ async fn can_parse_fee_estimation_error_inner<P: Provider + Send + Sync>(
     let eth_token_address =
         Felt::from_hex("049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7").unwrap();
 
-    let mut account =
+    let account =
         SingleOwnerAccount::new(provider, signer, address, CHAIN_ID, ExecutionEncoding::New);
-    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     match account
         .execute_v3(vec![Call {
@@ -205,9 +200,8 @@ async fn can_execute_eth_transfer_invoke_v3_inner<P: Provider + Send + Sync>(
     let eth_token_address =
         Felt::from_hex("049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7").unwrap();
 
-    let mut account =
+    let account =
         SingleOwnerAccount::new(provider, signer, address, CHAIN_ID, ExecutionEncoding::New);
-    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let result = account
         .execute_v3(vec![Call {
@@ -237,9 +231,8 @@ async fn can_execute_eth_transfer_invoke_v3_with_manual_gas_inner<P: Provider + 
     let eth_token_address =
         Felt::from_hex("049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7").unwrap();
 
-    let mut account =
+    let account =
         SingleOwnerAccount::new(provider, signer, address, CHAIN_ID, ExecutionEncoding::New);
-    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let result = account
         .execute_v3(vec![Call {
@@ -274,9 +267,8 @@ async fn can_estimate_declare_v3_fee_inner<P: Provider + Send + Sync>(provider: 
         Felt::from_hex("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").unwrap(),
     ));
     let address = Felt::from_hex(address).unwrap();
-    let mut account =
+    let account =
         SingleOwnerAccount::new(provider, signer, address, CHAIN_ID, ExecutionEncoding::New);
-    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let contract_artifact = serde_json::from_str::<SierraClass>(include_str!(
         "../test-data/cairo1/artifacts/abi_types_sierra.txt"
@@ -325,9 +317,8 @@ async fn can_declare_cairo1_contract_v3_inner<P: Provider + Send + Sync>(
         Felt::from_hex("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").unwrap(),
     ));
     let address = Felt::from_hex(address).unwrap();
-    let mut account =
+    let account =
         SingleOwnerAccount::new(provider, signer, address, CHAIN_ID, ExecutionEncoding::New);
-    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let contract_artifact = serde_json::from_str::<SierraClass>(include_str!(
         "../test-data/cairo1/artifacts/abi_types_sierra.txt"

--- a/starknet-contract/tests/contract_deployment.rs
+++ b/starknet-contract/tests/contract_deployment.rs
@@ -1,7 +1,7 @@
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 use starknet_accounts::{ExecutionEncoding, SingleOwnerAccount};
 use starknet_contract::ContractFactory;
-use starknet_core::types::{contract::legacy::LegacyContractClass, BlockId, BlockTag, Felt};
+use starknet_core::types::{contract::legacy::LegacyContractClass, Felt};
 use starknet_providers::{jsonrpc::HttpTransport, JsonRpcClient};
 use starknet_signers::{LocalWallet, SigningKey};
 use url::Url;
@@ -25,9 +25,8 @@ async fn can_deploy_contract_to_alpha_sepolia_with_invoke_v3() {
     let address =
         Felt::from_hex("0x034dd51aa591d174b60d1cb45e46dfcae47946fae1c5e62933bbf48effedde4d")
             .unwrap();
-    let mut account =
+    let account =
         SingleOwnerAccount::new(provider, signer, address, CHAIN_ID, ExecutionEncoding::New);
-    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let artifact = serde_json::from_str::<LegacyContractClass>(include_str!(
         "../test-data/cairo0/artifacts/oz_account.txt"


### PR DESCRIPTION
Many new users of the library ran into nonce conflict issues that can be traced back to using the latest block for accounts. Changing the default block to pending helps reduce the friction.

This is a breaking change but the next release will be bundled with a couple of other breaking changes.