### PR TITLE
release: bump starknet to 0.15.0 (and deps)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,7 +2237,7 @@ dependencies = [
 
 [[package]]
 name = "starknet"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "serde_json",
  "starknet-accounts",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2272,7 +2272,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "rand 0.8.5",
  "serde",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -2363,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-macros"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "starknet-core",
  "syn 2.0.87",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -35,17 +35,17 @@ all-features = true
 
 [dependencies]
 starknet-crypto = { version = "0.7.4", path = "./starknet-crypto" }
-starknet-core = { version = "0.13.0", path = "./starknet-core", default-features = false }
+starknet-core = { version = "0.14.0", path = "./starknet-core", default-features = false }
 starknet-core-derive = { version = "0.1.0", path = "./starknet-core-derive", features = ["import_from_starknet"] }
-starknet-providers = { version = "0.13.0", path = "./starknet-providers" }
-starknet-contract = { version = "0.13.0", path = "./starknet-contract" }
-starknet-signers = { version = "0.11.0", path = "./starknet-signers" }
-starknet-accounts = { version = "0.13.0", path = "./starknet-accounts" }
-starknet-macros = { version = "0.2.2", path = "./starknet-macros" }
+starknet-providers = { version = "0.14.0", path = "./starknet-providers" }
+starknet-contract = { version = "0.14.0", path = "./starknet-contract" }
+starknet-signers = { version = "0.12.0", path = "./starknet-signers" }
+starknet-accounts = { version = "0.14.0", path = "./starknet-accounts" }
+starknet-macros = { version = "0.2.3", path = "./starknet-macros" }
 
 [dev-dependencies]
 serde_json = "1.0.74"
-starknet-signers = { version = "0.11.0", path = "./starknet-signers", features = ["ledger"] }
+starknet-signers = { version = "0.12.0", path = "./starknet-signers", features = ["ledger"] }
 starknet-tokio-tungstenite = { version = "0.1.0", path = "./starknet-tokio-tungstenite" }
 tokio = { version = "1.15.0", features = ["full"] }
 url = "2.2.2"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To use the crate from [crates.io](https://crates.io/crates/starknet), add the fo
 
 ```toml
 [dependencies]
-starknet = "0.13.0"
+starknet = "0.15.0"
 ```
 
 Note that the [crates.io version](https://crates.io/crates/starknet) might be outdated. You may want to use the library directly from GitHub for all the latest features and fixes:

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-accounts"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,10 +14,10 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.13.0", path = "../starknet-core" }
+starknet-core = { version = "0.14.0", path = "../starknet-core" }
 starknet-crypto = { version = "0.7.4", path = "../starknet-crypto" }
-starknet-providers = { version = "0.13.0", path = "../starknet-providers" }
-starknet-signers = { version = "0.11.0", path = "../starknet-signers" }
+starknet-providers = { version = "0.14.0", path = "../starknet-providers" }
+starknet-signers = { version = "0.12.0", path = "../starknet-signers" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 thiserror = "1.0.40"

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-contract"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,9 +14,9 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.13.0", path = "../starknet-core" }
-starknet-providers = { version = "0.13.0", path = "../starknet-providers" }
-starknet-accounts = { version = "0.13.0", path = "../starknet-accounts" }
+starknet-core = { version = "0.14.0", path = "../starknet-core" }
+starknet-providers = { version = "0.14.0", path = "../starknet-providers" }
+starknet-accounts = { version = "0.14.0", path = "../starknet-accounts" }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
 serde_with = "3.9.0"
@@ -24,7 +24,7 @@ thiserror = "1.0.40"
 
 [dev-dependencies]
 rand = { version = "0.8.5", features=["std_rng"] }
-starknet-signers = { version = "0.11.0", path = "../starknet-signers" }
+starknet-signers = { version = "0.12.0", path = "../starknet-signers" }
 tokio = { version = "1.27.0", features = ["full"] }
 url = "2.3.1"
 

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-core"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/starknet-macros/Cargo.toml
+++ b/starknet-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-macros"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -16,7 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 proc-macro = true
 
 [dependencies]
-starknet-core = { version = "0.13.0", path = "../starknet-core" }
+starknet-core = { version = "0.14.0", path = "../starknet-core" }
 syn = "2.0.15"
 
 [features]

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-providers"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.13.0", path = "../starknet-core" }
+starknet-core = { version = "0.14.0", path = "../starknet-core" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 ethereum-types = "0.14.1"

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-signers"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,7 +13,7 @@ Starknet signer implementations
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.13.0", path = "../starknet-core" }
+starknet-core = { version = "0.14.0", path = "../starknet-core" }
 starknet-crypto = { version = "0.7.4", path = "../starknet-crypto" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"

--- a/starknet-tokio-tungstenite/Cargo.toml
+++ b/starknet-tokio-tungstenite/Cargo.toml
@@ -13,8 +13,8 @@ Starknet JSON-RPC WebSocket client implementation with tokio-tungstenite
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.13.0", path = "../starknet-core", default-features = false }
-starknet-providers = { version = "0.13.0", path = "../starknet-providers" }
+starknet-core = { version = "0.14.0", path = "../starknet-core", default-features = false }
+starknet-providers = { version = "0.14.0", path = "../starknet-providers" }
 futures-util = "0.3.31"
 rand = { version = "0.8.5", features = ["std_rng"] }
 serde = { version = "1.0.160", features = ["derive"] }


### PR DESCRIPTION
Publishes some breaking changes needed for the WebSocket implementation added in #725, along with some other long overdue breakage such as bumping `reqwest`.