### PR TITLE
feat: cloudflare workers jsonrpc transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,8 +259,10 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -810,6 +812,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,9 +847,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1309,6 +1319,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,6 +1520,26 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2062,6 +2098,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,6 +2446,7 @@ dependencies = [
  "thiserror 1.0.63",
  "tokio",
  "url",
+ "worker",
 ]
 
 [[package]]
@@ -3018,6 +3077,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3283,6 +3355,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.6.0",
+]
+
+[[package]]
+name = "worker"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727789ca7eff9733efbea9d0e97779edc1cf1926e98aee7d7d8afe32805458aa"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "js-sys",
+ "matchit",
+ "pin-project",
+ "serde",
+ "serde-wasm-bindgen 0.6.5",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "worker-kv",
+ "worker-macros",
+ "worker-sys",
+]
+
+[[package]]
+name = "worker-kv"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f06d4d1416a9f8346ee9123b0d9a11b3cfa38e6cfb5a139698017d1597c4d41"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde-wasm-bindgen 0.5.0",
+ "serde_json",
+ "thiserror 1.0.63",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "worker-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d625c24570ba9207a2617476013335f28a95cbe513e59bb814ffba092a18058"
+dependencies = [
+ "async-trait",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-macro-support",
+ "worker-sys",
+]
+
+[[package]]
+name = "worker-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34563340d41016b4381257c5a16b0d2bc590dbe00500ecfbebcaa16f5f85ce90"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ no_unknown_fields = [
     "starknet-core/no_unknown_fields",
     "starknet-providers/no_unknown_fields",
 ]
+# Cloudflare Workers provider support
+worker = ["starknet-providers/worker"]
 
 [workspace.lints]
 rust.missing_debug_implementations = "warn"

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = "1.0.40"
 serde = "1.0.160"
 serde_json = "1.0.96"
 serde_with = "3.9.0"
+worker = { version = "0.5.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.9", features = ["js"] }

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -27,6 +27,8 @@ use crate::{
 
 mod transports;
 pub use transports::{HttpTransport, HttpTransportError, JsonRpcTransport};
+#[cfg(feature = "worker")]
+pub use transports::{WorkersTransport, WorkersTransportError};
 
 /// A generic JSON-RPC client with any transport.
 ///

--- a/starknet-providers/src/jsonrpc/transports/mod.rs
+++ b/starknet-providers/src/jsonrpc/transports/mod.rs
@@ -11,6 +11,11 @@ use crate::{
 mod http;
 pub use http::{HttpTransport, HttpTransportError};
 
+#[cfg(feature = "worker")]
+mod worker;
+#[cfg(feature = "worker")]
+pub use worker::{WorkersTransport, WorkersTransportError};
+
 /// Any type that is capable of producing JSON-RPC responses when given JSON-RPC requests. An
 /// implementation does not necessarily use the network, but typically does.
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]

--- a/starknet-providers/src/jsonrpc/transports/worker.rs
+++ b/starknet-providers/src/jsonrpc/transports/worker.rs
@@ -1,0 +1,192 @@
+use async_trait::async_trait;
+use serde::{de::DeserializeOwned, Serialize};
+use url::Url;
+
+use crate::{
+    jsonrpc::{transports::JsonRpcTransport, JsonRpcMethod, JsonRpcResponse},
+    ProviderRequestData,
+};
+
+/// A [`JsonRpcTransport`] implementation for the Cloudflare Workers environment.
+#[derive(Debug, Clone)]
+pub struct WorkersTransport {
+    #[cfg_attr(not(target_arch = "wasm32"), allow(unused))]
+    url: Url,
+}
+
+/// Errors using [`WorkersTransport`].
+#[cfg_attr(not(target_arch = "wasm32"), allow(unused))]
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub enum WorkersTransportError {
+    /// JSON serialization/deserialization errors.
+    Json(serde_json::Error),
+    /// Workers SDK error.
+    Workers(worker::Error),
+    /// Unexpected response ID.
+    #[error("unexpected response ID: {0}")]
+    UnexpectedResponseId(u64),
+}
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Debug, Serialize)]
+struct JsonRpcRequest<T> {
+    id: u64,
+    jsonrpc: &'static str,
+    method: JsonRpcMethod,
+    params: T,
+}
+
+impl WorkersTransport {
+    /// Constructs [`WorkersTransport`] from a JSON-RPC server URL.
+    pub fn new(url: impl Into<Url>) -> Self {
+        Self { url: url.into() }
+    }
+}
+
+// Stub implementation to make allow compiling outside Workers environment. This makes development
+// easier.
+#[cfg(not(target_arch = "wasm32"))]
+#[async_trait]
+impl JsonRpcTransport for WorkersTransport {
+    type Error = WorkersTransportError;
+
+    async fn send_request<P, R>(
+        &self,
+        _method: JsonRpcMethod,
+        _params: P,
+    ) -> Result<JsonRpcResponse<R>, Self::Error>
+    where
+        P: Serialize + Send,
+        R: DeserializeOwned,
+    {
+        panic!("Cloudflare Workers transport is only supported in WASM")
+    }
+
+    async fn send_requests<R>(
+        &self,
+        _requests: R,
+    ) -> Result<Vec<JsonRpcResponse<serde_json::Value>>, Self::Error>
+    where
+        R: AsRef<[ProviderRequestData]> + Send + Sync,
+    {
+        panic!("Cloudflare Workers transport is only supported in WASM")
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[async_trait(?Send)]
+impl JsonRpcTransport for WorkersTransport {
+    type Error = WorkersTransportError;
+
+    async fn send_request<P, R>(
+        &self,
+        method: JsonRpcMethod,
+        params: P,
+    ) -> Result<JsonRpcResponse<R>, Self::Error>
+    where
+        P: Serialize + Send,
+        R: DeserializeOwned,
+    {
+        use worker::*;
+
+        let request_body = JsonRpcRequest {
+            id: 1,
+            jsonrpc: "2.0",
+            method,
+            params,
+        };
+
+        let request_body = serde_json::to_string(&request_body)?;
+
+        let mut headers = Headers::new();
+        headers.append("Content-Type", "application/json")?;
+
+        let mut init = RequestInit::new();
+        init.with_method(Method::Post)
+            .with_headers(headers)
+            .with_body(Some(request_body.into()));
+
+        let req = Request::new_with_init(self.url.as_ref(), &init)?;
+        let mut response = Fetch::Request(req).send().await?;
+        let response_body = response.text().await?;
+
+        let parsed_response = serde_json::from_str(&response_body)?;
+
+        Ok(parsed_response)
+    }
+
+    async fn send_requests<R>(
+        &self,
+        requests: R,
+    ) -> Result<Vec<JsonRpcResponse<serde_json::Value>>, Self::Error>
+    where
+        R: AsRef<[ProviderRequestData]> + Send + Sync,
+    {
+        use worker::*;
+
+        let request_bodies = requests
+            .as_ref()
+            .iter()
+            .enumerate()
+            .map(|(ind, request)| JsonRpcRequest {
+                id: ind as u64,
+                jsonrpc: "2.0",
+                method: request.jsonrpc_method(),
+                params: request,
+            })
+            .collect::<Vec<_>>();
+
+        let request_count = request_bodies.len();
+
+        let request_body = serde_json::to_string(&request_bodies)?;
+
+        let mut headers = Headers::new();
+        headers.append("Content-Type", "application/json")?;
+
+        let mut init = RequestInit::new();
+        init.with_method(Method::Post)
+            .with_headers(headers)
+            .with_body(Some(request_body.into()));
+
+        let req = Request::new_with_init(self.url.as_ref(), &init)?;
+        let mut response = Fetch::Request(req).send().await?;
+        let response_body = response.text().await?;
+
+        let parsed_response: Vec<JsonRpcResponse<serde_json::Value>> =
+            serde_json::from_str(&response_body).map_err(Self::Error::Json)?;
+
+        let mut responses: Vec<Option<JsonRpcResponse<serde_json::Value>>> = vec![];
+        responses.resize(request_bodies.len(), None);
+
+        // Re-order the responses as servers do not maintain order.
+        for response_item in parsed_response {
+            let id = match &response_item {
+                JsonRpcResponse::Success { id, .. } | JsonRpcResponse::Error { id, .. } => {
+                    *id as usize
+                }
+            };
+
+            if id >= request_count {
+                return Err(Self::Error::UnexpectedResponseId(id as u64));
+            }
+
+            responses[id] = Some(response_item);
+        }
+
+        let responses = responses.into_iter().flatten().collect::<Vec<_>>();
+        Ok(responses)
+    }
+}
+
+impl From<serde_json::Error> for WorkersTransportError {
+    fn from(value: serde_json::Error) -> Self {
+        Self::Json(value)
+    }
+}
+
+impl From<worker::Error> for WorkersTransportError {
+    fn from(value: worker::Error) -> Self {
+        Self::Workers(value)
+    }
+}


### PR DESCRIPTION
Adds a new feature-gated `WorkersTransport` type for using the library to connect to Starknet JSON-RPC nodes in a Cloudflare Workers environment.

The feature can be enabled either via the `worker` feature on `starknet` crate or the `worker` feature on the `starknet-providers` crate.