### PR TITLE
test: ledger integration test with button automation

### DIFF
--- a/starknet-signers/tests/ledger.rs
+++ b/starknet-signers/tests/ledger.rs
@@ -2,6 +2,7 @@
 
 use std::{
     process::{Child, Command},
+    sync::Arc,
     time::Duration,
 };
 
@@ -9,14 +10,17 @@ use async_trait::async_trait;
 use coins_ledger::{transports::LedgerAsync, APDUAnswer, APDUCommand, LedgerError};
 use reqwest::{Client, ClientBuilder};
 use semver::Version;
-use serde::{Deserialize, Serialize};
+use serde::{ser::SerializeSeq, Deserialize, Serialize};
 use starknet_core::types::Felt;
 use starknet_signers::ledger::LedgerStarknetApp;
 
 const TEST_PATH: &str = "m/2645'/1195502025'/1470455285'/0'/0'/0";
 
 #[derive(Debug)]
-struct SpeculosTransport {
+struct SpeculosTransport(Arc<SpeculosClient>);
+
+#[derive(Debug)]
+struct SpeculosClient {
     process: Child,
     port: u16,
     client: Client,
@@ -28,7 +32,30 @@ struct ApduData {
     data: Vec<u8>,
 }
 
-impl SpeculosTransport {
+#[derive(Debug, Serialize)]
+struct AutomationRequest {
+    version: u32,
+    rules: &'static [AutomationRule],
+}
+
+#[derive(Debug, Serialize)]
+struct AutomationRule {
+    text: &'static str,
+    actions: &'static [AutomationAction],
+}
+
+#[derive(Debug)]
+enum AutomationAction {
+    Button { button: Button, pressed: bool },
+}
+
+#[derive(Debug)]
+enum Button {
+    Left,
+    Right,
+}
+
+impl SpeculosClient {
     async fn new(port: u16) -> Self {
         let mut cmd = Command::new("speculos");
         let process = cmd
@@ -59,7 +86,7 @@ impl SpeculosTransport {
         }
     }
 
-    async fn send(&self, packet: &APDUCommand) -> Result<APDUAnswer, LedgerError> {
+    async fn apdu(&self, packet: &APDUCommand) -> Result<APDUAnswer, LedgerError> {
         let response = self
             .client
             .post(format!("http://localhost:{}/apdu", self.port))
@@ -73,31 +100,68 @@ impl SpeculosTransport {
         let body = response.json::<ApduData>().await.unwrap();
         APDUAnswer::from_answer(body.data)
     }
+
+    async fn automation(&self, rules: &'static [AutomationRule]) {
+        let response = self
+            .client
+            .post(format!("http://localhost:{}/automation", self.port))
+            .json(&AutomationRequest { version: 1, rules })
+            .send()
+            .await
+            .unwrap();
+
+        if !response.status().is_success() {
+            panic!("Response status code: {}", response.status());
+        }
+    }
 }
 
 #[async_trait]
 impl LedgerAsync for SpeculosTransport {
     async fn init() -> Result<Self, LedgerError> {
-        Ok(Self::new(5001).await)
+        Ok(Self(Arc::new(SpeculosClient::new(5001).await)))
     }
 
     async fn exchange(&self, packet: &APDUCommand) -> Result<APDUAnswer, LedgerError> {
-        self.send(packet).await
+        self.0.apdu(packet).await
     }
 
     fn close(self) {}
 }
 
-impl Drop for SpeculosTransport {
+impl Drop for SpeculosClient {
     fn drop(&mut self) {
         let _ = self.process.kill();
+    }
+}
+
+impl Serialize for AutomationAction {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Button { button, pressed } => {
+                let mut seq = serializer.serialize_seq(Some(3))?;
+
+                seq.serialize_element("button")?;
+                seq.serialize_element(&match button {
+                    Button::Left => 1,
+                    Button::Right => 2,
+                })?;
+                seq.serialize_element(pressed)?;
+
+                seq.end()
+            }
+        }
     }
 }
 
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_get_app_version() {
-    let app = LedgerStarknetApp::from_transport(SpeculosTransport::new(5001).await);
+    let client = Arc::new(SpeculosClient::new(5001).await);
+    let app = LedgerStarknetApp::from_transport(SpeculosTransport(client.clone()));
     let version = app.get_version().await.unwrap();
 
     assert_eq!(version, Version::new(2, 3, 1));
@@ -106,9 +170,82 @@ async fn test_get_app_version() {
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_get_public_key_headless() {
-    let app = LedgerStarknetApp::from_transport(SpeculosTransport::new(5002).await);
+    let client = Arc::new(SpeculosClient::new(5002).await);
+    let app = LedgerStarknetApp::from_transport(SpeculosTransport(client.clone()));
     let public_key = app
         .get_public_key(TEST_PATH.parse().unwrap(), false)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        public_key.scalar(),
+        Felt::from_hex_unchecked(
+            "0x07427aa749c4fc98a5bf76f037eb3c61e7b4793b576a72d45a4b52c5ded997f2"
+        )
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Speculos installation"]
+async fn test_get_public_key_with_confirmation() {
+    let client = Arc::new(SpeculosClient::new(5003).await);
+
+    // Automatically approve
+    client
+        .automation(&[AutomationRule {
+            text: "Confirm Public Key",
+            actions: &[
+                // Press right
+                AutomationAction::Button {
+                    button: Button::Right,
+                    pressed: true,
+                },
+                AutomationAction::Button {
+                    button: Button::Right,
+                    pressed: false,
+                },
+                // Press right
+                AutomationAction::Button {
+                    button: Button::Right,
+                    pressed: true,
+                },
+                AutomationAction::Button {
+                    button: Button::Right,
+                    pressed: false,
+                },
+                // Press right
+                AutomationAction::Button {
+                    button: Button::Right,
+                    pressed: true,
+                },
+                AutomationAction::Button {
+                    button: Button::Right,
+                    pressed: false,
+                },
+                // Press both
+                AutomationAction::Button {
+                    button: Button::Left,
+                    pressed: true,
+                },
+                AutomationAction::Button {
+                    button: Button::Right,
+                    pressed: true,
+                },
+                AutomationAction::Button {
+                    button: Button::Left,
+                    pressed: false,
+                },
+                AutomationAction::Button {
+                    button: Button::Right,
+                    pressed: false,
+                },
+            ],
+        }])
+        .await;
+
+    let app = LedgerStarknetApp::from_transport(SpeculosTransport(client.clone()));
+    let public_key = app
+        .get_public_key(TEST_PATH.parse().unwrap(), true)
         .await
         .unwrap();
 


### PR DESCRIPTION
Makes use of Speculos's button automation feature to run Ledger integration tests that involve using the device interactively. This unlocks more complex test cases like approving and sending transactions.