### PR TITLE
chore: use `speculos-client` for ledger tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -164,6 +164,7 @@ jobs:
       - name: Install stable Rust toolchain
         run: |
           rustup toolchain install stable
+          rustup default stable
 
       - name: Run tests
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -263,7 +263,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1059,22 +1059,26 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1195,6 +1199,16 @@ name = "ipnet"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "itertools"
@@ -1506,7 +1520,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1817,14 +1831,13 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1840,7 +1853,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1849,13 +1861,13 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
- "windows-registry",
+ "webpki-roots 1.0.0",
 ]
 
 [[package]]
@@ -1954,15 +1966,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -2093,9 +2096,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -2124,9 +2127,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2278,6 +2281,17 @@ checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "speculos-client"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8716f5006802a0c8555925b0af0777939f84f7e640d5258520ee998ee28fc999"
+dependencies = [
+ "hex",
+ "reqwest",
+ "serde",
 ]
 
 [[package]]
@@ -2463,11 +2477,9 @@ dependencies = [
  "crypto-bigint",
  "eth-keystore",
  "getrandom 0.2.15",
- "hex",
  "rand 0.8.5",
- "reqwest",
  "semver",
- "serde",
+ "speculos-client",
  "starknet-core",
  "starknet-crypto",
  "starknet-signers",
@@ -2786,6 +2798,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.6.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -3127,6 +3157,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3163,42 +3202,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
-
-[[package]]
-name = "windows-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
-dependencies = [
- "windows-result",
- "windows-strings",
- "windows-targets 0.53.0",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3207,7 +3211,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3216,7 +3220,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3225,30 +3229,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3258,22 +3246,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3282,22 +3258,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3306,22 +3270,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3330,22 +3282,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -31,10 +31,8 @@ eth-keystore = { version = "0.5.0", default-features = false }
 getrandom = { version = "0.2.9", features = ["js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+speculos-client = "0.1.1"
 starknet-signers = { path = ".", features = ["ledger"] }
-hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde"] }
-serde = { version = "1.0.160", features = ["derive"] }
-reqwest = { version = "0.12.15", default-features = false, features = ["json"] }
 tokio = { version = "1.27.0", features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/starknet-signers/tests/ledger.rs
+++ b/starknet-signers/tests/ledger.rs
@@ -1,167 +1,46 @@
 #![cfg(not(target_arch = "wasm32"))]
 
-use std::{
-    process::{Child, Command},
-    sync::Arc,
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use coins_ledger::{transports::LedgerAsync, APDUAnswer, APDUCommand, LedgerError};
-use reqwest::{Client, ClientBuilder};
 use semver::Version;
-use serde::{ser::SerializeSeq, Deserialize, Serialize};
+use speculos_client::{AutomationAction, AutomationRule, Button, DeviceModel, SpeculosClient};
 use starknet_core::types::Felt;
 use starknet_signers::ledger::LedgerStarknetApp;
 
 const TEST_PATH: &str = "m/2645'/1195502025'/1470455285'/0'/0'/0";
+const APP_PATH: &str = "./test-data/ledger-app/nanox_2.4.2_2.3.1_sdk_v22.10.0";
 
 #[derive(Debug)]
 struct SpeculosTransport(Arc<SpeculosClient>);
 
-#[derive(Debug)]
-struct SpeculosClient {
-    process: Child,
-    port: u16,
-    client: Client,
-}
-
-#[derive(Serialize, Deserialize)]
-struct ApduData {
-    #[serde(with = "hex")]
-    data: Vec<u8>,
-}
-
-#[derive(Debug, Serialize)]
-struct AutomationRequest {
-    version: u32,
-    rules: &'static [AutomationRule],
-}
-
-#[derive(Debug, Serialize)]
-struct AutomationRule {
-    text: &'static str,
-    actions: &'static [AutomationAction],
-}
-
-#[derive(Debug)]
-enum AutomationAction {
-    Button { button: Button, pressed: bool },
-}
-
-#[derive(Debug)]
-enum Button {
-    Left,
-    Right,
-}
-
-impl SpeculosClient {
-    async fn new(port: u16) -> Self {
-        let mut cmd = Command::new("speculos");
-        let process = cmd
-            .args([
-                "--api-port",
-                &port.to_string(),
-                "--apdu-port",
-                "0",
-                "-m",
-                "nanox",
-                "--display",
-                "headless",
-                "./test-data/ledger-app/nanox_2.4.2_2.3.1_sdk_v22.10.0",
-            ])
-            .spawn()
-            .expect("Unable to spawn speculos process");
-
-        // Wait for process to be ready (flaky)
-        tokio::time::sleep(Duration::from_secs(1)).await;
-
-        Self {
-            process,
-            port,
-            client: ClientBuilder::new()
-                .timeout(Duration::from_secs(10))
-                .build()
-                .unwrap(),
-        }
-    }
-
-    async fn apdu(&self, packet: &APDUCommand) -> Result<APDUAnswer, LedgerError> {
-        let response = self
-            .client
-            .post(format!("http://localhost:{}/apdu", self.port))
-            .json(&ApduData {
-                data: packet.serialize(),
-            })
-            .send()
-            .await
-            .unwrap();
-
-        let body = response.json::<ApduData>().await.unwrap();
-        APDUAnswer::from_answer(body.data)
-    }
-
-    async fn automation(&self, rules: &'static [AutomationRule]) {
-        let response = self
-            .client
-            .post(format!("http://localhost:{}/automation", self.port))
-            .json(&AutomationRequest { version: 1, rules })
-            .send()
-            .await
-            .unwrap();
-
-        if !response.status().is_success() {
-            panic!("Response status code: {}", response.status());
-        }
-    }
-}
-
 #[async_trait]
 impl LedgerAsync for SpeculosTransport {
     async fn init() -> Result<Self, LedgerError> {
-        Ok(Self(Arc::new(SpeculosClient::new(5001).await)))
+        Ok(Self(Arc::new(
+            SpeculosClient::new(DeviceModel::Nanox, 5001, APP_PATH).unwrap(),
+        )))
     }
 
     async fn exchange(&self, packet: &APDUCommand) -> Result<APDUAnswer, LedgerError> {
-        self.0.apdu(packet).await
+        let raw_asnwer = self.0.apdu(&packet.serialize()).await.unwrap();
+        Ok(APDUAnswer::from_answer(raw_asnwer).unwrap())
     }
 
     fn close(self) {}
 }
 
-impl Drop for SpeculosClient {
-    fn drop(&mut self) {
-        let _ = self.process.kill();
-    }
-}
-
-impl Serialize for AutomationAction {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        match self {
-            Self::Button { button, pressed } => {
-                let mut seq = serializer.serialize_seq(Some(3))?;
-
-                seq.serialize_element("button")?;
-                seq.serialize_element(&match button {
-                    Button::Left => 1,
-                    Button::Right => 2,
-                })?;
-                seq.serialize_element(pressed)?;
-
-                seq.end()
-            }
-        }
-    }
+fn setup_app(port: u16) -> (Arc<SpeculosClient>, LedgerStarknetApp<SpeculosTransport>) {
+    let client = Arc::new(SpeculosClient::new(DeviceModel::Nanox, port, APP_PATH).unwrap());
+    let app = LedgerStarknetApp::from_transport(SpeculosTransport(client.clone()));
+    (client, app)
 }
 
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_get_app_version() {
-    let client = Arc::new(SpeculosClient::new(5001).await);
-    let app = LedgerStarknetApp::from_transport(SpeculosTransport(client.clone()));
+    let (_, app) = setup_app(5001);
     let version = app.get_version().await.unwrap();
 
     assert_eq!(version, Version::new(2, 3, 1));
@@ -170,8 +49,7 @@ async fn test_get_app_version() {
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_get_public_key_headless() {
-    let client = Arc::new(SpeculosClient::new(5002).await);
-    let app = LedgerStarknetApp::from_transport(SpeculosTransport(client.clone()));
+    let (_, app) = setup_app(5002);
     let public_key = app
         .get_public_key(TEST_PATH.parse().unwrap(), false)
         .await
@@ -188,12 +66,18 @@ async fn test_get_public_key_headless() {
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_get_public_key_with_confirmation() {
-    let client = Arc::new(SpeculosClient::new(5003).await);
+    let (client, app) = setup_app(5003);
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Automatically approve
     client
         .automation(&[AutomationRule {
-            text: "Confirm Public Key",
+            text: Some("Confirm Public Key".into()),
+            regexp: None,
+            x: None,
+            y: None,
+            conditions: &[],
             actions: &[
                 // Press right
                 AutomationAction::Button {
@@ -241,9 +125,9 @@ async fn test_get_public_key_with_confirmation() {
                 },
             ],
         }])
-        .await;
+        .await
+        .unwrap();
 
-    let app = LedgerStarknetApp::from_transport(SpeculosTransport(client.clone()));
     let public_key = app
         .get_public_key(TEST_PATH.parse().unwrap(), true)
         .await


### PR DESCRIPTION
Cleaned up and refactored the Speculos client implementation into a new crate [`speculos-client`](https://crates.io/crates/speculos-client) as it needs to be reused in `starknet-accounts` tests as well.