### PR TITLE
feat: make getting broadcasted tx request methods public

### DIFF
--- a/starknet-accounts/src/account/declaration.rs
+++ b/starknet-accounts/src/account/declaration.rs
@@ -549,7 +549,7 @@ where
             .map_err(AccountError::Provider)
     }
 
-    async fn get_declare_request(
+    pub async fn get_declare_request(
         &self,
         query_only: bool,
         skip_signature: bool,

--- a/starknet-accounts/src/account/declaration.rs
+++ b/starknet-accounts/src/account/declaration.rs
@@ -549,6 +549,7 @@ where
             .map_err(AccountError::Provider)
     }
 
+    /// Get the broadcasted declare transaction request.
     pub async fn get_declare_request(
         &self,
         query_only: bool,

--- a/starknet-accounts/src/account/execution.rs
+++ b/starknet-accounts/src/account/execution.rs
@@ -568,7 +568,7 @@ where
     // The `simulate` function is temporarily removed until it's supported in [Provider]
     // TODO: add `simulate` back once transaction simulation in supported
 
-    async fn get_invoke_request(
+    pub async fn get_invoke_request(
         &self,
         query_only: bool,
         skip_signature: bool,

--- a/starknet-accounts/src/account/execution.rs
+++ b/starknet-accounts/src/account/execution.rs
@@ -568,6 +568,7 @@ where
     // The `simulate` function is temporarily removed until it's supported in [Provider]
     // TODO: add `simulate` back once transaction simulation in supported
 
+    /// Get the broadcasted invoke transaction request.
     pub async fn get_invoke_request(
         &self,
         query_only: bool,

--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -726,7 +726,7 @@ where
             .map_err(AccountFactoryError::Provider)
     }
 
-    async fn get_deploy_request(
+    pub async fn get_deploy_request(
         &self,
         query_only: bool,
         skip_signature: bool,

--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -726,6 +726,7 @@ where
             .map_err(AccountFactoryError::Provider)
     }
 
+    /// Get the broadcasted deploy account transaction request.
     pub async fn get_deploy_request(
         &self,
         query_only: bool,


### PR DESCRIPTION
Currently, there doesn't seem to be a way to get the raw broadcasted tx request.
