### PR TITLE
feat: tungstenite heartbeat handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,6 +2495,7 @@ name = "starknet-tokio-tungstenite"
 version = "0.1.0"
 dependencies = [
  "futures-util",
+ "log",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/starknet-tokio-tungstenite/Cargo.toml
+++ b/starknet-tokio-tungstenite/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 starknet-core = { version = "0.14.0", path = "../starknet-core", default-features = false }
 starknet-providers = { version = "0.14.1", path = "../starknet-providers" }
 futures-util = "0.3.31"
+log = "0.4.19"
 rand = { version = "0.8.5", features = ["std_rng"] }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.74"

--- a/starknet-tokio-tungstenite/src/lib.rs
+++ b/starknet-tokio-tungstenite/src/lib.rs
@@ -7,7 +7,7 @@ mod error;
 pub use error::*;
 
 mod stream;
-pub use stream::{StreamUpdateType, TungsteniteStream};
+pub use stream::{StreamUpdateType, TungsteniteStream, TungsteniteStreamBuilder};
 
 mod subscription;
 pub use subscription::*;

--- a/starknet-tokio-tungstenite/src/stream/mod.rs
+++ b/starknet-tokio-tungstenite/src/stream/mod.rs
@@ -7,7 +7,7 @@ use starknet_providers::{
     jsonrpc::{JsonRpcError, JsonRpcResponse, JsonRpcStreamUpdate},
     StreamUpdateData,
 };
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::{sync::mpsc::UnboundedSender, time::Instant};
 use tokio_tungstenite::connect_async;
 use tokio_util::sync::CancellationToken;
 use tungstenite::{client::IntoClientRequest, Error as TungsteniteError};
@@ -21,12 +21,20 @@ use write::{StreamWriteDriver, SubscribeWriteData};
 
 use crate::{
     error::{CloseError, ConnectError, SubscribeError},
+    stream::write::MetaAction,
     subscription::{
         EventSubscriptionOptions, EventsSubscription, NewHeadsSubscription,
         PendingTransactionDetailsSubscription, PendingTransactionHashesSubscription, Subscription,
         TransactionStatusSubscription,
     },
 };
+
+/// Helper type for configuring [`TungsteniteStream`].
+#[derive(Debug, Default, Clone)]
+pub struct TungsteniteStreamBuilder {
+    timeout: Duration,
+    keepalive_interval: Duration,
+}
 
 /// WebSocket stream client powered by `tokio-tungstenite`.
 ///
@@ -96,6 +104,54 @@ enum SubscriptionIdOrBool {
     Bool(bool),
 }
 
+impl TungsteniteStreamBuilder {
+    /// Creates a new [`TungsteniteStreamBuilder`] with default options.
+    pub const fn new() -> Self {
+        Self {
+            timeout: Duration::from_secs(10),
+            keepalive_interval: Duration::from_secs(10),
+        }
+    }
+
+    /// Gets the current timeout value.
+    ///
+    /// The timeout is applied to connection establishment and sending messages.
+    pub const fn get_timeout(&self) -> Duration {
+        self.timeout
+    }
+
+    /// Sets a new timeout value.
+    ///
+    /// The timeout is applied to connection establishment and sending messages.
+    pub const fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Gets the current keep-alive interval value.
+    ///
+    /// The stream sends out heartbeat messages at the rate defined by this interval.
+    pub const fn get_keepalive_interval(&self) -> Duration {
+        self.keepalive_interval
+    }
+
+    /// Sets a new keep-alive interval value.
+    ///
+    /// The stream sends out heartbeat messages at the rate defined by this interval.
+    pub const fn keepalive_interval(mut self, keepalive_interval: Duration) -> Self {
+        self.keepalive_interval = keepalive_interval;
+        self
+    }
+
+    /// Connects to the server to create a [`TungsteniteStream`].
+    pub async fn connect<R>(self, request: R) -> Result<TungsteniteStream, ConnectError>
+    where
+        R: IntoClientRequest,
+    {
+        TungsteniteStream::connect_opts(request, self.timeout, self.keepalive_interval).await
+    }
+}
+
 impl TungsteniteStream {
     /// Establishes a connection to a WebSocket server specified by the request.
     ///
@@ -112,45 +168,7 @@ impl TungsteniteStream {
     where
         R: IntoClientRequest,
     {
-        let connect = connect_async(request.into_client_request()?);
-        let (stream, _) = tokio::select! {
-            result = connect => result?,
-            _ = tokio::time::sleep(timeout) => {
-                return Err(ConnectError::Timeout);
-            }
-        };
-
-        // Using unbounded channel allows for sync queuing
-        let (write_queue_tx, write_queue_rx) =
-            tokio::sync::mpsc::unbounded_channel::<WriteAction>();
-        let (registration_tx, registration_rx) =
-            tokio::sync::mpsc::unbounded_channel::<ReadAction>();
-
-        let (write, read) = stream.split();
-        let disconnection_token = CancellationToken::new();
-
-        StreamWriteDriver {
-            timeout,
-            write_queue: write_queue_rx,
-            read_queue: registration_tx,
-            sink: write,
-            disconnection: disconnection_token.clone(),
-        }
-        .drive();
-
-        StreamReadDriver {
-            registry: Default::default(),
-            pending_subscriptions: Default::default(),
-            pending_unsubscriptions: Default::default(),
-            stream: read,
-            read_queue: registration_rx,
-            disconnection: disconnection_token,
-        }
-        .drive();
-
-        Ok(Self {
-            write_queue: write_queue_tx,
-        })
+        Self::connect_opts(request, timeout, Duration::from_secs(10)).await
     }
 
     /// Subscribes for new chain heads.
@@ -257,6 +275,60 @@ impl TungsteniteStream {
                 Ok(())
             }
         }
+    }
+
+    async fn connect_opts<R>(
+        request: R,
+        timeout: Duration,
+        keepalive_interval: Duration,
+    ) -> Result<Self, ConnectError>
+    where
+        R: IntoClientRequest,
+    {
+        let connect = connect_async(request.into_client_request()?);
+        let (stream, _) = tokio::select! {
+            result = connect => result?,
+            _ = tokio::time::sleep(timeout) => {
+                return Err(ConnectError::Timeout);
+            }
+        };
+
+        // Using unbounded channel allows for sync queuing
+        let (write_queue_tx, write_queue_rx) =
+            tokio::sync::mpsc::unbounded_channel::<WriteAction>();
+        let (meta_tx, meta_rx) = tokio::sync::mpsc::unbounded_channel::<MetaAction>();
+        let (registration_tx, registration_rx) =
+            tokio::sync::mpsc::unbounded_channel::<ReadAction>();
+
+        let (write, read) = stream.split();
+        let disconnection_token = CancellationToken::new();
+
+        StreamWriteDriver {
+            timeout,
+            write_queue: write_queue_rx,
+            meta_queue: meta_rx,
+            read_queue: registration_tx,
+            sink: write,
+            disconnection: disconnection_token.clone(),
+        }
+        .drive();
+
+        StreamReadDriver {
+            registry: Default::default(),
+            pending_subscriptions: Default::default(),
+            pending_unsubscriptions: Default::default(),
+            meta_queue: meta_tx,
+            ping_deadline: Instant::now() + keepalive_interval,
+            keepalive_interval,
+            stream: read,
+            read_queue: registration_rx,
+            disconnection: disconnection_token,
+        }
+        .drive();
+
+        Ok(Self {
+            write_queue: write_queue_tx,
+        })
     }
 
     async fn subscribe(&self, data: SubscribeWriteData) -> Result<Subscription, SubscribeError> {


### PR DESCRIPTION
Adds handling of incoming `Ping` messages and sending outgoing `Ping` messages at a configurable interval.

Related to: https://github.com/eqlabs/starknet-validator-attestation/issues/28.