### PR TITLE
release: bump starknet-tokio-tungstenite to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,7 +2492,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-tokio-tungstenite"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "futures-util",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ starknet-macros = { version = "0.2.3", path = "./starknet-macros" }
 [dev-dependencies]
 serde_json = "1.0.74"
 starknet-signers = { version = "0.12.0", path = "./starknet-signers", features = ["ledger"] }
-starknet-tokio-tungstenite = { version = "0.1.0", path = "./starknet-tokio-tungstenite" }
+starknet-tokio-tungstenite = { version = "0.1.1", path = "./starknet-tokio-tungstenite" }
 tokio = { version = "1.15.0", features = ["full"] }
 url = "2.2.2"
 

--- a/starknet-tokio-tungstenite/Cargo.toml
+++ b/starknet-tokio-tungstenite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-tokio-tungstenite"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
To make #742 available.