### PR TITLE
Address remaining occurrences of "pending"

### DIFF
--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -95,7 +95,7 @@ pub use contract::ContractArtifact;
 /// A pending block lacks certain information on the block header compared to a non-pending block.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum MaybePendingBlockWithTxHashes {
+pub enum MaybePreConfirmedBlockWithTxHashes {
     /// A confirmed, non-pending block.
     Block(BlockWithTxHashes),
     /// A pending block.
@@ -107,7 +107,7 @@ pub enum MaybePendingBlockWithTxHashes {
 /// A pending block lacks certain information on the block header compared to a non-pending block.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum MaybePendingBlockWithTxs {
+pub enum MaybePreConfirmedBlockWithTxs {
     /// A confirmed, non-pending block.
     Block(BlockWithTxs),
     /// A pending block.
@@ -119,7 +119,7 @@ pub enum MaybePendingBlockWithTxs {
 /// A pending block lacks certain information on the block header compared to a non-pending block.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum MaybePendingBlockWithReceipts {
+pub enum MaybePreConfirmedBlockWithReceipts {
     /// A confirmed, non-pending block.
     Block(BlockWithReceipts),
     /// A pending block.
@@ -132,7 +132,7 @@ pub enum MaybePendingBlockWithReceipts {
 /// block.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum MaybePendingStateUpdate {
+pub enum MaybePreConfirmedStateUpdate {
     /// The state update is for a confirmed, non-pending block.
     Update(StateUpdate),
     /// The state update is for a pending block.
@@ -569,7 +569,7 @@ mod errors {
 }
 pub use errors::ParseMsgToL2Error;
 
-impl MaybePendingBlockWithTxHashes {
+impl MaybePreConfirmedBlockWithTxHashes {
     /// Gets a reference to the list of transaction hashes.
     pub fn transactions(&self) -> &[Felt] {
         match self {
@@ -603,7 +603,7 @@ impl MaybePendingBlockWithTxHashes {
     }
 }
 
-impl MaybePendingBlockWithTxs {
+impl MaybePreConfirmedBlockWithTxs {
     /// Gets a reference to the list of transactions.
     pub fn transactions(&self) -> &[Transaction] {
         match self {
@@ -621,7 +621,7 @@ impl MaybePendingBlockWithTxs {
     }
 }
 
-impl MaybePendingBlockWithReceipts {
+impl MaybePreConfirmedBlockWithReceipts {
     /// Gets a reference to the list of transactions with receipts.
     pub fn transactions(&self) -> &[TransactionWithReceipt] {
         match self {

--- a/starknet-core/src/types/mod.rs
+++ b/starknet-core/src/types/mod.rs
@@ -90,52 +90,55 @@ pub mod requests;
 pub mod contract;
 pub use contract::ContractArtifact;
 
-/// A block with transaction hashes that may or may not be pending.
+/// A block with transaction hashes that may or may not be confirmed.
 ///
-/// A pending block lacks certain information on the block header compared to a non-pending block.
+/// A pre-confirmed block lacks certain information on the block header compared to a confirmed
+/// block.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum MaybePreConfirmedBlockWithTxHashes {
-    /// A confirmed, non-pending block.
+    /// A confirmed block.
     Block(BlockWithTxHashes),
-    /// A pending block.
+    /// A pre-confirmed block.
     PreConfirmedBlock(PreConfirmedBlockWithTxHashes),
 }
 
-/// A block with full transactions that may or may not be pending.
+/// A block with full transactions that may or may not be confirmed.
 ///
-/// A pending block lacks certain information on the block header compared to a non-pending block.
+/// A pre-confirmed block lacks certain information on the block header compared to a confirmed
+/// block.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum MaybePreConfirmedBlockWithTxs {
-    /// A confirmed, non-pending block.
+    /// A confirmed block.
     Block(BlockWithTxs),
-    /// A pending block.
+    /// A pre-confirmed block.
     PreConfirmedBlock(PreConfirmedBlockWithTxs),
 }
 
-/// A block with full transactions and receipts that may or may not be pending.
+/// A block with full transactions and receipts that may or may not be confirmed.
 ///
-/// A pending block lacks certain information on the block header compared to a non-pending block.
+/// A pre-confirmed block lacks certain information on the block header compared to a confirmed
+/// block.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum MaybePreConfirmedBlockWithReceipts {
-    /// A confirmed, non-pending block.
+    /// A confirmed block.
     Block(BlockWithReceipts),
-    /// A pending block.
+    /// A pre-confirmed block.
     PreConfirmedBlock(PreConfirmedBlockWithReceipts),
 }
 
-/// State update of a block that may or may not be pending.
+/// State update of a block that may or may not be confirmed.
 ///
-/// State update for a pending block lacks certain information compared to that of a non-pending
+/// State update for a pre-confirmed block lacks certain information compared to that of a confirmed
 /// block.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum MaybePreConfirmedStateUpdate {
-    /// The state update is for a confirmed, non-pending block.
+    /// The state update is for a confirmed block.
     Update(StateUpdate),
-    /// The state update is for a pending block.
+    /// The state update is for a pre-confirmed block.
     PreConfirmedUpdate(PreConfirmedStateUpdate),
 }
 

--- a/starknet-core/src/types/receipt_block.rs
+++ b/starknet-core/src/types/receipt_block.rs
@@ -12,9 +12,9 @@ use starknet_types_core::felt::Felt;
 /// [`None`](Option::None) toggether, allowing idiomatic access without unnecessary unwraps.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReceiptBlock {
-    /// The receipt is attached to a pending block.
-    Pending,
-    /// The receipt is attached to a confirmed, non-pending block.
+    /// The receipt is attached to a pre-confirmed block.
+    PreConfirmed,
+    /// The receipt is attached to a confirmed block.
     Block {
         /// Block hash.
         block_hash: Felt,
@@ -24,10 +24,10 @@ pub enum ReceiptBlock {
 }
 
 impl ReceiptBlock {
-    /// Returns `true` if and only if it's the `Pending` variant.
-    pub const fn is_pending(&self) -> bool {
+    /// Returns `true` if and only if it's the `PreConfirmed` variant.
+    pub const fn is_pre_confirmed(&self) -> bool {
         match self {
-            Self::Pending => true,
+            Self::PreConfirmed => true,
             Self::Block { .. } => false,
         }
     }
@@ -35,7 +35,7 @@ impl ReceiptBlock {
     /// Returns `true` if and only if it's the `Block` variant.
     pub const fn is_block(&self) -> bool {
         match self {
-            Self::Pending => false,
+            Self::PreConfirmed => false,
             Self::Block { .. } => true,
         }
     }
@@ -45,7 +45,7 @@ impl ReceiptBlock {
     /// A more idiomatic way of accessing the block hash is to match the `Block` enum variant.
     pub const fn block_hash(&self) -> Option<Felt> {
         match self {
-            Self::Pending => None,
+            Self::PreConfirmed => None,
             Self::Block { block_hash, .. } => Some(*block_hash),
         }
     }
@@ -55,7 +55,7 @@ impl ReceiptBlock {
     /// A more idiomatic way of accessing the block number is to match the `Block` enum variant.
     pub const fn block_number(&self) -> Option<u64> {
         match self {
-            Self::Pending => None,
+            Self::PreConfirmed => None,
             Self::Block { block_number, .. } => Some(*block_number),
         }
     }
@@ -78,7 +78,7 @@ impl Serialize for ReceiptBlock {
         S: serde::Serializer,
     {
         let raw = match self {
-            Self::Pending => Raw {
+            Self::PreConfirmed => Raw {
                 block_hash: None,
                 block_number: None,
             },
@@ -107,7 +107,7 @@ impl<'de> Deserialize<'de> for ReceiptBlock {
                 block_hash,
                 block_number,
             }),
-            (None, None) => Ok(Self::Pending),
+            (None, None) => Ok(Self::PreConfirmed),
             (Some(_), None) => Err(serde::de::Error::custom(
                 "field `block_hash` must not exist when `block_number` is missing",
             )),

--- a/starknet-core/src/types/receipt_block.rs
+++ b/starknet-core/src/types/receipt_block.rs
@@ -9,7 +9,7 @@ use starknet_types_core::felt::Felt;
 ///
 /// Instead of directly exposing the `block_hash` and `block_number` fields as [`Option<Felt>`],
 /// this struct captures the fact that these fields are always [`Some`](Option::Some) or
-/// [`None`](Option::None) toggether, allowing idiomatic access without unnecessary unwraps.
+/// [`None`](Option::None) together, allowing idiomatic access without unnecessary unwraps.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReceiptBlock {
     /// The receipt is attached to a pre-confirmed block.

--- a/starknet-providers/src/any.rs
+++ b/starknet-providers/src/any.rs
@@ -4,9 +4,10 @@ use starknet_core::types::{
     BroadcastedDeployAccountTransaction, BroadcastedInvokeTransaction, BroadcastedTransaction,
     ConfirmedBlockId, ContractClass, ContractStorageKeys, DeclareTransactionResult,
     DeployAccountTransactionResult, EventFilter, EventsPage, FeeEstimate, Felt, FunctionCall,
-    Hash256, InvokeTransactionResult, MaybePendingBlockWithReceipts, MaybePendingBlockWithTxHashes,
-    MaybePendingBlockWithTxs, MaybePendingStateUpdate, MessageFeeEstimate, MessageStatus,
-    MsgFromL1, SimulatedTransaction, SimulationFlag, SimulationFlagForEstimateFee, StorageProof,
+    Hash256, InvokeTransactionResult, MaybePreConfirmedBlockWithReceipts,
+    MaybePreConfirmedBlockWithTxHashes, MaybePreConfirmedBlockWithTxs,
+    MaybePreConfirmedStateUpdate, MessageFeeEstimate, MessageStatus, MsgFromL1,
+    SimulatedTransaction, SimulationFlag, SimulationFlagForEstimateFee, StorageProof,
     SyncStatusType, Transaction, TransactionReceiptWithBlockInfo, TransactionStatus,
     TransactionTrace, TransactionTraceWithHash,
 };
@@ -50,7 +51,7 @@ impl Provider for AnyProvider {
     async fn get_block_with_tx_hashes<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithTxHashes, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithTxHashes, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -71,7 +72,7 @@ impl Provider for AnyProvider {
     async fn get_block_with_txs<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithTxs, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithTxs, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -89,7 +90,7 @@ impl Provider for AnyProvider {
     async fn get_block_with_receipts<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithReceipts, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithReceipts, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -108,7 +109,7 @@ impl Provider for AnyProvider {
     async fn get_state_update<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingStateUpdate, ProviderError>
+    ) -> Result<MaybePreConfirmedStateUpdate, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {

--- a/starknet-providers/src/jsonrpc/mod.rs
+++ b/starknet-providers/src/jsonrpc/mod.rs
@@ -11,13 +11,13 @@ use starknet_core::{
         ConfirmedBlockId, ContractClass, ContractErrorData, ContractStorageKeys,
         DeclareTransactionResult, DeployAccountTransactionResult, EventFilter, EventFilterWithPage,
         EventsPage, FeeEstimate, Felt as FeltPrimitive, FunctionCall, Hash256,
-        InvokeTransactionResult, MaybePendingBlockWithReceipts, MaybePendingBlockWithTxHashes,
-        MaybePendingBlockWithTxs, MaybePendingStateUpdate, MessageFeeEstimate, MessageStatus,
-        MsgFromL1, NoTraceAvailableErrorData, ResultPageRequest, SimulatedTransaction,
-        SimulationFlag, SimulationFlagForEstimateFee, StarknetError, StorageProof, SubscriptionId,
-        SyncStatusType, Transaction, TransactionExecutionErrorData,
-        TransactionReceiptWithBlockInfo, TransactionStatus, TransactionTrace,
-        TransactionTraceWithHash,
+        InvokeTransactionResult, MaybePreConfirmedBlockWithReceipts,
+        MaybePreConfirmedBlockWithTxHashes, MaybePreConfirmedBlockWithTxs,
+        MaybePreConfirmedStateUpdate, MessageFeeEstimate, MessageStatus, MsgFromL1,
+        NoTraceAvailableErrorData, ResultPageRequest, SimulatedTransaction, SimulationFlag,
+        SimulationFlagForEstimateFee, StarknetError, StorageProof, SubscriptionId, SyncStatusType,
+        Transaction, TransactionExecutionErrorData, TransactionReceiptWithBlockInfo,
+        TransactionStatus, TransactionTrace, TransactionTraceWithHash,
     },
 };
 
@@ -316,25 +316,25 @@ where
                         ),
                         ProviderRequestData::GetBlockWithTxHashes(_) => {
                             ProviderResponseData::GetBlockWithTxHashes(
-                                MaybePendingBlockWithTxHashes::deserialize(result)
+                                MaybePreConfirmedBlockWithTxHashes::deserialize(result)
                                     .map_err(JsonRpcClientError::<T::Error>::JsonError)?,
                             )
                         }
                         ProviderRequestData::GetBlockWithTxs(_) => {
                             ProviderResponseData::GetBlockWithTxs(
-                                MaybePendingBlockWithTxs::deserialize(result)
+                                MaybePreConfirmedBlockWithTxs::deserialize(result)
                                     .map_err(JsonRpcClientError::<T::Error>::JsonError)?,
                             )
                         }
                         ProviderRequestData::GetBlockWithReceipts(_) => {
                             ProviderResponseData::GetBlockWithReceipts(
-                                MaybePendingBlockWithReceipts::deserialize(result)
+                                MaybePreConfirmedBlockWithReceipts::deserialize(result)
                                     .map_err(JsonRpcClientError::<T::Error>::JsonError)?,
                             )
                         }
                         ProviderRequestData::GetStateUpdate(_) => {
                             ProviderResponseData::GetStateUpdate(
-                                MaybePendingStateUpdate::deserialize(result)
+                                MaybePreConfirmedStateUpdate::deserialize(result)
                                     .map_err(JsonRpcClientError::<T::Error>::JsonError)?,
                             )
                         }
@@ -541,7 +541,7 @@ where
     async fn get_block_with_tx_hashes<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithTxHashes, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithTxHashes, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -558,7 +558,7 @@ where
     async fn get_block_with_txs<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithTxs, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithTxs, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -575,7 +575,7 @@ where
     async fn get_block_with_receipts<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithReceipts, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithReceipts, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -592,7 +592,7 @@ where
     async fn get_state_update<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingStateUpdate, ProviderError>
+    ) -> Result<MaybePreConfirmedStateUpdate, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {

--- a/starknet-providers/src/provider.rs
+++ b/starknet-providers/src/provider.rs
@@ -6,9 +6,10 @@ use starknet_core::types::{
     BroadcastedDeployAccountTransaction, BroadcastedInvokeTransaction, BroadcastedTransaction,
     ConfirmedBlockId, ContractClass, ContractStorageKeys, DeclareTransactionResult,
     DeployAccountTransactionResult, EventFilter, EventsPage, FeeEstimate, Felt, FunctionCall,
-    Hash256, InvokeTransactionResult, MaybePendingBlockWithReceipts, MaybePendingBlockWithTxHashes,
-    MaybePendingBlockWithTxs, MaybePendingStateUpdate, MessageFeeEstimate, MessageStatus,
-    MsgFromL1, SimulatedTransaction, SimulationFlag, SimulationFlagForEstimateFee, StarknetError,
+    Hash256, InvokeTransactionResult, MaybePreConfirmedBlockWithReceipts,
+    MaybePreConfirmedBlockWithTxHashes, MaybePreConfirmedBlockWithTxs,
+    MaybePreConfirmedStateUpdate, MessageFeeEstimate, MessageStatus, MsgFromL1,
+    SimulatedTransaction, SimulationFlag, SimulationFlagForEstimateFee, StarknetError,
     StorageProof, SubscriptionId, SyncStatusType, Transaction, TransactionReceiptWithBlockInfo,
     TransactionStatus, TransactionTrace, TransactionTraceWithHash,
 };
@@ -35,7 +36,7 @@ pub trait Provider {
     async fn get_block_with_tx_hashes<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithTxHashes, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithTxHashes, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync;
 
@@ -43,7 +44,7 @@ pub trait Provider {
     async fn get_block_with_txs<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithTxs, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithTxs, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync;
 
@@ -51,7 +52,7 @@ pub trait Provider {
     async fn get_block_with_receipts<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithReceipts, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithReceipts, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync;
 
@@ -59,7 +60,7 @@ pub trait Provider {
     async fn get_state_update<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingStateUpdate, ProviderError>
+    ) -> Result<MaybePreConfirmedStateUpdate, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync;
 
@@ -470,13 +471,13 @@ pub enum ProviderResponseData {
     /// Response data for `starknet_specVersion`.
     SpecVersion(String),
     /// Response data for `starknet_getBlockWithTxHashes`.
-    GetBlockWithTxHashes(MaybePendingBlockWithTxHashes),
+    GetBlockWithTxHashes(MaybePreConfirmedBlockWithTxHashes),
     /// Response data for `starknet_getBlockWithTxs`.
-    GetBlockWithTxs(MaybePendingBlockWithTxs),
+    GetBlockWithTxs(MaybePreConfirmedBlockWithTxs),
     /// Response data for `starknet_getBlockWithReceipts`.
-    GetBlockWithReceipts(MaybePendingBlockWithReceipts),
+    GetBlockWithReceipts(MaybePreConfirmedBlockWithReceipts),
     /// Response data for `starknet_getStateUpdate`.
-    GetStateUpdate(MaybePendingStateUpdate),
+    GetStateUpdate(MaybePreConfirmedStateUpdate),
     /// Response data for `starknet_getStorageAt`.
     GetStorageAt(Felt),
     /// Response data for `starknet_getMessagesStatus`.

--- a/starknet-providers/src/sequencer/models/conversions.rs
+++ b/starknet-providers/src/sequencer/models/conversions.rs
@@ -29,7 +29,7 @@ impl From<core::BlockId> for BlockId {
     }
 }
 
-impl TryFrom<Block> for core::MaybePendingBlockWithTxHashes {
+impl TryFrom<Block> for core::MaybePreConfirmedBlockWithTxHashes {
     type Error = ConversionError;
 
     fn try_from(value: Block) -> Result<Self, Self::Error> {
@@ -71,7 +71,7 @@ impl TryFrom<Block> for core::MaybePendingBlockWithTxHashes {
     }
 }
 
-impl TryFrom<Block> for core::MaybePendingBlockWithTxs {
+impl TryFrom<Block> for core::MaybePreConfirmedBlockWithTxs {
     type Error = ConversionError;
 
     fn try_from(value: Block) -> Result<Self, Self::Error> {
@@ -113,7 +113,7 @@ impl TryFrom<Block> for core::MaybePendingBlockWithTxs {
     }
 }
 
-impl TryFrom<Block> for core::MaybePendingBlockWithReceipts {
+impl TryFrom<Block> for core::MaybePreConfirmedBlockWithReceipts {
     type Error = ConversionError;
 
     fn try_from(value: Block) -> Result<Self, Self::Error> {
@@ -451,7 +451,7 @@ impl From<core::DataAvailabilityMode> for DataAvailabilityMode {
     }
 }
 
-impl TryFrom<StateUpdate> for core::MaybePendingStateUpdate {
+impl TryFrom<StateUpdate> for core::MaybePreConfirmedStateUpdate {
     type Error = ConversionError;
 
     fn try_from(value: StateUpdate) -> Result<Self, Self::Error> {

--- a/starknet-providers/src/sequencer/models/transaction_receipt.rs
+++ b/starknet-providers/src/sequencer/models/transaction_receipt.rs
@@ -38,13 +38,13 @@ pub enum TransactionStatus {
     NotReceived,
     /// Transaction was received by the sequenced
     Received,
-    /// Transaction passed teh validation and entered the pending block
+    /// Transaction passed the validation and entered the pending block
     Pending,
     /// The transaction failed validation and was skipped (applies both to a
     /// pending and actual created block)
     Rejected,
     Reverted,
-    /// Transaction passed teh validation and entered a created block
+    /// Transaction passed the validation and entered a created block
     AcceptedOnL2,
     /// Transaction was accepted on-chain
     AcceptedOnL1,

--- a/starknet-providers/src/sequencer/provider.rs
+++ b/starknet-providers/src/sequencer/provider.rs
@@ -8,9 +8,10 @@ use starknet_core::types::{
     BroadcastedDeployAccountTransaction, BroadcastedInvokeTransaction, BroadcastedTransaction,
     ConfirmedBlockId, ContractClass, ContractStorageKeys, DeclareTransactionResult,
     DeployAccountTransactionResult, EventFilter, EventsPage, FeeEstimate, Felt, FunctionCall,
-    Hash256, InvokeTransactionResult, MaybePendingBlockWithReceipts, MaybePendingBlockWithTxHashes,
-    MaybePendingBlockWithTxs, MaybePendingStateUpdate, MessageFeeEstimate, MessageStatus,
-    MsgFromL1, SimulatedTransaction, SimulationFlag, SimulationFlagForEstimateFee, StarknetError,
+    Hash256, InvokeTransactionResult, MaybePreConfirmedBlockWithReceipts,
+    MaybePreConfirmedBlockWithTxHashes, MaybePreConfirmedBlockWithTxs,
+    MaybePreConfirmedStateUpdate, MessageFeeEstimate, MessageStatus, MsgFromL1,
+    SimulatedTransaction, SimulationFlag, SimulationFlagForEstimateFee, StarknetError,
     StorageProof, SyncStatusType, Transaction, TransactionReceiptWithBlockInfo, TransactionStatus,
     TransactionTrace, TransactionTraceWithHash,
 };
@@ -34,7 +35,7 @@ impl Provider for SequencerGatewayProvider {
     async fn get_block_with_tx_hashes<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithTxHashes, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithTxHashes, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -47,7 +48,7 @@ impl Provider for SequencerGatewayProvider {
     async fn get_block_with_txs<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithTxs, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithTxs, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -60,7 +61,7 @@ impl Provider for SequencerGatewayProvider {
     async fn get_block_with_receipts<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithReceipts, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithReceipts, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -73,7 +74,7 @@ impl Provider for SequencerGatewayProvider {
     async fn get_state_update<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingStateUpdate, ProviderError>
+    ) -> Result<MaybePreConfirmedStateUpdate, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -4,11 +4,11 @@ use starknet_core::{
         BlockId, BlockTag, BroadcastedInvokeTransaction, BroadcastedTransaction, ConfirmedBlockId,
         ContractClass, ContractStorageKeys, DataAvailabilityMode, DeclareTransaction,
         DeployAccountTransaction, EthAddress, EventFilter, ExecuteInvocation, ExecutionResult,
-        Felt, FunctionCall, Hash256, InvokeTransaction, MaybePendingBlockWithReceipts,
-        MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs, MaybePendingStateUpdate,
-        MsgFromL1, ResourceBounds, ResourceBoundsMapping, StarknetError, SyncStatusType,
-        Transaction, TransactionFinalityStatus, TransactionReceipt, TransactionStatus,
-        TransactionTrace,
+        Felt, FunctionCall, Hash256, InvokeTransaction, MaybePreConfirmedBlockWithReceipts,
+        MaybePreConfirmedBlockWithTxHashes, MaybePreConfirmedBlockWithTxs,
+        MaybePreConfirmedStateUpdate, MsgFromL1, ResourceBounds, ResourceBoundsMapping,
+        StarknetError, SyncStatusType, Transaction, TransactionFinalityStatus, TransactionReceipt,
+        TransactionStatus, TransactionTrace,
     },
     utils::{get_selector_from_name, get_storage_var_address},
 };
@@ -43,7 +43,7 @@ async fn jsonrpc_get_block_with_tx_hashes() {
         .unwrap();
 
     let block = match block {
-        MaybePendingBlockWithTxHashes::Block(block) => block,
+        MaybePreConfirmedBlockWithTxHashes::Block(block) => block,
         _ => panic!("unexpected block response type"),
     };
 
@@ -60,7 +60,7 @@ async fn jsonrpc_get_block_with_txs() {
         .unwrap();
 
     let block = match block {
-        MaybePendingBlockWithTxs::Block(block) => block,
+        MaybePreConfirmedBlockWithTxs::Block(block) => block,
         _ => panic!("unexpected block response type"),
     };
 
@@ -77,7 +77,7 @@ async fn jsonrpc_get_block_with_receipts() {
         .unwrap();
 
     let block = match block {
-        MaybePendingBlockWithReceipts::Block(block) => block,
+        MaybePreConfirmedBlockWithReceipts::Block(block) => block,
         _ => panic!("unexpected block response type"),
     };
 
@@ -94,7 +94,7 @@ async fn jsonrpc_get_state_update() {
         .unwrap();
 
     let state_update = match state_update {
-        MaybePendingStateUpdate::Update(value) => value,
+        MaybePreConfirmedStateUpdate::Update(value) => value,
         _ => panic!("unexpected data type"),
     };
 


### PR DESCRIPTION
- Change `MaybePending*` to `MaybePreConfirmed*`
- Leave sequencer models as-is.
- Address occurrences of "pending" in receipt_block.rs.
- Address occurrences of "pending" in code docs.
- Fix a few typos in code docs ("teh", "toggether").