### PR TITLE
Improve Error Message Wording in TypedDataError

### DIFF
--- a/starknet-core/src/types/typed_data/error.rs
+++ b/starknet-core/src/types/typed_data/error.rs
@@ -6,7 +6,7 @@ use super::{revision::Revision, value::ValueKind};
 /// Possible errors when processing [`TypedData`](super::TypedData) and its related types.
 #[derive(Debug)]
 pub enum TypedDataError {
-    /// Revision implied by `types` is differernt from revision specified by `domain`.
+    /// Revision implied by `types` is different from revision specified by `domain`.
     InconsistentRevision {
         /// The revision implied from `types` with the domain type definition.
         types: Revision,
@@ -36,14 +36,14 @@ pub enum TypedDataError {
     },
     /// The number of fields from struct definition is different from the one in value.
     StructFieldCountMismatch {
-        /// The number of fields specificed by the struct definition.
+        /// The number of fields specified by the struct definition.
         expected: usize,
         /// The actual number of fields found in value.
         actual: usize,
     },
     /// The number of elements from enum variant definition is different from the one in value.
     EnumElementCountMismatch {
-        /// The number of elements specificed by the enum variant definition.
+        /// The number of elements specified by the enum variant definition.
         expected: usize,
         /// The actual number of elements found in value.
         actual: usize,


### PR DESCRIPTION


---


**Description:**  
- Refined the wording of several error messages in `TypedDataError` for clarity and consistency.
- Replaced "differnt" with "different" and standardized the use of "specified" in struct and enum mismatch errors.

---