### PR TITLE
feat: support jsonrpc v0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 **Complete Starknet library in Rust[™](https://www.reddit.com/r/rust/comments/12e7tdb/rust_trademark_policy_feedback_form/)**
 
 ![starknet-version-v0.14.0](https://img.shields.io/badge/Starknet_Version-v0.14.0-2ea44f?logo=ethereum)
-[![jsonrpc-spec-v0.9.0](https://img.shields.io/badge/JSON--RPC-v0.9.0-2ea44f?logo=ethereum)](https://github.com/starkware-libs/starknet-specs/releases/tag/v0.9.0-rc.3)
+[![jsonrpc-spec-v0.9.0](https://img.shields.io/badge/JSON--RPC-v0.9.0-2ea44f?logo=ethereum)](https://github.com/starkware-libs/starknet-specs/releases/tag/v0.9.0)
 [![linting-badge](https://github.com/xJonathanLEI/starknet-rs/actions/workflows/lint.yaml/badge.svg?branch=master)](https://github.com/xJonathanLEI/starknet-rs/actions/workflows/lint.yaml)
 [![crates-badge](https://img.shields.io/crates/v/starknet.svg)](https://crates.io/crates/starknet)
 

--- a/starknet-core/src/types/codegen.rs
+++ b/starknet-core/src/types/codegen.rs
@@ -3,7 +3,7 @@
 //     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen
 
 // Code generated with version:
-//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen#a8e2da3746497b437d551b1982b2ed8a05f43d99
+//     https://github.com/xJonathanLEI/starknet-jsonrpc-codegen#29b359aeb373001f024553059cd242f1e91417d1
 
 // These types are ignored from code generation. Implement them manually:
 // - `RECEIPT_BLOCK`

--- a/starknet-providers/tests/jsonrpc.rs
+++ b/starknet-providers/tests/jsonrpc.rs
@@ -30,7 +30,7 @@ async fn jsonrpc_spec_version() {
 
     let version = rpc_client.spec_version().await.unwrap();
 
-    assert_eq!(version, "0.9.0-rc.3");
+    assert_eq!(version, "0.9.0");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Spec [v0.9.0 released](https://github.com/starkware-libs/starknet-specs/releases/tag/v0.9.0).

No real changes here. Just marking the supported version from `-rc.3` to the stable release.