### PR TITLE
Published ProviderImplError trait

### DIFF
--- a/starknet-providers/src/lib.rs
+++ b/starknet-providers/src/lib.rs
@@ -8,7 +8,8 @@
 
 mod provider;
 pub use provider::{
-    Provider, ProviderError, ProviderRequestData, ProviderResponseData, StreamUpdateData,
+    Provider, ProviderError, ProviderImplError, ProviderRequestData, ProviderResponseData,
+    StreamUpdateData,
 };
 
 // Sequencer-related functionalities are mostly deprecated so we skip the docs.


### PR DESCRIPTION
Published ProviderImplError trait so that external users could implement custom ProviderError (ProviderError::Other)

Fix #767