### PR TITLE
fix: add missing `tip` getters to raw execution types

### DIFF
--- a/starknet-accounts/src/account/declaration.rs
+++ b/starknet-accounts/src/account/declaration.rs
@@ -583,6 +583,11 @@ impl RawDeclarationV3 {
     pub const fn l1_data_gas_price(&self) -> u128 {
         self.l1_data_gas_price
     }
+
+    /// Gets the `tip` of the declaration request.
+    pub const fn tip(&self) -> u64 {
+        self.tip
+    }
 }
 
 impl<A> PreparedDeclarationV3<'_, A>

--- a/starknet-accounts/src/account/execution.rs
+++ b/starknet-accounts/src/account/execution.rs
@@ -592,6 +592,11 @@ impl RawExecutionV3 {
     pub const fn l1_data_gas_price(&self) -> u128 {
         self.l1_data_gas_price
     }
+
+    /// Gets the `tip` of the execution request.
+    pub const fn tip(&self) -> u64 {
+        self.tip
+    }
 }
 
 impl<A> PreparedExecutionV3<'_, A>

--- a/starknet-accounts/src/factory/mod.rs
+++ b/starknet-accounts/src/factory/mod.rs
@@ -679,6 +679,11 @@ impl RawAccountDeploymentV3 {
     pub const fn l1_data_gas_price(&self) -> u128 {
         self.l1_data_gas_price
     }
+
+    /// Gets the `tip` of the deployment request.
+    pub const fn tip(&self) -> u64 {
+        self.tip
+    }
 }
 
 impl<'f, F> PreparedAccountDeploymentV3<'f, F> {


### PR DESCRIPTION
The tip field has been added to `RawExecutionV3` and `RawDeclarationV3` but the `tip()` getter method was missing.