### PR TITLE
feat: built-in support for new UDC

### DIFF
--- a/examples/deploy_contract.rs
+++ b/examples/deploy_contract.rs
@@ -14,6 +14,7 @@ use starknet::{
     },
     signers::{LocalWallet, SigningKey},
 };
+use starknet_contract::UdcSelector;
 
 #[tokio::main]
 async fn main() {
@@ -43,7 +44,7 @@ async fn main() {
     // `Arc<Account>` implements `Account` too.
     let account = Arc::new(account);
 
-    let contract_factory = ContractFactory::new(class_hash, account);
+    let contract_factory = ContractFactory::new_with_udc(class_hash, account, UdcSelector::New);
     contract_factory
         .deploy_v3(vec![felt!("123456")], felt!("1122"), false)
         .send()

--- a/starknet-contract/src/lib.rs
+++ b/starknet-contract/src/lib.rs
@@ -9,4 +9,4 @@
 #![deny(missing_docs)]
 
 mod factory;
-pub use factory::{ContractFactory, DeploymentV3};
+pub use factory::{ContractFactory, DeploymentV3, UdcSelector};

--- a/starknet-contract/tests/contract_deployment.rs
+++ b/starknet-contract/tests/contract_deployment.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, SystemTime};
 
 use starknet_accounts::{ExecutionEncoding, SingleOwnerAccount};
-use starknet_contract::ContractFactory;
+use starknet_contract::{ContractFactory, UdcSelector};
 use starknet_core::{
     chain_id,
     types::{contract::legacy::LegacyContractClass, BlockId, BlockTag, ExecutionResult, Felt},
@@ -11,7 +11,50 @@ use starknet_signers::{LocalWallet, SigningKey};
 use url::Url;
 
 #[tokio::test]
-async fn can_deploy_contract_to_alpha_sepolia() {
+async fn can_deploy_contract_with_legacy_udc_unique() {
+    can_deploy_contract_inner(
+        Felt::from_hex("0x034dd51aa591d174b60d1cb45e46dfcae47946fae1c5e62933bbf48effedde4d")
+            .unwrap(),
+        UdcSelector::Legacy,
+        true,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn can_deploy_contract_with_legacy_udc_not_unique() {
+    can_deploy_contract_inner(
+        Felt::from_hex("0x0608560dcfc38cdd06092bc182784e72a25bd4c3d33a08f3d76ec0382ad2bfd2")
+            .unwrap(),
+        UdcSelector::Legacy,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn can_deploy_contract_with_new_udc_unique() {
+    can_deploy_contract_inner(
+        Felt::from_hex("0x047c86c40070523edefbfb96fd84b0198444c2753105eebb1b3f9e3a229b68fe")
+            .unwrap(),
+        UdcSelector::New,
+        true,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn can_deploy_contract_with_new_udc_not_unique() {
+    can_deploy_contract_inner(
+        Felt::from_hex("0x03503c8a593f6e09219be18915d428841abf0388348fdf6dd626bad6e3024186")
+            .unwrap(),
+        UdcSelector::New,
+        false,
+    )
+    .await;
+}
+
+async fn can_deploy_contract_inner(account_address: Felt, udc: UdcSelector, unique: bool) {
     let rpc_url = std::env::var("STARKNET_RPC")
         .unwrap_or_else(|_| "https://pathfinder.rpc.sepolia.starknet.rs/rpc/v0_9".into());
     let provider = JsonRpcClient::new(HttpTransport::new(Url::parse(&rpc_url).unwrap()));
@@ -22,8 +65,7 @@ async fn can_deploy_contract_to_alpha_sepolia() {
             Felt::from_hex("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
                 .unwrap(),
         )),
-        Felt::from_hex("0x034dd51aa591d174b60d1cb45e46dfcae47946fae1c5e62933bbf48effedde4d")
-            .unwrap(),
+        account_address,
         chain_id::SEPOLIA,
         ExecutionEncoding::New,
     );
@@ -34,11 +76,11 @@ async fn can_deploy_contract_to_alpha_sepolia() {
     .unwrap();
     let class_hash = artifact.class_hash().unwrap();
 
-    let factory = ContractFactory::new(class_hash, account);
+    let factory = ContractFactory::new_with_udc(class_hash, account, udc);
     let salt = SigningKey::from_random().secret_scalar();
 
     let deployment = factory
-        .deploy_v3(vec![Felt::ONE], salt, true)
+        .deploy_v3(vec![Felt::ONE], salt, unique)
         .l1_gas(0)
         .l1_gas_price(1000000000000000)
         .l2_gas(2000000)


### PR DESCRIPTION
Deprecates the old `new()` constructor in favour of the more specific `new_with_udc()`.