### PR TITLE
release: breaking releases for `starknet-curve` and `starknet-crypto`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "crypto-bigint",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-curve"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "starknet-types-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 all-features = true
 
 [dependencies]
-starknet-crypto = { version = "0.7.4", path = "./starknet-crypto" }
+starknet-crypto = { version = "0.8.0", path = "./starknet-crypto" }
 starknet-core = { version = "0.16.0-rc.3", path = "./starknet-core", default-features = false }
 starknet-core-derive = { version = "0.1.0", path = "./starknet-core-derive", features = ["import_from_starknet"] }
 starknet-providers = { version = "0.16.0-rc.3", path = "./starknet-providers" }

--- a/examples/starknet-wasm/Cargo.toml
+++ b/examples/starknet-wasm/Cargo.toml
@@ -19,6 +19,6 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-starknet-crypto = { version = "0.7.4", path = "../../starknet-crypto" }
+starknet-crypto = { version = "0.8.0", path = "../../starknet-crypto" }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 wasm-bindgen = "0.2.84"

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["test-data/**"]
 
 [dependencies]
 starknet-core = { version = "0.16.0-rc.3", path = "../starknet-core" }
-starknet-crypto = { version = "0.7.4", path = "../starknet-crypto" }
+starknet-crypto = { version = "0.8.0", path = "../starknet-crypto" }
 starknet-providers = { version = "0.16.0-rc.3", path = "../starknet-providers" }
 starknet-signers = { version = "0.14.0-rc.3", path = "../starknet-signers" }
 async-trait = "0.1.68"

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["test-data/**"]
 all-features = true
 
 [dependencies]
-starknet-crypto = { version = "0.7.4", path = "../starknet-crypto", default-features = false, features = ["alloc"] }
+starknet-crypto = { version = "0.8.0", path = "../starknet-crypto", default-features = false, features = ["alloc"] }
 starknet-core-derive = { version = "0.1.0", path = "../starknet-core-derive" }
 base64 = { version = "0.21.0", default-features = false, features = ["alloc"] }
 crypto-bigint = { version = "0.5.1", default-features = false }

--- a/starknet-crypto/Cargo.toml
+++ b/starknet-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-crypto"
-version = "0.7.4"
+version = "0.8.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3", "no_std"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-curve = { version = "0.5.1", path = "../starknet-curve" }
+starknet-curve = { version = "0.6.0", path = "../starknet-curve" }
 crypto-bigint = { version = "0.5.1", default-features = false, features = ["generic-array", "zeroize"] }
 hmac = { version = "0.12.1", default-features = false }
 num-bigint = { version = "0.4.3", default-features = false }

--- a/starknet-curve/Cargo.toml
+++ b/starknet-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-curve"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
 starknet-core = { version = "0.16.0-rc.3", path = "../starknet-core" }
-starknet-crypto = { version = "0.7.4", path = "../starknet-crypto" }
+starknet-crypto = { version = "0.8.0", path = "../starknet-crypto" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 thiserror = "1.0.40"


### PR DESCRIPTION
While most crates in the repo are still in RC stage, these 2 low-level crates should be released directly to expose #774 for the rest of the ecosystem to integrate.