### PR TITLE
release: bump starknet to 0.17.0-rc.4 (and deps)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "starknet"
-version = "0.17.0-rc.3"
+version = "0.17.0-rc.4"
 dependencies = [
  "serde_json",
  "starknet-accounts",
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "rand 0.8.5",
  "serde",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-macros"
-version = "0.2.5-rc.3"
+version = "0.2.5-rc.4"
 dependencies = [
  "starknet-core",
  "syn 2.0.87",
@@ -2457,7 +2457,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2479,7 +2479,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-tokio-tungstenite"
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 dependencies = [
  "futures-util",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet"
-version = "0.17.0-rc.3"
+version = "0.17.0-rc.4"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -35,18 +35,18 @@ all-features = true
 
 [dependencies]
 starknet-crypto = { version = "0.8.0", path = "./starknet-crypto" }
-starknet-core = { version = "0.16.0-rc.3", path = "./starknet-core", default-features = false }
+starknet-core = { version = "0.16.0-rc.4", path = "./starknet-core", default-features = false }
 starknet-core-derive = { version = "0.1.0", path = "./starknet-core-derive", features = ["import_from_starknet"] }
-starknet-providers = { version = "0.16.0-rc.3", path = "./starknet-providers" }
-starknet-contract = { version = "0.16.0-rc.3", path = "./starknet-contract" }
-starknet-signers = { version = "0.14.0-rc.3", path = "./starknet-signers" }
-starknet-accounts = { version = "0.16.0-rc.3", path = "./starknet-accounts" }
-starknet-macros = { version = "0.2.5-rc.3", path = "./starknet-macros" }
+starknet-providers = { version = "0.16.0-rc.4", path = "./starknet-providers" }
+starknet-contract = { version = "0.16.0-rc.4", path = "./starknet-contract" }
+starknet-signers = { version = "0.14.0-rc.4", path = "./starknet-signers" }
+starknet-accounts = { version = "0.16.0-rc.4", path = "./starknet-accounts" }
+starknet-macros = { version = "0.2.5-rc.4", path = "./starknet-macros" }
 
 [dev-dependencies]
 serde_json = "1.0.74"
-starknet-signers = { version = "0.14.0-rc.3", path = "./starknet-signers", features = ["ledger"] }
-starknet-tokio-tungstenite = { version = "0.3.0-rc.3", path = "./starknet-tokio-tungstenite" }
+starknet-signers = { version = "0.14.0-rc.4", path = "./starknet-signers", features = ["ledger"] }
+starknet-tokio-tungstenite = { version = "0.3.0-rc.4", path = "./starknet-tokio-tungstenite" }
 tokio = { version = "1.15.0", features = ["full"] }
 url = "2.2.2"
 

--- a/starknet-accounts/Cargo.toml
+++ b/starknet-accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-accounts"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,10 +14,10 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.16.0-rc.3", path = "../starknet-core" }
+starknet-core = { version = "0.16.0-rc.4", path = "../starknet-core" }
 starknet-crypto = { version = "0.8.0", path = "../starknet-crypto" }
-starknet-providers = { version = "0.16.0-rc.3", path = "../starknet-providers" }
-starknet-signers = { version = "0.14.0-rc.3", path = "../starknet-signers" }
+starknet-providers = { version = "0.16.0-rc.4", path = "../starknet-providers" }
+starknet-signers = { version = "0.14.0-rc.4", path = "../starknet-signers" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 thiserror = "1.0.40"
@@ -31,7 +31,7 @@ url = "2.3.1"
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 coins-ledger = { version = "0.12.0", default-features = false }
 speculos-client = "0.1.2"
-starknet-signers = { version = "0.14.0-rc.3", path = "../starknet-signers", features = ["ledger"] }
+starknet-signers = { version = "0.14.0-rc.4", path = "../starknet-signers", features = ["ledger"] }
 
 [lints]
 workspace = true

--- a/starknet-contract/Cargo.toml
+++ b/starknet-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-contract"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,9 +14,9 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.16.0-rc.3", path = "../starknet-core" }
-starknet-providers = { version = "0.16.0-rc.3", path = "../starknet-providers" }
-starknet-accounts = { version = "0.16.0-rc.3", path = "../starknet-accounts" }
+starknet-core = { version = "0.16.0-rc.4", path = "../starknet-core" }
+starknet-providers = { version = "0.16.0-rc.4", path = "../starknet-providers" }
+starknet-accounts = { version = "0.16.0-rc.4", path = "../starknet-accounts" }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
 serde_with = "3.9.0"
@@ -24,7 +24,7 @@ thiserror = "1.0.40"
 
 [dev-dependencies]
 rand = { version = "0.8.5", features=["std_rng"] }
-starknet-signers = { version = "0.14.0-rc.3", path = "../starknet-signers" }
+starknet-signers = { version = "0.14.0-rc.4", path = "../starknet-signers" }
 tokio = { version = "1.27.0", features = ["full"] }
 url = "2.3.1"
 

--- a/starknet-core/Cargo.toml
+++ b/starknet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-core"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/starknet-macros/Cargo.toml
+++ b/starknet-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-macros"
-version = "0.2.5-rc.3"
+version = "0.2.5-rc.4"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -16,7 +16,7 @@ keywords = ["ethereum", "starknet", "web3"]
 proc-macro = true
 
 [dependencies]
-starknet-core = { version = "0.16.0-rc.3", path = "../starknet-core" }
+starknet-core = { version = "0.16.0-rc.4", path = "../starknet-core" }
 syn = "2.0.15"
 
 [features]

--- a/starknet-providers/Cargo.toml
+++ b/starknet-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-providers"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -14,7 +14,7 @@ keywords = ["ethereum", "starknet", "web3"]
 exclude = ["test-data/**"]
 
 [dependencies]
-starknet-core = { version = "0.16.0-rc.3", path = "../starknet-core" }
+starknet-core = { version = "0.16.0-rc.4", path = "../starknet-core" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"
 ethereum-types = "0.14.1"

--- a/starknet-signers/Cargo.toml
+++ b/starknet-signers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-signers"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.4"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,7 +13,7 @@ Starknet signer implementations
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.16.0-rc.3", path = "../starknet-core" }
+starknet-core = { version = "0.16.0-rc.4", path = "../starknet-core" }
 starknet-crypto = { version = "0.8.0", path = "../starknet-crypto" }
 async-trait = "0.1.68"
 auto_impl = "1.0.1"

--- a/starknet-tokio-tungstenite/Cargo.toml
+++ b/starknet-tokio-tungstenite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-tokio-tungstenite"
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,8 +13,8 @@ Starknet JSON-RPC WebSocket client implementation with tokio-tungstenite
 keywords = ["ethereum", "starknet", "web3"]
 
 [dependencies]
-starknet-core = { version = "0.16.0-rc.3", path = "../starknet-core", default-features = false }
-starknet-providers = { version = "0.16.0-rc.3", path = "../starknet-providers" }
+starknet-core = { version = "0.16.0-rc.4", path = "../starknet-core", default-features = false }
+starknet-providers = { version = "0.16.0-rc.4", path = "../starknet-providers" }
 futures-util = "0.3.31"
 log = "0.4.19"
 rand = { version = "0.8.5", features = ["std_rng"] }
@@ -26,7 +26,7 @@ tokio-util = "0.7.15"
 tungstenite = { version = "0.26.2", features = ["url"] }
 
 [dev-dependencies]
-starknet-providers = { version = "0.16.0-rc.3", path = "../starknet-providers", features = ["no_unknown_fields"] }
+starknet-providers = { version = "0.16.0-rc.4", path = "../starknet-providers", features = ["no_unknown_fields"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Note that this RC uses new breaking versions of `starknet-curve` and `starknet-crypto` due to the breaking version change of the underlying `starknet-types-core`.