### PR TITLE
chore: add Clone trait to PoseidonHasher

### DIFF
--- a/starknet-crypto/src/poseidon_hash.rs
+++ b/starknet-crypto/src/poseidon_hash.rs
@@ -6,7 +6,7 @@ use starknet_types_core::{felt::Felt, hash::Poseidon};
 /// A stateful hasher for Starknet Poseidon hash.
 ///
 /// Using this hasher is the same as calling [`poseidon_hash_many`].
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct PoseidonHasher {
     state: [Felt; 3],
     buffer: Option<Felt>,


### PR DESCRIPTION
Added `Clone` trait to `PoseidonHasher` in order to use pre-computed hashes in software that uses Starknet.
For example, in my case, I'm hashing an order and it emplies four hash operations (PoseidonHasher::update calls), in which the first two (message_felt and domain hash) are immutable and the same for any order. I'd like to hash those fields once, save the hasher and then clone it to continue with the rest two fields.

I wrote and run a test for that, but haven't included it since it seems obvious.

cargo fmt and clippy: checked.

Thanks!